### PR TITLE
Fix overflow in x

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -25,7 +25,7 @@ const Navbar: React.FC = (props: PropsWithChildren<BoxProps>) => {
 			) : (
 				<></>
 			)}
-			<Box w="100vw" display={"flex"} h="auto" {...props}>
+			<Box display={"flex"} h="auto" {...props}>
 				<div className={styles.navbar}>
 					<Stack
 						p={["7px 20px", "10px 30px", "10px 30px", "10px 30px"]}


### PR DESCRIPTION
 `w="100vw"` sets the width to the full width, there is however and margin added so the final width is `100vw + margin` which is bigger than the view width causing an overflow in the x axis.