### PR TITLE
fix: use lazy database initialization to prevent connection errors

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2,11 +2,46 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema";
 
-const connectionString = process.env.DATABASE_URL!;
+// Lazy initialization to avoid issues at module load time
+let _db: ReturnType<typeof drizzle<typeof schema>> | null = null;
+let _queryClient: ReturnType<typeof postgres> | null = null;
 
-// For query purposes
-const queryClient = postgres(connectionString);
-export const db = drizzle(queryClient, { schema });
+function getConnectionString(): string {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error(
+      "DATABASE_URL environment variable is not set. " +
+      "Please configure it in your environment or .env.local file."
+    );
+  }
+  return connectionString;
+}
+
+function createDbClient() {
+  if (!_db) {
+    const connectionString = getConnectionString();
+    _queryClient = postgres(connectionString, {
+      // Connection pool settings for serverless
+      max: 10,
+      idle_timeout: 20,
+      connect_timeout: 10,
+    });
+    _db = drizzle(_queryClient, { schema });
+  }
+  return _db;
+}
+
+// Export a proxy that lazily initializes the database
+export const db = new Proxy({} as ReturnType<typeof drizzle<typeof schema>>, {
+  get(_target, prop) {
+    const client = createDbClient();
+    const value = (client as unknown as Record<string | symbol, unknown>)[prop];
+    if (typeof value === "function") {
+      return value.bind(client);
+    }
+    return value;
+  },
+});
 
 // Re-export schema for convenience
 export * from "./schema";


### PR DESCRIPTION
## Summary
Database client was being initialized eagerly at module load time, which could fail if DATABASE_URL wasn't available or misconfigured.

## Changes
- Lazy initialization on first database access using a Proxy
- Better error message when DATABASE_URL is missing
- Connection pool settings optimized for serverless

## Test plan
- [x] Local build passes
- [x] Local API works correctly
- [ ] Vercel deployment succeeds
- [ ] Production API works