### PR TITLE
fix: use dynamic rendering for database-dependent pages

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,16 +2,14 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { Navbar } from "@/components/Navbar";
-import { formatBlogDate, getPostBySlug, getAllSlugs } from "@/lib/blog";
+import { formatBlogDate, getPostBySlug } from "@/lib/blog";
 import { mdxComponents } from "@/components/MDXComponents";
+
+// Force dynamic rendering since we need database access
+export const dynamic = "force-dynamic";
 
 interface Props {
 	params: Promise<{ slug: string }>;
-}
-
-export async function generateStaticParams() {
-	const slugs = await getAllSlugs();
-	return slugs.map((slug) => ({ slug }));
 }
 
 export async function generateMetadata({ params }: Props) {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -7,6 +7,9 @@ export const metadata = {
 	description: "Thoughts on Ethereum, cryptography, and distributed systems.",
 };
 
+// Force dynamic rendering since we need database access
+export const dynamic = "force-dynamic";
+
 export default async function BlogPage() {
 	const posts = await getAllPosts();
 

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -8,8 +8,8 @@ export const metadata = {
 	description: "Job opportunities at companies in my network",
 };
 
-// Revalidate every 60 seconds
-export const revalidate = 60;
+// Force dynamic rendering since we need database access
+export const dynamic = "force-dynamic";
 
 function JobsGridFallback() {
 	return (

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -9,8 +9,8 @@ export const metadata = {
     "Curated links, blog posts, and announcements from dcbuilder's portfolio companies.",
 };
 
-// Revalidate every 60 seconds
-export const revalidate = 60;
+// Force dynamic rendering since we need database access
+export const dynamic = "force-dynamic";
 
 export default async function NewsPage() {
   const news = await getAllNews();


### PR DESCRIPTION
## Summary
- Add `dynamic = "force-dynamic"` to /jobs, /blog, /news pages
- Remove generateStaticParams from /blog/[slug] (now renders at runtime)

## Problem
Vercel build failed because database-dependent pages tried to statically generate at build time when the database wasn't accessible:
```
Error: connect ECONNREFUSED 127.0.0.1:5432
```

## Solution
Force dynamic rendering for all pages that need database access. This ensures pages are server-rendered on demand rather than statically generated at build time.

## Test plan
- [x] Local build passes (`bun run build`)
- [ ] Vercel deployment succeeds