### PR TITLE
feat: investment join button & dynamic job tags/roles

### DIFF
--- a/.claude/skills/post-news/SKILL.md
+++ b/.claude/skills/post-news/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: post-news
+description: This skill should be used when the user asks to "add news", "post news", "add an X post to news", "add tweet to news", "add announcement", "add curated link", "post to news feed", "share on news", "add article to news", or mentions adding content to the dcbuilder.dev news section. Provides workflows for adding announcements (portfolio company posts with logos) and curated links (external content) with optional R2 image upload.
+---
+
+# Post News Skill
+
+Add news items to the dcbuilder.dev news feed. Supports two types: **announcements** (company posts with logos) and **curated links** (external content without logos).
+
+## Quick Decision
+
+| Scenario | Type | Use When |
+|----------|------|----------|
+| **Announcement** | Company post | Portfolio company content, needs logo display |
+| **Curated Link** | External content | Individual posts, articles, no logo needed |
+
+## Workflow: Add Announcement
+
+For portfolio company posts (X posts, blog posts, etc.) with company logo.
+
+### Step 1: Gather Information
+
+Required fields:
+- **title**: Post title/headline
+- **url**: Full URL to the post
+- **company**: Company name (e.g., "Lighter", "MegaETH")
+- **platform**: `x`, `blog`, `discord`, `github`, or `other`
+- **date**: Publication date (YYYY-MM-DD format, use today if not specified)
+- **category**: Usually `x_post` for X posts, or `product`, `funding`, etc.
+
+Optional:
+- **companyLogo**: Path to logo image
+- **description**: Brief summary
+- **featured**: Set to `true` to spotlight
+
+### Step 2: Resolve Company Logo
+
+Check if company has existing logo in investments data:
+
+```bash
+grep -i "company-name" src/data/investments.ts
+```
+
+Common logo paths: `/images/investments/lighter.jpg`, `/images/investments/megaeth.png`
+
+If no existing logo, see "Image Upload Flow" below.
+
+### Step 3: Insert via Database
+
+Run from project root:
+
+```bash
+bun -e "
+import { db, announcements } from './src/db';
+
+await db.insert(announcements).values({
+  title: 'YOUR_TITLE',
+  url: 'YOUR_URL',
+  company: 'COMPANY_NAME',
+  companyLogo: '/images/investments/company.jpg',
+  platform: 'x',
+  date: new Date('YYYY-MM-DD'),
+  category: 'x_post',
+}).returning().then(r => console.log('Created:', JSON.stringify(r, null, 2)));
+
+process.exit(0);
+"
+```
+
+## Workflow: Add Curated Link
+
+For external articles, individual posts, or content not from portfolio companies.
+
+### Step 1: Gather Information
+
+Required fields:
+- **title**: Post/article title
+- **url**: Full URL
+- **source**: Author name or publication (e.g., "Vitalik Buterin", "Paradigm")
+- **date**: Publication date (YYYY-MM-DD)
+- **category**: `x_post`, `crypto`, `ai`, `research`, etc.
+
+### Step 2: Insert via Database
+
+```bash
+bun -e "
+import { db, curatedLinks } from './src/db';
+
+await db.insert(curatedLinks).values({
+  title: 'YOUR_TITLE',
+  url: 'YOUR_URL',
+  source: 'SOURCE_NAME',
+  date: new Date('YYYY-MM-DD'),
+  category: 'x_post',
+}).returning().then(r => console.log('Created:', JSON.stringify(r, null, 2)));
+
+process.exit(0);
+"
+```
+
+## Image Upload Flow
+
+When a new image is needed (not already in investments):
+
+### Option 1: Download and Upload
+
+```bash
+# 1. Download image
+curl -L "IMAGE_URL" -o /tmp/company-logo.jpg
+
+# 2. Upload to R2 (requires R2 env vars)
+bun -e "
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { createId } from '@paralleldrive/cuid2';
+
+const r2 = new S3Client({
+  region: 'auto',
+  endpoint: process.env.R2_ENDPOINT?.replace(/\\/dcbuilder-images$/, ''),
+  credentials: {
+    accessKeyId: process.env.R2_ACCESS_KEY_ID || '',
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY || '',
+  },
+});
+
+const buffer = await Bun.file('/tmp/company-logo.jpg').arrayBuffer();
+const key = 'news/' + createId() + '.jpg';
+
+await r2.send(new PutObjectCommand({
+  Bucket: 'dcbuilder-images',
+  Key: key,
+  Body: Buffer.from(buffer),
+  ContentType: 'image/jpeg',
+  CacheControl: 'public, max-age=31536000, immutable',
+}));
+
+console.log('Uploaded:', process.env.R2_PUBLIC_URL + '/' + key);
+"
+```
+
+### Option 2: Use Existing Investment Logo
+
+Most portfolio companies already have logos. Check:
+```bash
+ls public/images/investments/
+```
+
+Use path format: `/images/investments/company-name.jpg`
+
+## Categories Reference
+
+| Value | Display | Use For |
+|-------|---------|---------|
+| `x_post` | X Post | Twitter/X posts |
+| `crypto` | Crypto | Cryptocurrency news |
+| `ai` | AI | AI/ML content |
+| `infrastructure` | Infrastructure | Blockchain infra |
+| `defi` | DeFi | DeFi protocols |
+| `research` | Research | Papers, research |
+| `product` | Product | Product launches |
+| `funding` | Funding | Fundraising news |
+| `general` | General | Other news |
+
+## Verification
+
+After adding, verify the item exists:
+
+```bash
+# For announcements
+curl -s "http://localhost:3000/api/v1/news/announcements?limit=1" | jq .
+
+# For curated links
+curl -s "http://localhost:3000/api/v1/news/curated?limit=1" | jq .
+```
+
+## Common Examples
+
+### X Post from Portfolio Company
+```bash
+bun -e "
+import { db, announcements } from './src/db';
+await db.insert(announcements).values({
+  title: 'Product launch announcement',
+  url: 'https://x.com/company/status/123456',
+  company: 'Company',
+  companyLogo: '/images/investments/company.jpg',
+  platform: 'x',
+  date: new Date(),
+  category: 'x_post',
+}).returning().then(r => console.log(JSON.stringify(r, null, 2)));
+process.exit(0);
+"
+```
+
+### Article from Individual
+```bash
+bun -e "
+import { db, curatedLinks } from './src/db';
+await db.insert(curatedLinks).values({
+  title: 'Interesting article title',
+  url: 'https://example.com/article',
+  source: 'Author Name',
+  date: new Date(),
+  category: 'research',
+}).returning().then(r => console.log(JSON.stringify(r, null, 2)));
+process.exit(0);
+"
+```
+
+## Additional Resources
+
+### Reference Files
+- **`references/schemas.md`** - Detailed field schemas and validation rules
+
+### Scripts
+- **`scripts/add-announcement.ts`** - Add announcement via JSON
+- **`scripts/add-curated-link.ts`** - Add curated link via JSON
+- **`scripts/download-image.ts`** - Download image from URL
+- **`scripts/upload-to-r2.ts`** - Upload image to R2

--- a/.claude/skills/post-news/references/schemas.md
+++ b/.claude/skills/post-news/references/schemas.md
@@ -1,0 +1,93 @@
+# News Data Schemas
+
+## News Categories
+
+Valid values for the `category` field:
+
+| Category | Label | Use For |
+|----------|-------|---------|
+| `crypto` | Crypto | Cryptocurrency topics |
+| `ai` | AI | Artificial intelligence |
+| `infrastructure` | Infrastructure | Blockchain/Web3 infrastructure |
+| `defi` | DeFi | Decentralized finance |
+| `research` | Research | Academic/research papers |
+| `product` | Product | Product launches |
+| `funding` | Funding | Funding announcements |
+| `general` | General | General news |
+| `x_post` | X Post | X/Twitter posts |
+
+## Announcement Schema
+
+For company/portfolio announcements with logos.
+
+```typescript
+{
+  title: string;           // Required: Announcement title
+  url: string;             // Required: Link URL
+  company: string;         // Required: Company name
+  platform: string;        // Required: x | blog | discord | github | other
+  date: string;            // Required: Date (YYYY-MM-DD)
+  category: string;        // Required: See categories above
+  companyLogo?: string;    // Optional: Logo URL (R2 or local path)
+  description?: string;    // Optional: Summary text
+  featured?: boolean;      // Optional: Spotlight flag (default: false)
+}
+```
+
+**Platform values:**
+- `x` - X/Twitter post
+- `blog` - Blog post
+- `discord` - Discord announcement
+- `github` - GitHub release/discussion
+- `other` - Other platforms
+
+## Curated Link Schema
+
+For external articles and posts without logos.
+
+```typescript
+{
+  title: string;           // Required: Link title
+  url: string;             // Required: Link URL
+  source: string;          // Required: Author or publication name
+  date: string;            // Required: Date (YYYY-MM-DD)
+  category: string;        // Required: See categories above
+  description?: string;    // Optional: Summary text
+  featured?: boolean;      // Optional: Spotlight flag (default: false)
+}
+```
+
+## When to Use Which Type
+
+### Use Announcement when:
+- Post is from a portfolio company
+- A company logo should be displayed
+- Content is official company communication
+
+### Use Curated Link when:
+- Post is from an individual (not a company)
+- No logo is needed
+- Sharing interesting external content
+
+## Image Storage
+
+### Local Images (investments folder)
+Already uploaded to R2 via sync. Use path format:
+```
+/images/investments/company-name.jpg
+```
+
+### R2 Public URL
+For images uploaded directly to R2:
+```
+https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/folder/filename.ext
+```
+
+### Investment Logos
+Existing portfolio company logos are in `/images/investments/`:
+- `lighter.jpg`
+- `megaeth.png`
+- `friend.jpg`
+- etc.
+
+Check `src/data/investments.ts` for the full list.

--- a/.claude/skills/post-news/scripts/add-announcement.ts
+++ b/.claude/skills/post-news/scripts/add-announcement.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bun
+/**
+ * Add an announcement to the database
+ * Usage: bun scripts/add-announcement.ts <json-data>
+ *
+ * JSON data should contain:
+ * - title (required): Announcement title
+ * - url (required): Link URL
+ * - company (required): Company name
+ * - platform (required): x | blog | discord | github | other
+ * - date (required): Date string (YYYY-MM-DD)
+ * - category (required): x_post | crypto | ai | infrastructure | defi | research | product | funding | general
+ * - companyLogo (optional): Logo URL or local path
+ * - description (optional): Description text
+ * - featured (optional): boolean
+ */
+
+import { db, announcements } from "../../../src/db";
+
+const jsonData = process.argv[2];
+
+if (!jsonData) {
+  console.error("Usage: bun add-announcement.ts '<json-data>'");
+  process.exit(1);
+}
+
+try {
+  const data = JSON.parse(jsonData);
+
+  // Validate required fields
+  const required = ["title", "url", "company", "platform", "date", "category"];
+  for (const field of required) {
+    if (!data[field]) {
+      throw new Error(`Missing required field: ${field}`);
+    }
+  }
+
+  const result = await db.insert(announcements).values({
+    title: data.title,
+    url: data.url,
+    company: data.company,
+    companyLogo: data.companyLogo,
+    platform: data.platform,
+    date: new Date(data.date),
+    description: data.description,
+    category: data.category,
+    featured: data.featured || false,
+  }).returning();
+
+  console.log(JSON.stringify({ success: true, data: result[0] }, null, 2));
+  process.exit(0);
+} catch (error) {
+  console.error(JSON.stringify({
+    success: false,
+    error: error instanceof Error ? error.message : String(error),
+  }));
+  process.exit(1);
+}

--- a/.claude/skills/post-news/scripts/add-curated-link.ts
+++ b/.claude/skills/post-news/scripts/add-curated-link.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env bun
+/**
+ * Add a curated link to the database
+ * Usage: bun scripts/add-curated-link.ts <json-data>
+ *
+ * JSON data should contain:
+ * - title (required): Link title
+ * - url (required): Link URL
+ * - source (required): Source name (e.g., "Vitalik Buterin", "Paradigm")
+ * - date (required): Date string (YYYY-MM-DD)
+ * - category (required): x_post | crypto | ai | infrastructure | defi | research | product | funding | general
+ * - description (optional): Description text
+ * - featured (optional): boolean
+ */
+
+import { db, curatedLinks } from "../../../src/db";
+
+const jsonData = process.argv[2];
+
+if (!jsonData) {
+  console.error("Usage: bun add-curated-link.ts '<json-data>'");
+  process.exit(1);
+}
+
+try {
+  const data = JSON.parse(jsonData);
+
+  // Validate required fields
+  const required = ["title", "url", "source", "date", "category"];
+  for (const field of required) {
+    if (!data[field]) {
+      throw new Error(`Missing required field: ${field}`);
+    }
+  }
+
+  const result = await db.insert(curatedLinks).values({
+    title: data.title,
+    url: data.url,
+    source: data.source,
+    date: new Date(data.date),
+    description: data.description,
+    category: data.category,
+    featured: data.featured || false,
+  }).returning();
+
+  console.log(JSON.stringify({ success: true, data: result[0] }, null, 2));
+  process.exit(0);
+} catch (error) {
+  console.error(JSON.stringify({
+    success: false,
+    error: error instanceof Error ? error.message : String(error),
+  }));
+  process.exit(1);
+}

--- a/.claude/skills/post-news/scripts/download-image.ts
+++ b/.claude/skills/post-news/scripts/download-image.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env bun
+/**
+ * Download an image from a URL and save it locally
+ * Usage: bun scripts/download-image.ts <url> [output-path]
+ */
+
+const url = process.argv[2];
+const outputPath = process.argv[3] || `/tmp/downloaded-${Date.now()}.jpg`;
+
+if (!url) {
+  console.error("Usage: bun download-image.ts <url> [output-path]");
+  process.exit(1);
+}
+
+try {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
+  }
+
+  const buffer = await response.arrayBuffer();
+  await Bun.write(outputPath, buffer);
+
+  console.log(JSON.stringify({
+    success: true,
+    path: outputPath,
+    size: buffer.byteLength,
+    contentType: response.headers.get("content-type"),
+  }));
+} catch (error) {
+  console.error(JSON.stringify({
+    success: false,
+    error: error instanceof Error ? error.message : String(error),
+  }));
+  process.exit(1);
+}

--- a/.claude/skills/post-news/scripts/upload-to-r2.ts
+++ b/.claude/skills/post-news/scripts/upload-to-r2.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env bun
+/**
+ * Upload an image to Cloudflare R2
+ * Usage: bun scripts/upload-to-r2.ts <file-path> [folder]
+ *
+ * Requires environment variables:
+ * - R2_ENDPOINT
+ * - R2_ACCESS_KEY_ID
+ * - R2_SECRET_ACCESS_KEY
+ * - R2_BUCKET_NAME (default: dcbuilder-images)
+ * - R2_PUBLIC_URL
+ */
+
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { createId } from "@paralleldrive/cuid2";
+import { extname } from "path";
+
+const filePath = process.argv[2];
+const folder = process.argv[3] || "news";
+
+if (!filePath) {
+  console.error("Usage: bun upload-to-r2.ts <file-path> [folder]");
+  process.exit(1);
+}
+
+const MIME_TYPES: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+};
+
+const r2 = new S3Client({
+  region: "auto",
+  endpoint: process.env.R2_ENDPOINT?.replace(/\/dcbuilder-images$/, ""),
+  credentials: {
+    accessKeyId: process.env.R2_ACCESS_KEY_ID || "",
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY || "",
+  },
+});
+
+const BUCKET_NAME = process.env.R2_BUCKET_NAME || "dcbuilder-images";
+const PUBLIC_URL = process.env.R2_PUBLIC_URL || "";
+
+try {
+  const file = Bun.file(filePath);
+  const buffer = await file.arrayBuffer();
+
+  const ext = extname(filePath).toLowerCase();
+  const contentType = MIME_TYPES[ext] || "application/octet-stream";
+  const filename = `${createId()}${ext}`;
+  const key = `${folder}/${filename}`;
+
+  await r2.send(
+    new PutObjectCommand({
+      Bucket: BUCKET_NAME,
+      Key: key,
+      Body: Buffer.from(buffer),
+      ContentType: contentType,
+      CacheControl: "public, max-age=31536000, immutable",
+    })
+  );
+
+  const url = `${PUBLIC_URL}/${key}`;
+
+  console.log(JSON.stringify({
+    success: true,
+    url,
+    key,
+    filename,
+    size: buffer.byteLength,
+    contentType,
+  }));
+} catch (error) {
+  console.error(JSON.stringify({
+    success: false,
+    error: error instanceof Error ? error.message : String(error),
+  }));
+  process.exit(1);
+}

--- a/.claude/skills/tag-jobs/SKILL.md
+++ b/.claude/skills/tag-jobs/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: tag-jobs
+description: This skill should be used when the user asks to "tag jobs", "categorize jobs", "update job tags", "assign roles to jobs", "review job classifications", "fix job tagging", or wants to ensure all jobs have proper tags and role/department assignments. Iterates through ALL jobs systematically and suggests appropriate tags based on job title, company, and description.
+---
+
+# Tag Jobs Skill
+
+Systematically review and tag all jobs in the database with appropriate tags and roles/departments.
+
+## Quick Start
+
+Run this skill when you need to:
+- Tag new jobs that don't have tags yet
+- Review existing job tags for accuracy
+- Assign departments/roles to jobs missing them
+- Batch update jobs with consistent tagging
+
+## Workflow
+
+### Step 1: Fetch Current Tags and Roles
+
+First, get the available tags and roles from the database:
+
+```bash
+bun -e "
+import { db, jobTags, jobRoles } from './src/db';
+import { asc } from 'drizzle-orm';
+
+const [tags, roles] = await Promise.all([
+  db.select().from(jobTags).orderBy(asc(jobTags.label)),
+  db.select().from(jobRoles).orderBy(asc(jobRoles.label)),
+]);
+
+console.log('=== AVAILABLE TAGS ===');
+tags.forEach(t => console.log(\`  \${t.slug}: \${t.label} (\${t.color || 'no color'})\`));
+console.log('\\n=== AVAILABLE ROLES ===');
+roles.forEach(r => console.log(\`  \${r.slug}: \${r.label}\`));
+process.exit(0);
+"
+```
+
+### Step 2: Fetch All Jobs
+
+Get all jobs that need review:
+
+```bash
+bun -e "
+import { db, jobs } from './src/db';
+import { desc } from 'drizzle-orm';
+
+const allJobs = await db.select({
+  id: jobs.id,
+  title: jobs.title,
+  company: jobs.company,
+  department: jobs.department,
+  tags: jobs.tags,
+  description: jobs.description,
+}).from(jobs).orderBy(desc(jobs.createdAt));
+
+console.log(\`Found \${allJobs.length} jobs to review\\n\`);
+
+allJobs.forEach((job, i) => {
+  console.log(\`[\${i+1}] \${job.title} @ \${job.company}\`);
+  console.log(\`    Department: \${job.department || '(none)'}\`);
+  console.log(\`    Tags: \${job.tags?.join(', ') || '(none)'}\`);
+  console.log('');
+});
+process.exit(0);
+"
+```
+
+### Step 3: Analyze and Tag Each Job
+
+For each job, analyze the title, company, and description to determine:
+
+1. **Department/Role** (the `department` field): What function does this role serve?
+   - Engineering, Design, Product, Marketing, Sales, Operations, etc.
+
+2. **Tags** (the `tags` array): What characteristics describe this job?
+   - Technology: `ai`, `ml`, `zkp`, `cryptography`, `rust`, `frontend`, `backend`, `fullstack`, `mobile`
+   - Domain: `defi`, `protocol`, `infra`, `gaming`, `trading`, `mev`, `security`
+   - Level: `entry-level`, `internship`, `leadership`, `management`
+   - Ecosystem: `solana`, `monad-ecosystem`, `berachain-ecosystem`, `world`
+   - Type: `research`, `design`, `bd`, `marketing`, `sales`, `legal`, `accounting`, `talent`
+
+### Step 4: Update Jobs
+
+Update a single job:
+
+```bash
+bun -e "
+import { db, jobs } from './src/db';
+import { eq } from 'drizzle-orm';
+
+const [updated] = await db.update(jobs)
+  .set({
+    department: 'Engineering',
+    tags: ['ai', 'ml', 'research', 'fullstack'],
+  })
+  .where(eq(jobs.id, 'JOB_ID_HERE'))
+  .returning();
+
+console.log('Updated:', updated.title);
+process.exit(0);
+"
+```
+
+Batch update multiple jobs:
+
+```bash
+bun -e "
+import { db, jobs } from './src/db';
+import { eq } from 'drizzle-orm';
+
+const updates = [
+  { id: 'job1', department: 'Engineering', tags: ['frontend', 'web3'] },
+  { id: 'job2', department: 'Design', tags: ['design', 'product'] },
+  // Add more...
+];
+
+for (const { id, ...data } of updates) {
+  await db.update(jobs).set(data).where(eq(jobs.id, id));
+  console.log(\`Updated: \${id}\`);
+}
+
+console.log(\`\\nUpdated \${updates.length} jobs\`);
+process.exit(0);
+"
+```
+
+## Tagging Guidelines
+
+### Department Assignment
+
+| Job Title Contains | Department |
+|-------------------|------------|
+| Engineer, Developer, SWE, SRE, DevOps | Engineering |
+| Designer, UX, UI | Design |
+| Product Manager, PM | Product |
+| Marketing, Growth, Content | Marketing |
+| Sales, Account Executive, SDR, BDR | Sales |
+| BD, Business Development, Partnerships | Business Development |
+| Research, Researcher, Scientist | Research |
+| HR, People, Recruiter, Talent | Human Resources |
+| Legal, Counsel, Compliance | Legal |
+| Finance, Accountant, Controller | Finance |
+| Operations, Ops, Office Manager | Operations |
+| Community, Mod, Ambassador | Community |
+| DevRel, Developer Advocate | Developer Relations |
+| Support, Success, Help Desk | Support |
+| CEO, CTO, CFO, COO, VP, Director, Head | Executive |
+| Data, Analytics, BI | Data |
+| Security, Infosec, Pentester | Security |
+
+### Tag Assignment Rules
+
+**By Title Keywords:**
+- "AI", "Machine Learning", "ML", "LLM" → `ai`, `ml`
+- "Solidity", "Smart Contract" → `protocol`, `defi`
+- "ZK", "Zero Knowledge" → `zkp`, `cryptography`
+- "Rust" → `rust`
+- "Frontend", "React", "Vue" → `frontend`
+- "Backend", "API", "Server" → `backend`
+- "Full Stack", "Fullstack" → `fullstack`
+- "Mobile", "iOS", "Android" → `mobile`
+- "Security", "Audit" → `security`
+- "Trading", "Quant" → `trading`
+- "MEV" → `mev`
+- "Infrastructure", "Platform" → `infra`
+- "Research" → `research`
+
+**By Company/Ecosystem:**
+- Monad Foundation, Category Labs → `monad-ecosystem`
+- Berachain → `berachain-ecosystem`
+- Worldcoin, World ID → `world`
+- Solana Labs, Solana Foundation → `solana`
+
+**By Seniority:**
+- "Junior", "Entry", "Associate", "New Grad" → `entry-level`
+- "Intern" → `internship`
+- "Senior", "Staff", "Principal" → (no special tag)
+- "Lead", "Manager", "Director", "VP", "Head" → `leadership` or `management`
+
+**Special Tags:**
+- `hot` - Only for exceptional, high-priority roles (add manually)
+- `top` - Only for featured positions (add manually)
+
+## Verification
+
+After tagging, verify changes:
+
+```bash
+bun -e "
+import { db, jobs } from './src/db';
+import { isNull, or, eq, sql } from 'drizzle-orm';
+
+// Jobs without department
+const noDept = await db.select({ count: sql\`count(*)\` })
+  .from(jobs)
+  .where(or(isNull(jobs.department), eq(jobs.department, '')));
+
+// Jobs without tags
+const noTags = await db.select({ count: sql\`count(*)\` })
+  .from(jobs)
+  .where(or(isNull(jobs.tags), eq(sql\`array_length(tags, 1)\`, sql\`0\`)));
+
+console.log(\`Jobs without department: \${noDept[0].count}\`);
+console.log(\`Jobs without tags: \${noTags[0].count}\`);
+process.exit(0);
+"
+```
+
+## Creating New Tags
+
+If a job needs a tag that doesn't exist:
+
+```bash
+bun -e "
+import { db, jobTags } from './src/db';
+
+const [tag] = await db.insert(jobTags).values({
+  slug: 'new-tag-slug',
+  label: 'New Tag Label',
+  color: 'blue', // blue, green, purple, red, amber, etc.
+}).returning();
+
+console.log('Created tag:', tag);
+process.exit(0);
+"
+```
+
+## Creating New Roles
+
+If a department doesn't exist as a role:
+
+```bash
+bun -e "
+import { db, jobRoles } from './src/db';
+
+const [role] = await db.insert(jobRoles).values({
+  slug: 'new-role-slug',
+  label: 'New Role Label',
+}).returning();
+
+console.log('Created role:', role);
+process.exit(0);
+"
+```
+
+## Additional Resources
+
+- **`references/tag-mapping.md`** - Detailed tag definitions and colors
+- **`references/role-mapping.md`** - Department/role definitions

--- a/.claude/skills/tag-jobs/references/role-mapping.md
+++ b/.claude/skills/tag-jobs/references/role-mapping.md
@@ -1,0 +1,52 @@
+# Job Roles/Departments Reference
+
+Available departments/roles for job classification.
+
+## Department Mapping
+
+| Slug | Label | Job Title Keywords |
+|------|-------|-------------------|
+| `engineering` | Engineering | Engineer, Developer, SWE, Programmer, Architect |
+| `design` | Design | Designer, UX, UI, Visual, Creative |
+| `product` | Product | Product Manager, PM, Product Owner |
+| `marketing` | Marketing | Marketing, Growth, Content, Brand |
+| `sales` | Sales | Sales, Account Executive, SDR, BDR |
+| `business-development` | Business Development | BD, Partnerships, Strategic |
+| `research` | Research | Researcher, Scientist, R&D |
+| `hr` | Human Resources | HR, People, Recruiter, Talent |
+| `legal` | Legal | Legal, Counsel, Compliance, Attorney |
+| `finance` | Finance | Finance, Accountant, Controller, FP&A |
+| `operations` | Operations | Operations, Ops, Office Manager |
+| `community` | Community | Community, Mod, Ambassador |
+| `devrel` | Developer Relations | DevRel, Developer Advocate, DX |
+| `support` | Support | Support, Success, Help Desk |
+| `executive` | Executive | CEO, CTO, CFO, COO, VP, Director, Head |
+| `data` | Data | Data, Analytics, BI, Data Science |
+| `security` | Security | Security, Infosec, Pentester |
+| `strategy` | Strategy | Strategy, Chief of Staff |
+| `content` | Content | Content, Writer, Editor |
+
+## Assignment Priority
+
+When a job title could match multiple departments, use this priority:
+
+1. **Primary Function First** - What will this person do day-to-day?
+2. **Seniority Doesn't Change Department** - "Senior Engineer" is still Engineering
+3. **Hybrid Roles** - Use the more specific department
+   - "Product Designer" → Design (not Product)
+   - "Growth Engineer" → Engineering (not Marketing)
+   - "Sales Engineer" → Sales (not Engineering)
+   - "DevRel Engineer" → Developer Relations
+
+## Common Edge Cases
+
+| Title | Department | Reasoning |
+|-------|------------|-----------|
+| Technical Writer | Content | Content creation role |
+| Security Engineer | Security | Security-focused |
+| Data Engineer | Engineering | Building data pipelines |
+| Data Scientist | Data | Analysis/ML focused |
+| ML Engineer | Engineering | Building systems |
+| Research Engineer | Research | Research-focused |
+| Founding Engineer | Engineering | Core eng role |
+| Protocol Engineer | Engineering | Blockchain eng |

--- a/.claude/skills/tag-jobs/references/tag-mapping.md
+++ b/.claude/skills/tag-jobs/references/tag-mapping.md
@@ -1,0 +1,83 @@
+# Job Tags Reference
+
+Complete list of available job tags with their display labels and colors.
+
+## Special Tags (Manual Assignment Only)
+
+| Slug | Label | Color | Usage |
+|------|-------|-------|-------|
+| `hot` | HOT | orange | High-priority, urgent positions |
+| `top` | TOP | amber | Featured, top positions |
+
+## Technology Tags
+
+| Slug | Label | Color | Keywords |
+|------|-------|-------|----------|
+| `ai` | AI | purple | AI, artificial intelligence, GPT, LLM |
+| `ml` | ML | purple | Machine learning, neural networks, deep learning |
+| `zkp` | ZKP | blue | Zero knowledge, zk-SNARKs, zk-STARKs, ZKP |
+| `cryptography` | Cryptography | blue | Crypto, encryption, cryptographic |
+| `rust` | Rust | orange | Rust language |
+| `frontend` | Frontend | sky | Frontend, React, Vue, Angular, UI |
+| `backend` | Backend | slate | Backend, API, server-side |
+| `fullstack` | Full Stack | blue | Full stack, fullstack |
+| `mobile` | Mobile | green | Mobile, app development |
+| `android` | Android | green | Android specific |
+| `ios` | iOS | gray | iOS, Swift, Apple |
+| `hardware` | Hardware | slate | Hardware engineering |
+
+## Domain Tags
+
+| Slug | Label | Color | Keywords |
+|------|-------|-------|----------|
+| `defi` | DeFi | emerald | DeFi, decentralized finance, lending, DEX |
+| `protocol` | Protocol | indigo | Protocol, blockchain, L1, L2 |
+| `infra` | Infrastructure | slate | Infrastructure, platform, devtools |
+| `gaming` | Gaming | pink | Gaming, games, GameFi |
+| `trading` | Trading | green | Trading, quant, market making |
+| `mev` | MEV | red | MEV, searcher, block builder |
+| `security` | Security | red | Security, audit, pentesting |
+| `privacy` | Privacy | gray | Privacy, private, confidential |
+| `web3` | Web3 | purple | Web3, dApps |
+| `account-abstraction` | Account Abstraction | indigo | AA, 4337, smart accounts |
+| `bci` | BCI | cyan | Brain-computer interface, neural |
+
+## Function Tags
+
+| Slug | Label | Color | Keywords |
+|------|-------|-------|----------|
+| `research` | Research | violet | Research, researcher, R&D |
+| `design` | Design | rose | Design, designer, UX, UI |
+| `marketing` | Marketing | orange | Marketing, growth, content |
+| `bd` | BD | cyan | Business development, partnerships |
+| `sales` | Sales | orange | Sales, account executive |
+| `legal` | Legal | gray | Legal, counsel, compliance |
+| `accounting` | Accounting | gray | Accounting, finance, controller |
+| `talent` | Talent | pink | Recruiting, HR, people ops |
+| `product` | Product | blue | Product management |
+| `growth` | Growth | emerald | Growth, user acquisition |
+
+## Seniority Tags
+
+| Slug | Label | Color | Keywords |
+|------|-------|-------|----------|
+| `entry-level` | Entry Level | green | Junior, entry, associate, new grad |
+| `internship` | Internship | green | Intern, internship |
+| `leadership` | Leadership | amber | Lead, head, director, VP |
+| `management` | Management | amber | Manager, managing |
+
+## Ecosystem Tags
+
+| Slug | Label | Color | Keywords |
+|------|-------|-------|----------|
+| `monad-ecosystem` | Monad Ecosystem | purple | Monad Foundation, Category Labs |
+| `berachain-ecosystem` | Berachain Ecosystem | amber | Berachain, Bera |
+| `solana` | Solana | purple | Solana, SOL |
+| `world` | World | blue | Worldcoin, World ID |
+
+## Other Tags
+
+| Slug | Label | Color | Keywords |
+|------|-------|-------|----------|
+| `vc` | VC | indigo | Venture capital, investor |
+| `health` | Health | green | Health, medical, biotech |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -390,6 +390,51 @@ components:
           format: date-time
           readOnly: true
 
+    JobTag:
+      type: object
+      required:
+        - slug
+        - label
+      properties:
+        id:
+          type: string
+          readOnly: true
+        slug:
+          type: string
+          pattern: ^[a-z0-9-]+$
+          description: URL-friendly identifier
+        label:
+          type: string
+          description: Display name for the tag
+        color:
+          type: string
+          description: Tailwind color name (e.g., blue, green, purple)
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+
+    JobRole:
+      type: object
+      required:
+        - slug
+        - label
+      properties:
+        id:
+          type: string
+          readOnly: true
+        slug:
+          type: string
+          pattern: ^[a-z0-9-]+$
+          description: URL-friendly identifier
+        label:
+          type: string
+          description: Display name for the role/department
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+
   parameters:
     LimitParam:
       name: limit
@@ -896,3 +941,153 @@ paths:
       responses:
         '200':
           description: Analytics data from PostHog
+
+  /job-tags:
+    get:
+      tags: [Jobs]
+      summary: List job tags
+      security: []
+      responses:
+        '200':
+          description: List of job tags
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/JobTag'
+    post:
+      tags: [Jobs]
+      summary: Create job tag
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobTag'
+      responses:
+        '201':
+          description: Job tag created
+        '400':
+          description: Validation error
+        '401':
+          description: Unauthorized
+        '409':
+          description: Tag with this slug already exists
+
+  /job-tags/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags: [Jobs]
+      summary: Get job tag by ID
+      security: []
+      responses:
+        '200':
+          description: Job tag details
+        '404':
+          description: Job tag not found
+    patch:
+      tags: [Jobs]
+      summary: Update job tag
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobTag'
+      responses:
+        '200':
+          description: Job tag updated
+        '404':
+          description: Job tag not found
+    delete:
+      tags: [Jobs]
+      summary: Delete job tag
+      responses:
+        '200':
+          description: Job tag deleted
+        '404':
+          description: Job tag not found
+
+  /job-roles:
+    get:
+      tags: [Jobs]
+      summary: List job roles
+      security: []
+      responses:
+        '200':
+          description: List of job roles
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/JobRole'
+    post:
+      tags: [Jobs]
+      summary: Create job role
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobRole'
+      responses:
+        '201':
+          description: Job role created
+        '400':
+          description: Validation error
+        '401':
+          description: Unauthorized
+        '409':
+          description: Role with this slug already exists
+
+  /job-roles/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags: [Jobs]
+      summary: Get job role by ID
+      security: []
+      responses:
+        '200':
+          description: Job role details
+        '404':
+          description: Job role not found
+    patch:
+      tags: [Jobs]
+      summary: Update job role
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobRole'
+      responses:
+        '200':
+          description: Job role updated
+        '404':
+          description: Job role not found
+    delete:
+      tags: [Jobs]
+      summary: Delete job role
+      responses:
+        '200':
+          description: Job role deleted
+        '404':
+          description: Job role not found

--- a/scripts/migrate-job-tags-roles.ts
+++ b/scripts/migrate-job-tags-roles.ts
@@ -1,0 +1,184 @@
+import postgres from "postgres";
+
+const sql = postgres(process.env.DATABASE_URL!);
+
+// Existing tags from src/data/jobs.ts
+const existingTags = [
+  { slug: "hot", label: "🔥 HOT", color: "orange" },
+  { slug: "top", label: "⭐ TOP", color: "amber" },
+  { slug: "ai", label: "AI", color: "purple" },
+  { slug: "ml", label: "ML", color: "purple" },
+  { slug: "mev", label: "MEV", color: "red" },
+  { slug: "health", label: "Health", color: "green" },
+  { slug: "cryptography", label: "Cryptography", color: "blue" },
+  { slug: "zkp", label: "ZKP", color: "blue" },
+  { slug: "protocol", label: "Protocol", color: "indigo" },
+  { slug: "defi", label: "DeFi", color: "emerald" },
+  { slug: "infra", label: "Infrastructure", color: "slate" },
+  { slug: "trading", label: "Trading", color: "green" },
+  { slug: "gaming", label: "Gaming", color: "pink" },
+  { slug: "design", label: "Design", color: "rose" },
+  { slug: "marketing", label: "Marketing", color: "orange" },
+  { slug: "bd", label: "BD", color: "cyan" },
+  { slug: "research", label: "Research", color: "violet" },
+  { slug: "security", label: "Security", color: "red" },
+  { slug: "legal", label: "Legal", color: "gray" },
+  { slug: "world", label: "World", color: "blue" },
+  { slug: "monad-ecosystem", label: "Monad Ecosystem", color: "purple" },
+  { slug: "berachain-ecosystem", label: "Berachain Ecosystem", color: "amber" },
+  { slug: "entry-level", label: "Entry Level", color: "green" },
+  { slug: "vc", label: "VC", color: "indigo" },
+  { slug: "accounting", label: "Accounting", color: "gray" },
+  { slug: "bci", label: "BCI", color: "cyan" },
+  { slug: "hardware", label: "Hardware", color: "slate" },
+  { slug: "talent", label: "Talent", color: "pink" },
+  { slug: "leadership", label: "Leadership", color: "amber" },
+  { slug: "management", label: "Management", color: "amber" },
+  { slug: "product", label: "Product", color: "blue" },
+  { slug: "solana", label: "Solana", color: "purple" },
+  { slug: "internship", label: "Internship", color: "green" },
+  { slug: "growth", label: "Growth", color: "emerald" },
+  { slug: "sales", label: "Sales", color: "orange" },
+  { slug: "account-abstraction", label: "Account Abstraction", color: "indigo" },
+  { slug: "privacy", label: "Privacy", color: "gray" },
+  { slug: "web3", label: "Web3", color: "purple" },
+  { slug: "frontend", label: "Frontend", color: "sky" },
+  { slug: "backend", label: "Backend", color: "slate" },
+  { slug: "fullstack", label: "Full Stack", color: "blue" },
+  { slug: "rust", label: "Rust", color: "orange" },
+  { slug: "mobile", label: "Mobile", color: "green" },
+  { slug: "android", label: "Android", color: "green" },
+  { slug: "ios", label: "iOS", color: "gray" },
+];
+
+// Common job roles/departments
+const existingRoles = [
+  { slug: "engineering", label: "Engineering" },
+  { slug: "design", label: "Design" },
+  { slug: "product", label: "Product" },
+  { slug: "marketing", label: "Marketing" },
+  { slug: "sales", label: "Sales" },
+  { slug: "operations", label: "Operations" },
+  { slug: "finance", label: "Finance" },
+  { slug: "legal", label: "Legal" },
+  { slug: "hr", label: "Human Resources" },
+  { slug: "research", label: "Research" },
+  { slug: "data", label: "Data" },
+  { slug: "security", label: "Security" },
+  { slug: "devrel", label: "Developer Relations" },
+  { slug: "community", label: "Community" },
+  { slug: "content", label: "Content" },
+  { slug: "support", label: "Support" },
+  { slug: "business-development", label: "Business Development" },
+  { slug: "strategy", label: "Strategy" },
+  { slug: "executive", label: "Executive" },
+];
+
+async function migrate() {
+  console.log("Creating job_tags table...");
+  await sql`
+    CREATE TABLE IF NOT EXISTS job_tags (
+      id TEXT PRIMARY KEY,
+      slug TEXT NOT NULL UNIQUE,
+      label TEXT NOT NULL,
+      color TEXT,
+      created_at TIMESTAMP DEFAULT NOW() NOT NULL
+    )
+  `;
+  await sql`CREATE INDEX IF NOT EXISTS job_tags_slug_idx ON job_tags(slug)`;
+
+  console.log("Creating job_roles table...");
+  await sql`
+    CREATE TABLE IF NOT EXISTS job_roles (
+      id TEXT PRIMARY KEY,
+      slug TEXT NOT NULL UNIQUE,
+      label TEXT NOT NULL,
+      created_at TIMESTAMP DEFAULT NOW() NOT NULL
+    )
+  `;
+  await sql`CREATE INDEX IF NOT EXISTS job_roles_slug_idx ON job_roles(slug)`;
+
+  console.log("Seeding job_tags...");
+  for (const tag of existingTags) {
+    try {
+      await sql`
+        INSERT INTO job_tags (id, slug, label, color)
+        VALUES (gen_random_uuid()::text, ${tag.slug}, ${tag.label}, ${tag.color})
+        ON CONFLICT (slug) DO UPDATE SET label = ${tag.label}, color = ${tag.color}
+      `;
+      console.log(`  ✓ ${tag.slug}`);
+    } catch (e) {
+      console.log(`  ✗ ${tag.slug}:`, e);
+    }
+  }
+
+  console.log("Seeding job_roles...");
+  for (const role of existingRoles) {
+    try {
+      await sql`
+        INSERT INTO job_roles (id, slug, label)
+        VALUES (gen_random_uuid()::text, ${role.slug}, ${role.label})
+        ON CONFLICT (slug) DO UPDATE SET label = ${role.label}
+      `;
+      console.log(`  ✓ ${role.slug}`);
+    } catch (e) {
+      console.log(`  ✗ ${role.slug}:`, e);
+    }
+  }
+
+  // Also extract unique departments from existing jobs and add them
+  console.log("\nExtracting existing departments from jobs...");
+  const existingDepartments = await sql`
+    SELECT DISTINCT department FROM jobs WHERE department IS NOT NULL AND department != ''
+  `;
+
+  for (const row of existingDepartments) {
+    const dept = row.department as string;
+    const slug = dept.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+    try {
+      await sql`
+        INSERT INTO job_roles (id, slug, label)
+        VALUES (gen_random_uuid()::text, ${slug}, ${dept})
+        ON CONFLICT (slug) DO NOTHING
+      `;
+      console.log(`  ✓ Added role from job: ${dept}`);
+    } catch (e) {
+      // Ignore conflicts
+    }
+  }
+
+  // Extract unique tags from existing jobs and add them
+  console.log("\nExtracting existing tags from jobs...");
+  const jobsWithTags = await sql`
+    SELECT DISTINCT unnest(tags) as tag FROM jobs WHERE tags IS NOT NULL
+  `;
+
+  for (const row of jobsWithTags) {
+    const tag = row.tag as string;
+    if (!tag) continue;
+    const existingTag = existingTags.find(t => t.slug === tag);
+    if (!existingTag) {
+      // This is a tag in the DB that wasn't in our hardcoded list
+      const label = tag.split("-").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+      try {
+        await sql`
+          INSERT INTO job_tags (id, slug, label)
+          VALUES (gen_random_uuid()::text, ${tag}, ${label})
+          ON CONFLICT (slug) DO NOTHING
+        `;
+        console.log(`  ✓ Added tag from job: ${tag} -> ${label}`);
+      } catch (e) {
+        // Ignore conflicts
+      }
+    }
+  }
+
+  console.log("\n✅ Migration complete!");
+  await sql.end();
+  process.exit(0);
+}
+
+migrate().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/src/app/admin/job-roles/page.tsx
+++ b/src/app/admin/job-roles/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { TableSkeleton } from "@/components/admin/TableSkeleton";
+import { EditButton, DeleteButton, ErrorAlert } from "@/components/admin/ActionButtons";
+import { getAdminApiKey, adminFetch, withMinDelay } from "@/lib/admin-utils";
+import { ADMIN_THEMES } from "@/lib/admin-themes";
+
+interface JobRole {
+  id: string;
+  slug: string;
+  label: string;
+  createdAt: string;
+}
+
+const emptyRole: Partial<JobRole> = {
+  slug: "",
+  label: "",
+};
+
+const theme = ADMIN_THEMES.roles;
+
+export default function AdminJobRoles() {
+  const [roles, setRoles] = useState<JobRole[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editingRole, setEditingRole] = useState<Partial<JobRole> | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const fetchRoles = useCallback(async () => {
+    try {
+      const data = await withMinDelay(adminFetch("/api/v1/job-roles"));
+      setRoles(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch roles");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRoles();
+  }, [fetchRoles]);
+
+  const handleSave = async () => {
+    if (!editingRole) return;
+    const apiKey = getAdminApiKey();
+
+    try {
+      if (isCreating) {
+        const newRole = await adminFetch("/api/v1/job-roles", {
+          method: "POST",
+          headers: { "x-api-key": apiKey, "Content-Type": "application/json" },
+          body: JSON.stringify(editingRole),
+        });
+        setRoles([...roles, newRole].sort((a, b) => a.label.localeCompare(b.label)));
+      } else {
+        const updated = await adminFetch("/api/v1/job-roles", {
+          method: "PATCH",
+          headers: { "x-api-key": apiKey, "Content-Type": "application/json" },
+          body: JSON.stringify(editingRole),
+        });
+        setRoles(roles.map((r) => (r.id === updated.id ? updated : r)));
+      }
+      setEditingRole(null);
+      setIsCreating(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save role");
+    }
+  };
+
+  const handleDelete = async (role: JobRole) => {
+    if (!confirm(`Delete role "${role.label}"?`)) return;
+    const apiKey = getAdminApiKey();
+
+    try {
+      await adminFetch(`/api/v1/job-roles?id=${role.id}`, {
+        method: "DELETE",
+        headers: { "x-api-key": apiKey },
+      });
+      setRoles(roles.filter((r) => r.id !== role.id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete role");
+    }
+  };
+
+  const filteredRoles = roles.filter((role) =>
+    role.label.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    role.slug.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  if (loading) return <TableSkeleton columns={3} rows={10} />;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Job Roles</h1>
+        <button
+          onClick={() => {
+            setEditingRole(emptyRole);
+            setIsCreating(true);
+          }}
+          className={`px-4 py-2 ${theme.primary} text-white rounded-lg hover:opacity-90 transition-opacity`}
+        >
+          + Add Role
+        </button>
+      </div>
+
+      {error && <ErrorAlert message={error} onDismiss={() => setError(null)} />}
+
+      {/* Search */}
+      <div className="flex gap-4">
+        <input
+          type="text"
+          placeholder="Search roles..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="flex-1 px-4 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-900"
+        />
+      </div>
+
+      {/* Edit Modal */}
+      {editingRole && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-neutral-900 rounded-xl p-6 w-full max-w-md space-y-4">
+            <h2 className="text-xl font-bold">
+              {isCreating ? "Add Role" : "Edit Role"}
+            </h2>
+            <div>
+              <label className="block text-sm font-medium mb-1">Slug</label>
+              <input
+                type="text"
+                value={editingRole.slug || ""}
+                onChange={(e) => setEditingRole({ ...editingRole, slug: e.target.value })}
+                placeholder="e.g., engineering, design, product"
+                className="w-full px-3 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+              />
+              <p className="text-xs text-neutral-500 mt-1">Used internally, lowercase with hyphens</p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Label</label>
+              <input
+                type="text"
+                value={editingRole.label || ""}
+                onChange={(e) => setEditingRole({ ...editingRole, label: e.target.value })}
+                placeholder="e.g., Engineering, Design, Product"
+                className="w-full px-3 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+              />
+              <p className="text-xs text-neutral-500 mt-1">Displayed to users</p>
+            </div>
+            <div className="flex justify-end gap-2 pt-4">
+              <button
+                onClick={() => {
+                  setEditingRole(null);
+                  setIsCreating(false);
+                }}
+                className="px-4 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSave}
+                className={`px-4 py-2 ${theme.primary} text-white rounded-lg hover:opacity-90`}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Roles Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-neutral-200 dark:border-neutral-700">
+              <th className="text-left py-3 px-4 font-medium">Slug</th>
+              <th className="text-left py-3 px-4 font-medium">Label</th>
+              <th className="text-right py-3 px-4 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredRoles.map((role) => (
+              <tr
+                key={role.id}
+                className="border-b border-neutral-100 dark:border-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-800/50"
+              >
+                <td className="py-3 px-4 font-mono text-sm">{role.slug}</td>
+                <td className="py-3 px-4">{role.label}</td>
+                <td className="py-3 px-4">
+                  <div className="flex justify-end gap-2">
+                    <EditButton
+                      onClick={() => {
+                        setEditingRole(role);
+                        setIsCreating(false);
+                      }}
+                    />
+                    <DeleteButton onClick={() => handleDelete(role)} />
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-sm text-neutral-500">
+        {filteredRoles.length} role{filteredRoles.length !== 1 ? "s" : ""}
+      </p>
+    </div>
+  );
+}

--- a/src/app/admin/job-tags/page.tsx
+++ b/src/app/admin/job-tags/page.tsx
@@ -27,6 +27,30 @@ const COLOR_OPTIONS = [
   "cyan", "sky", "blue", "indigo", "violet", "purple", "fuchsia", "pink", "rose", "slate", "gray"
 ];
 
+const TAG_COLOR_CLASSES: Record<string, string> = {
+  red: "bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400",
+  orange: "bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400",
+  amber: "bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400",
+  yellow: "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400",
+  lime: "bg-lime-100 dark:bg-lime-900/30 text-lime-700 dark:text-lime-400",
+  green: "bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400",
+  emerald: "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400",
+  teal: "bg-teal-100 dark:bg-teal-900/30 text-teal-700 dark:text-teal-400",
+  cyan: "bg-cyan-100 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-400",
+  sky: "bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400",
+  blue: "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400",
+  indigo: "bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400",
+  violet: "bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400",
+  purple: "bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400",
+  fuchsia: "bg-fuchsia-100 dark:bg-fuchsia-900/30 text-fuchsia-700 dark:text-fuchsia-400",
+  pink: "bg-pink-100 dark:bg-pink-900/30 text-pink-700 dark:text-pink-400",
+  rose: "bg-rose-100 dark:bg-rose-900/30 text-rose-700 dark:text-rose-400",
+  slate: "bg-slate-100 dark:bg-slate-900/30 text-slate-700 dark:text-slate-400",
+  gray: "bg-gray-100 dark:bg-gray-900/30 text-gray-700 dark:text-gray-400",
+};
+
+const DEFAULT_TAG_COLOR_CLASS = "bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300";
+
 export default function AdminJobTags() {
   const [tags, setTags] = useState<JobTag[]>([]);
   const [loading, setLoading] = useState(true);
@@ -230,9 +254,7 @@ export default function AdminJobTags() {
                 <td className="py-3 px-4">
                   <span
                     className={`px-2 py-1 text-xs rounded-full ${
-                      tag.color
-                        ? `bg-${tag.color}-100 dark:bg-${tag.color}-900/30 text-${tag.color}-700 dark:text-${tag.color}-400`
-                        : "bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300"
+                      tag.color ? TAG_COLOR_CLASSES[tag.color] ?? DEFAULT_TAG_COLOR_CLASS : DEFAULT_TAG_COLOR_CLASS
                     }`}
                   >
                     {tag.label}

--- a/src/app/admin/job-tags/page.tsx
+++ b/src/app/admin/job-tags/page.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { TableSkeleton } from "@/components/admin/TableSkeleton";
+import { EditButton, DeleteButton, ErrorAlert } from "@/components/admin/ActionButtons";
+import { getAdminApiKey, adminFetch, withMinDelay } from "@/lib/admin-utils";
+import { ADMIN_THEMES } from "@/lib/admin-themes";
+
+interface JobTag {
+  id: string;
+  slug: string;
+  label: string;
+  color: string | null;
+  createdAt: string;
+}
+
+const emptyTag: Partial<JobTag> = {
+  slug: "",
+  label: "",
+  color: "",
+};
+
+const theme = ADMIN_THEMES.tags;
+
+const COLOR_OPTIONS = [
+  "red", "orange", "amber", "yellow", "lime", "green", "emerald", "teal",
+  "cyan", "sky", "blue", "indigo", "violet", "purple", "fuchsia", "pink", "rose", "slate", "gray"
+];
+
+export default function AdminJobTags() {
+  const [tags, setTags] = useState<JobTag[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editingTag, setEditingTag] = useState<Partial<JobTag> | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const fetchTags = useCallback(async () => {
+    try {
+      const data = await withMinDelay(adminFetch("/api/v1/job-tags"));
+      setTags(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch tags");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTags();
+  }, [fetchTags]);
+
+  const handleSave = async () => {
+    if (!editingTag) return;
+    const apiKey = getAdminApiKey();
+
+    try {
+      if (isCreating) {
+        const newTag = await adminFetch("/api/v1/job-tags", {
+          method: "POST",
+          headers: { "x-api-key": apiKey, "Content-Type": "application/json" },
+          body: JSON.stringify(editingTag),
+        });
+        setTags([...tags, newTag].sort((a, b) => a.label.localeCompare(b.label)));
+      } else {
+        const updated = await adminFetch("/api/v1/job-tags", {
+          method: "PATCH",
+          headers: { "x-api-key": apiKey, "Content-Type": "application/json" },
+          body: JSON.stringify(editingTag),
+        });
+        setTags(tags.map((t) => (t.id === updated.id ? updated : t)));
+      }
+      setEditingTag(null);
+      setIsCreating(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save tag");
+    }
+  };
+
+  const handleDelete = async (tag: JobTag) => {
+    if (!confirm(`Delete tag "${tag.label}"?`)) return;
+    const apiKey = getAdminApiKey();
+
+    try {
+      await adminFetch(`/api/v1/job-tags?id=${tag.id}`, {
+        method: "DELETE",
+        headers: { "x-api-key": apiKey },
+      });
+      setTags(tags.filter((t) => t.id !== tag.id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete tag");
+    }
+  };
+
+  const filteredTags = tags.filter((tag) =>
+    tag.label.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    tag.slug.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  if (loading) return <TableSkeleton columns={4} rows={10} />;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Job Tags</h1>
+        <button
+          onClick={() => {
+            setEditingTag(emptyTag);
+            setIsCreating(true);
+          }}
+          className={`px-4 py-2 ${theme.primary} text-white rounded-lg hover:opacity-90 transition-opacity`}
+        >
+          + Add Tag
+        </button>
+      </div>
+
+      {error && <ErrorAlert message={error} onDismiss={() => setError(null)} />}
+
+      {/* Search */}
+      <div className="flex gap-4">
+        <input
+          type="text"
+          placeholder="Search tags..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="flex-1 px-4 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-900"
+        />
+      </div>
+
+      {/* Edit Modal */}
+      {editingTag && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-neutral-900 rounded-xl p-6 w-full max-w-md space-y-4">
+            <h2 className="text-xl font-bold">
+              {isCreating ? "Add Tag" : "Edit Tag"}
+            </h2>
+            <div>
+              <label className="block text-sm font-medium mb-1">Slug</label>
+              <input
+                type="text"
+                value={editingTag.slug || ""}
+                onChange={(e) => setEditingTag({ ...editingTag, slug: e.target.value })}
+                placeholder="e.g., ai, design, leadership"
+                className="w-full px-3 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+              />
+              <p className="text-xs text-neutral-500 mt-1">Used internally, lowercase with hyphens</p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Label</label>
+              <input
+                type="text"
+                value={editingTag.label || ""}
+                onChange={(e) => setEditingTag({ ...editingTag, label: e.target.value })}
+                placeholder="e.g., AI, Design, Leadership"
+                className="w-full px-3 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+              />
+              <p className="text-xs text-neutral-500 mt-1">Displayed to users</p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Color</label>
+              <select
+                value={editingTag.color || ""}
+                onChange={(e) => setEditingTag({ ...editingTag, color: e.target.value })}
+                className="w-full px-3 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+              >
+                <option value="">No color</option>
+                {COLOR_OPTIONS.map((color) => (
+                  <option key={color} value={color}>{color}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex justify-end gap-2 pt-4">
+              <button
+                onClick={() => {
+                  setEditingTag(null);
+                  setIsCreating(false);
+                }}
+                className="px-4 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSave}
+                className={`px-4 py-2 ${theme.primary} text-white rounded-lg hover:opacity-90`}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Tags Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-neutral-200 dark:border-neutral-700">
+              <th className="text-left py-3 px-4 font-medium">Slug</th>
+              <th className="text-left py-3 px-4 font-medium">Label</th>
+              <th className="text-left py-3 px-4 font-medium">Color</th>
+              <th className="text-left py-3 px-4 font-medium">Preview</th>
+              <th className="text-right py-3 px-4 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredTags.map((tag) => (
+              <tr
+                key={tag.id}
+                className="border-b border-neutral-100 dark:border-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-800/50"
+              >
+                <td className="py-3 px-4 font-mono text-sm">{tag.slug}</td>
+                <td className="py-3 px-4">{tag.label}</td>
+                <td className="py-3 px-4">{tag.color || "-"}</td>
+                <td className="py-3 px-4">
+                  <span
+                    className={`px-2 py-1 text-xs rounded-full ${
+                      tag.color
+                        ? `bg-${tag.color}-100 dark:bg-${tag.color}-900/30 text-${tag.color}-700 dark:text-${tag.color}-400`
+                        : "bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300"
+                    }`}
+                  >
+                    {tag.label}
+                  </span>
+                </td>
+                <td className="py-3 px-4">
+                  <div className="flex justify-end gap-2">
+                    <EditButton
+                      onClick={() => {
+                        setEditingTag(tag);
+                        setIsCreating(false);
+                      }}
+                    />
+                    <DeleteButton onClick={() => handleDelete(tag)} />
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-sm text-neutral-500">
+        {filteredTags.length} tag{filteredTags.length !== 1 ? "s" : ""}
+      </p>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -90,7 +90,7 @@ export default function AdminLayout({
     setIsAuthenticated(false);
   };
 
-  // Order: Dashboard, Affiliations (About page), Blog, News, Portfolio, Jobs, Candidates
+  // Order: Dashboard, Affiliations (About page), Blog, News, Portfolio, Jobs, Candidates, Tags, Roles
   const navItems = [
     { href: "/admin", label: "Dashboard", color: "neutral", bg: "bg-neutral-100 dark:bg-neutral-800", bgHover: "hover:bg-neutral-200 dark:hover:bg-neutral-700", bgActive: "bg-neutral-700 dark:bg-neutral-600", text: "text-neutral-600 dark:text-neutral-400" },
     { href: "/admin/affiliations", label: "Affiliations", color: "pink", bg: "bg-pink-100 dark:bg-pink-900/30", bgHover: "hover:bg-pink-200 dark:hover:bg-pink-800/40", bgActive: "bg-pink-500 dark:bg-pink-600", text: "text-pink-600 dark:text-pink-400" },
@@ -98,9 +98,9 @@ export default function AdminLayout({
     { href: "/admin/news", label: "News", color: "purple", bg: "bg-purple-100 dark:bg-purple-900/30", bgHover: "hover:bg-purple-200 dark:hover:bg-purple-800/40", bgActive: "bg-purple-500 dark:bg-purple-600", text: "text-purple-600 dark:text-purple-400" },
     { href: "/admin/investments", label: "Portfolio", color: "amber", bg: "bg-amber-100 dark:bg-amber-900/30", bgHover: "hover:bg-amber-200 dark:hover:bg-amber-800/40", bgActive: "bg-amber-500 dark:bg-amber-600", text: "text-amber-600 dark:text-amber-400" },
     { href: "/admin/jobs", label: "Jobs", color: "blue", bg: "bg-blue-100 dark:bg-blue-900/30", bgHover: "hover:bg-blue-200 dark:hover:bg-blue-800/40", bgActive: "bg-blue-500 dark:bg-blue-600", text: "text-blue-600 dark:text-blue-400" },
-    { href: "/admin/job-tags", label: "Tags", color: "cyan", bg: "bg-cyan-100 dark:bg-cyan-900/30", bgHover: "hover:bg-cyan-200 dark:hover:bg-cyan-800/40", bgActive: "bg-cyan-500 dark:bg-cyan-600", text: "text-cyan-600 dark:text-cyan-400" },
-    { href: "/admin/job-roles", label: "Roles", color: "teal", bg: "bg-teal-100 dark:bg-teal-900/30", bgHover: "hover:bg-teal-200 dark:hover:bg-teal-800/40", bgActive: "bg-teal-500 dark:bg-teal-600", text: "text-teal-600 dark:text-teal-400" },
     { href: "/admin/candidates", label: "Candidates", color: "green", bg: "bg-green-100 dark:bg-green-900/30", bgHover: "hover:bg-green-200 dark:hover:bg-green-800/40", bgActive: "bg-green-500 dark:bg-green-600", text: "text-green-600 dark:text-green-400" },
+    { href: "/admin/job-tags", label: "Tags", color: "orange", bg: "bg-orange-100 dark:bg-orange-900/30", bgHover: "hover:bg-orange-200 dark:hover:bg-orange-800/40", bgActive: "bg-orange-500 dark:bg-orange-600", text: "text-orange-600 dark:text-orange-400" },
+    { href: "/admin/job-roles", label: "Roles", color: "violet", bg: "bg-violet-100 dark:bg-violet-900/30", bgHover: "hover:bg-violet-200 dark:hover:bg-violet-800/40", bgActive: "bg-violet-500 dark:bg-violet-600", text: "text-violet-600 dark:text-violet-400" },
   ];
 
   if (isLoading) {

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -98,6 +98,8 @@ export default function AdminLayout({
     { href: "/admin/news", label: "News", color: "purple", bg: "bg-purple-100 dark:bg-purple-900/30", bgHover: "hover:bg-purple-200 dark:hover:bg-purple-800/40", bgActive: "bg-purple-500 dark:bg-purple-600", text: "text-purple-600 dark:text-purple-400" },
     { href: "/admin/investments", label: "Portfolio", color: "amber", bg: "bg-amber-100 dark:bg-amber-900/30", bgHover: "hover:bg-amber-200 dark:hover:bg-amber-800/40", bgActive: "bg-amber-500 dark:bg-amber-600", text: "text-amber-600 dark:text-amber-400" },
     { href: "/admin/jobs", label: "Jobs", color: "blue", bg: "bg-blue-100 dark:bg-blue-900/30", bgHover: "hover:bg-blue-200 dark:hover:bg-blue-800/40", bgActive: "bg-blue-500 dark:bg-blue-600", text: "text-blue-600 dark:text-blue-400" },
+    { href: "/admin/job-tags", label: "Tags", color: "cyan", bg: "bg-cyan-100 dark:bg-cyan-900/30", bgHover: "hover:bg-cyan-200 dark:hover:bg-cyan-800/40", bgActive: "bg-cyan-500 dark:bg-cyan-600", text: "text-cyan-600 dark:text-cyan-400" },
+    { href: "/admin/job-roles", label: "Roles", color: "teal", bg: "bg-teal-100 dark:bg-teal-900/30", bgHover: "hover:bg-teal-200 dark:hover:bg-teal-800/40", bgActive: "bg-teal-500 dark:bg-teal-600", text: "text-teal-600 dark:text-teal-400" },
     { href: "/admin/candidates", label: "Candidates", color: "green", bg: "bg-green-100 dark:bg-green-900/30", bgHover: "hover:bg-green-200 dark:hover:bg-green-800/40", bgActive: "bg-green-500 dark:bg-green-600", text: "text-green-600 dark:text-green-400" },
   ];
 

--- a/src/app/api/v1/job-roles/route.ts
+++ b/src/app/api/v1/job-roles/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db, jobRoles } from "@/db";
+import { eq, asc } from "drizzle-orm";
+import { validateApiKey } from "@/lib/api-auth";
+
+// GET all job roles
+export async function GET() {
+  try {
+    const roles = await db.select().from(jobRoles).orderBy(asc(jobRoles.label));
+    return NextResponse.json(roles);
+  } catch (error) {
+    console.error("Error fetching job roles:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch job roles" },
+      { status: 500 }
+    );
+  }
+}
+
+// POST create a new job role
+export async function POST(request: NextRequest) {
+  const authError = await validateApiKey(request);
+  if (authError) return authError;
+
+  try {
+    const body = await request.json();
+    const { slug, label } = body;
+
+    if (!slug || !label) {
+      return NextResponse.json(
+        { error: "slug and label are required" },
+        { status: 400 }
+      );
+    }
+
+    // Normalize slug
+    const normalizedSlug = slug.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+
+    const [role] = await db
+      .insert(jobRoles)
+      .values({ slug: normalizedSlug, label })
+      .returning();
+
+    return NextResponse.json(role, { status: 201 });
+  } catch (error: unknown) {
+    console.error("Error creating job role:", error);
+    if (error && typeof error === "object" && "code" in error && error.code === "23505") {
+      return NextResponse.json(
+        { error: "A role with this slug already exists" },
+        { status: 409 }
+      );
+    }
+    return NextResponse.json(
+      { error: "Failed to create job role" },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE a job role
+export async function DELETE(request: NextRequest) {
+  const authError = await validateApiKey(request);
+  if (authError) return authError;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get("id");
+
+    if (!id) {
+      return NextResponse.json(
+        { error: "id is required" },
+        { status: 400 }
+      );
+    }
+
+    await db.delete(jobRoles).where(eq(jobRoles.id, id));
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting job role:", error);
+    return NextResponse.json(
+      { error: "Failed to delete job role" },
+      { status: 500 }
+    );
+  }
+}
+
+// PATCH update a job role
+export async function PATCH(request: NextRequest) {
+  const authError = await validateApiKey(request);
+  if (authError) return authError;
+
+  try {
+    const body = await request.json();
+    const { id, slug, label } = body;
+
+    if (!id) {
+      return NextResponse.json(
+        { error: "id is required" },
+        { status: 400 }
+      );
+    }
+
+    const updates: Partial<{ slug: string; label: string }> = {};
+    if (slug) updates.slug = slug.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+    if (label) updates.label = label;
+
+    const [role] = await db
+      .update(jobRoles)
+      .set(updates)
+      .where(eq(jobRoles.id, id))
+      .returning();
+
+    return NextResponse.json(role);
+  } catch (error) {
+    console.error("Error updating job role:", error);
+    return NextResponse.json(
+      { error: "Failed to update job role" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/job-roles/route.ts
+++ b/src/app/api/v1/job-roles/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db, jobRoles } from "@/db";
 import { eq, asc } from "drizzle-orm";
-import { validateApiKey } from "@/lib/api-auth";
+import { requireAuth } from "@/lib/api-auth";
 
 // GET all job roles
 export async function GET() {
@@ -19,8 +19,8 @@ export async function GET() {
 
 // POST create a new job role
 export async function POST(request: NextRequest) {
-  const authError = await validateApiKey(request);
-  if (authError) return authError;
+  const auth = await requireAuth(request, "jobs:write");
+  if (auth instanceof Response) return auth;
 
   try {
     const body = await request.json();
@@ -59,8 +59,8 @@ export async function POST(request: NextRequest) {
 
 // DELETE a job role
 export async function DELETE(request: NextRequest) {
-  const authError = await validateApiKey(request);
-  if (authError) return authError;
+  const auth = await requireAuth(request, "jobs:write");
+  if (auth instanceof Response) return auth;
 
   try {
     const { searchParams } = new URL(request.url);
@@ -86,8 +86,8 @@ export async function DELETE(request: NextRequest) {
 
 // PATCH update a job role
 export async function PATCH(request: NextRequest) {
-  const authError = await validateApiKey(request);
-  if (authError) return authError;
+  const auth = await requireAuth(request, "jobs:write");
+  if (auth instanceof Response) return auth;
 
   try {
     const body = await request.json();

--- a/src/app/api/v1/job-tags/route.ts
+++ b/src/app/api/v1/job-tags/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db, jobTags } from "@/db";
 import { eq, asc } from "drizzle-orm";
-import { validateApiKey } from "@/lib/api-auth";
+import { requireAuth } from "@/lib/api-auth";
 
 // GET all job tags
 export async function GET() {
@@ -19,8 +19,8 @@ export async function GET() {
 
 // POST create a new job tag
 export async function POST(request: NextRequest) {
-  const authError = await validateApiKey(request);
-  if (authError) return authError;
+  const auth = await requireAuth(request, "jobs:write");
+  if (auth instanceof Response) return auth;
 
   try {
     const body = await request.json();
@@ -59,8 +59,8 @@ export async function POST(request: NextRequest) {
 
 // DELETE a job tag
 export async function DELETE(request: NextRequest) {
-  const authError = await validateApiKey(request);
-  if (authError) return authError;
+  const auth = await requireAuth(request, "jobs:write");
+  if (auth instanceof Response) return auth;
 
   try {
     const { searchParams } = new URL(request.url);
@@ -86,8 +86,8 @@ export async function DELETE(request: NextRequest) {
 
 // PATCH update a job tag
 export async function PATCH(request: NextRequest) {
-  const authError = await validateApiKey(request);
-  if (authError) return authError;
+  const auth = await requireAuth(request, "jobs:write");
+  if (auth instanceof Response) return auth;
 
   try {
     const body = await request.json();

--- a/src/app/api/v1/job-tags/route.ts
+++ b/src/app/api/v1/job-tags/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db, jobTags } from "@/db";
+import { eq, asc } from "drizzle-orm";
+import { validateApiKey } from "@/lib/api-auth";
+
+// GET all job tags
+export async function GET() {
+  try {
+    const tags = await db.select().from(jobTags).orderBy(asc(jobTags.label));
+    return NextResponse.json(tags);
+  } catch (error) {
+    console.error("Error fetching job tags:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch job tags" },
+      { status: 500 }
+    );
+  }
+}
+
+// POST create a new job tag
+export async function POST(request: NextRequest) {
+  const authError = await validateApiKey(request);
+  if (authError) return authError;
+
+  try {
+    const body = await request.json();
+    const { slug, label, color } = body;
+
+    if (!slug || !label) {
+      return NextResponse.json(
+        { error: "slug and label are required" },
+        { status: 400 }
+      );
+    }
+
+    // Normalize slug
+    const normalizedSlug = slug.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+
+    const [tag] = await db
+      .insert(jobTags)
+      .values({ slug: normalizedSlug, label, color })
+      .returning();
+
+    return NextResponse.json(tag, { status: 201 });
+  } catch (error: unknown) {
+    console.error("Error creating job tag:", error);
+    if (error && typeof error === "object" && "code" in error && error.code === "23505") {
+      return NextResponse.json(
+        { error: "A tag with this slug already exists" },
+        { status: 409 }
+      );
+    }
+    return NextResponse.json(
+      { error: "Failed to create job tag" },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE a job tag
+export async function DELETE(request: NextRequest) {
+  const authError = await validateApiKey(request);
+  if (authError) return authError;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get("id");
+
+    if (!id) {
+      return NextResponse.json(
+        { error: "id is required" },
+        { status: 400 }
+      );
+    }
+
+    await db.delete(jobTags).where(eq(jobTags.id, id));
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting job tag:", error);
+    return NextResponse.json(
+      { error: "Failed to delete job tag" },
+      { status: 500 }
+    );
+  }
+}
+
+// PATCH update a job tag
+export async function PATCH(request: NextRequest) {
+  const authError = await validateApiKey(request);
+  if (authError) return authError;
+
+  try {
+    const body = await request.json();
+    const { id, slug, label, color } = body;
+
+    if (!id) {
+      return NextResponse.json(
+        { error: "id is required" },
+        { status: 400 }
+      );
+    }
+
+    const updates: Partial<{ slug: string; label: string; color: string | null }> = {};
+    if (slug) updates.slug = slug.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+    if (label) updates.label = label;
+    if (color !== undefined) updates.color = color;
+
+    const [tag] = await db
+      .update(jobTags)
+      .set(updates)
+      .where(eq(jobTags.id, id))
+      .returning();
+
+    return NextResponse.json(tag);
+  } catch (error) {
+    console.error("Error updating job tag:", error);
+    return NextResponse.json(
+      { error: "Failed to update job tag" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/news/announcements/[id]/route.ts
+++ b/src/app/api/v1/news/announcements/[id]/route.ts
@@ -44,13 +44,24 @@ export async function PUT(
   try {
     const body = await request.json();
 
+    // Only update allowed fields, explicitly handle timestamps
+    const updateData: Record<string, unknown> = {
+      updatedAt: new Date(),
+    };
+
+    if (body.title !== undefined) updateData.title = body.title;
+    if (body.url !== undefined) updateData.url = body.url;
+    if (body.company !== undefined) updateData.company = body.company;
+    if (body.companyLogo !== undefined) updateData.companyLogo = body.companyLogo;
+    if (body.platform !== undefined) updateData.platform = body.platform;
+    if (body.date !== undefined) updateData.date = new Date(body.date);
+    if (body.description !== undefined) updateData.description = body.description;
+    if (body.category !== undefined) updateData.category = body.category;
+    if (body.featured !== undefined) updateData.featured = body.featured;
+
     const [updated] = await db
       .update(announcements)
-      .set({
-        ...body,
-        date: body.date ? new Date(body.date) : undefined,
-        updatedAt: new Date(),
-      })
+      .set(updateData)
       .where(eq(announcements.id, id))
       .returning();
 

--- a/src/app/api/v1/news/curated/[id]/route.ts
+++ b/src/app/api/v1/news/curated/[id]/route.ts
@@ -44,13 +44,22 @@ export async function PUT(
   try {
     const body = await request.json();
 
+    // Only update allowed fields, explicitly handle timestamps
+    const updateData: Record<string, unknown> = {
+      updatedAt: new Date(),
+    };
+
+    if (body.title !== undefined) updateData.title = body.title;
+    if (body.url !== undefined) updateData.url = body.url;
+    if (body.source !== undefined) updateData.source = body.source;
+    if (body.date !== undefined) updateData.date = new Date(body.date);
+    if (body.description !== undefined) updateData.description = body.description;
+    if (body.category !== undefined) updateData.category = body.category;
+    if (body.featured !== undefined) updateData.featured = body.featured;
+
     const [updated] = await db
       .update(curatedLinks)
-      .set({
-        ...body,
-        date: body.date ? new Date(body.date) : undefined,
-        updatedAt: new Date(),
-      })
+      .set(updateData)
       .where(eq(curatedLinks.id, id))
       .returning();
 

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -2,6 +2,8 @@ import { Suspense } from "react";
 import { Navbar } from "@/components/Navbar";
 import { JobsGrid } from "@/components/JobsGrid";
 import { getJobsFromDB } from "@/lib/data";
+import { db, jobTags, jobRoles } from "@/db";
+import { asc } from "drizzle-orm";
 
 export const metadata = {
 	title: "Jobs",
@@ -24,8 +26,19 @@ function JobsGridFallback() {
 	);
 }
 
+async function getTagsAndRoles() {
+	const [tags, roles] = await Promise.all([
+		db.select().from(jobTags).orderBy(asc(jobTags.label)),
+		db.select().from(jobRoles).orderBy(asc(jobRoles.label)),
+	]);
+	return { tags, roles };
+}
+
 export default async function Jobs() {
-	const jobs = await getJobsFromDB();
+	const [jobs, { tags, roles }] = await Promise.all([
+		getJobsFromDB(),
+		getTagsAndRoles(),
+	]);
 
 	return (
 		<>
@@ -62,7 +75,7 @@ export default async function Jobs() {
 
 					{/* Jobs Grid */}
 					<Suspense fallback={<JobsGridFallback />}>
-						<JobsGrid jobs={jobs} />
+						<JobsGrid jobs={jobs} tagDefinitions={tags} roleDefinitions={roles} />
 					</Suspense>
 				</div>
 			</main>

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -2,39 +2,48 @@ import { Navbar } from "@/components/Navbar";
 import { PortfolioGrid } from "@/components/PortfolioGrid";
 import { db, investments as investmentsTable, jobs as jobsTable } from "@/db";
 import { desc, asc, sql } from "drizzle-orm";
+import { unstable_cache } from "next/cache";
 
 export const metadata = {
   title: "Portfolio",
 };
 
-// Force dynamic rendering since we need database access
-export const dynamic = "force-dynamic";
+// Use ISR with 5 minute revalidation instead of force-dynamic
+export const revalidate = 300;
 
-async function getInvestments() {
-  const data = await db
-    .select()
-    .from(investmentsTable)
-    .orderBy(asc(investmentsTable.tier), desc(investmentsTable.featured));
+const getInvestments = unstable_cache(
+  async () => {
+    const data = await db
+      .select()
+      .from(investmentsTable)
+      .orderBy(asc(investmentsTable.tier), desc(investmentsTable.featured));
 
-  // Map to expected format with tier as number
-  return data.map(inv => ({
-    ...inv,
-    tier: (parseInt(inv.tier || "2") || 2) as 1 | 2 | 3 | 4,
-    featured: inv.featured ?? false,
-  }));
-}
+    // Map to expected format with tier as number
+    return data.map(inv => ({
+      ...inv,
+      tier: (parseInt(inv.tier || "2") || 2) as 1 | 2 | 3 | 4,
+      featured: inv.featured ?? false,
+    }));
+  },
+  ["investments"],
+  { revalidate: 300, tags: ["investments"] }
+);
 
-async function getJobCountsByCompany(): Promise<Record<string, number>> {
-  const results = await db
-    .select({
-      company: jobsTable.company,
-      count: sql<number>`count(*)::int`,
-    })
-    .from(jobsTable)
-    .groupBy(jobsTable.company);
+const getJobCountsByCompany = unstable_cache(
+  async (): Promise<Record<string, number>> => {
+    const results = await db
+      .select({
+        company: jobsTable.company,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(jobsTable)
+      .groupBy(jobsTable.company);
 
-  return Object.fromEntries(results.map(r => [r.company, r.count]));
-}
+    return Object.fromEntries(results.map(r => [r.company, r.count]));
+  },
+  ["job-counts-by-company"],
+  { revalidate: 300, tags: ["jobs"] }
+);
 
 export default async function Portfolio() {
   const [investments, jobCounts] = await Promise.all([

--- a/src/components/CustomMultiSelect.tsx
+++ b/src/components/CustomMultiSelect.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+
+interface Option {
+	value: string;
+	label: string;
+}
+
+interface CustomMultiSelectProps {
+	id?: string;
+	values: string[];
+	onChange: (values: string[]) => void;
+	options: Option[];
+	placeholder?: string;
+	className?: string;
+	searchable?: boolean;
+}
+
+export function CustomMultiSelect({
+	id,
+	values,
+	onChange,
+	options,
+	placeholder = "Select...",
+	className = "",
+	searchable = false,
+}: CustomMultiSelectProps) {
+	const [isOpen, setIsOpen] = useState(false);
+	const [focusedIndex, setFocusedIndex] = useState(-1);
+	const [searchQuery, setSearchQuery] = useState("");
+	const containerRef = useRef<HTMLDivElement>(null);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const listboxRef = useRef<HTMLDivElement>(null);
+	const searchInputRef = useRef<HTMLInputElement>(null);
+
+	// Filter options based on search query
+	const filteredOptions = searchable && searchQuery
+		? options.filter((opt) =>
+			opt.label.toLowerCase().includes(searchQuery.toLowerCase())
+		)
+		: options;
+
+	const focusDropdown = useCallback(() => {
+		window.setTimeout(() => {
+			if (searchable) {
+				searchInputRef.current?.focus();
+			} else {
+				listboxRef.current?.focus();
+			}
+		}, 0);
+	}, [searchable]);
+
+	const openDropdown = useCallback(() => {
+		setIsOpen(true);
+		setFocusedIndex(0);
+		focusDropdown();
+	}, [focusDropdown]);
+
+	const closeDropdown = useCallback(() => {
+		setIsOpen(false);
+		setSearchQuery("");
+		setFocusedIndex(-1);
+	}, []);
+
+	// Close on click outside
+	useEffect(() => {
+		if (!isOpen) return;
+
+		const handleClickOutside = (e: MouseEvent) => {
+			if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+				closeDropdown();
+			}
+		};
+
+		document.addEventListener("mousedown", handleClickOutside);
+		return () => document.removeEventListener("mousedown", handleClickOutside);
+	}, [isOpen, closeDropdown]);
+
+	// Toggle a value
+	const toggleValue = useCallback((value: string) => {
+		if (values.includes(value)) {
+			onChange(values.filter((v) => v !== value));
+		} else {
+			onChange([...values, value]);
+		}
+	}, [values, onChange]);
+
+	// Handle keyboard navigation
+	const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+		if (!isOpen) {
+			if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown" || e.key === "ArrowUp") {
+				e.preventDefault();
+				openDropdown();
+			}
+			return;
+		}
+
+		switch (e.key) {
+			case "Escape":
+				e.preventDefault();
+				closeDropdown();
+				triggerRef.current?.focus();
+				break;
+			case "Tab":
+				closeDropdown();
+				break;
+			case "ArrowDown":
+				e.preventDefault();
+				setFocusedIndex((prev) => (prev < filteredOptions.length - 1 ? prev + 1 : prev));
+				break;
+			case "ArrowUp":
+				e.preventDefault();
+				setFocusedIndex((prev) => (prev > 0 ? prev - 1 : prev));
+				break;
+			case "Enter":
+			case " ":
+				e.preventDefault();
+				if (focusedIndex >= 0 && focusedIndex < filteredOptions.length) {
+					toggleValue(filteredOptions[focusedIndex].value);
+				}
+				break;
+			case "Home":
+				e.preventDefault();
+				setFocusedIndex(0);
+				break;
+			case "End":
+				e.preventDefault();
+				setFocusedIndex(filteredOptions.length - 1);
+				break;
+		}
+	}, [isOpen, focusedIndex, filteredOptions, toggleValue, closeDropdown, openDropdown]);
+
+	// Scroll focused option into view
+	useEffect(() => {
+		if (isOpen && listboxRef.current && focusedIndex >= 0) {
+			const option = listboxRef.current.children[searchable ? focusedIndex + 1 : focusedIndex] as HTMLElement;
+			if (option) {
+				option.scrollIntoView({ block: "nearest" });
+			}
+		}
+	}, [isOpen, focusedIndex, searchable]);
+
+	// Display text
+	const displayText = values.length === 0
+		? placeholder
+		: values.length === 1
+			? options.find((o) => o.value === values[0])?.label || values[0]
+			: `${values.length} selected`;
+
+	return (
+		<div ref={containerRef} className={`relative ${className}`} onKeyDown={handleKeyDown}>
+			{/* Trigger button */}
+			<button
+				id={id}
+				type="button"
+				ref={triggerRef}
+				onClick={() => {
+					if (isOpen) {
+						closeDropdown();
+					} else {
+						openDropdown();
+					}
+				}}
+				aria-haspopup="listbox"
+				aria-expanded={isOpen}
+				aria-controls={id ? `${id}-listbox` : undefined}
+				className="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
+			>
+				<span className="truncate">{displayText}</span>
+				<div className="flex items-center gap-1.5">
+					{values.length > 0 && (
+						<span
+							role="button"
+							tabIndex={0}
+							onClick={(e) => {
+								e.stopPropagation();
+								onChange([]);
+							}}
+							onKeyDown={(e) => {
+								if (e.key === "Enter" || e.key === " ") {
+									e.preventDefault();
+									e.stopPropagation();
+									onChange([]);
+								}
+							}}
+							className="p-0.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 cursor-pointer"
+							aria-label="Clear selection"
+						>
+							<svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+							</svg>
+						</span>
+					)}
+					<svg
+						className={`w-4 h-4 flex-shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`}
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+					</svg>
+				</div>
+			</button>
+
+			{/* Dropdown */}
+			{isOpen && (
+				<>
+					{/* Backdrop for mobile */}
+					<div
+						className="sm:hidden fixed inset-0 z-[var(--z-sticky)]"
+						onClick={closeDropdown}
+					/>
+
+					{/* Dropdown menu */}
+					<div
+						ref={listboxRef}
+						id={id ? `${id}-listbox` : undefined}
+						role="listbox"
+						tabIndex={searchable ? undefined : -1}
+						aria-labelledby={id}
+						aria-multiselectable="true"
+						aria-activedescendant={focusedIndex >= 0 && id ? `${id}-option-${focusedIndex}` : undefined}
+						className="absolute z-[var(--z-dropdown)] mt-1 w-full min-w-[200px] bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-lg max-h-[60vh] sm:max-h-60 overflow-y-auto"
+					>
+						{/* Search input */}
+						{searchable && (
+							<div className="sticky top-0 p-2 bg-white dark:bg-neutral-900 border-b border-neutral-200 dark:border-neutral-700">
+								<input
+									ref={searchInputRef}
+									type="text"
+									value={searchQuery}
+									onChange={(e) => {
+										setSearchQuery(e.target.value);
+										setFocusedIndex(0);
+									}}
+									placeholder="Search..."
+									className="w-full px-3 py-2 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
+									onClick={(e) => e.stopPropagation()}
+								/>
+							</div>
+						)}
+						{filteredOptions.length === 0 ? (
+							<div className="px-4 py-3 text-sm text-neutral-500">
+								No results found
+							</div>
+						) : (
+							filteredOptions.map((option, index) => {
+								const isSelected = values.includes(option.value);
+								return (
+									<button
+										key={option.value}
+										id={id ? `${id}-option-${index}` : undefined}
+										type="button"
+										role="option"
+										aria-selected={isSelected}
+										onClick={() => toggleValue(option.value)}
+										onMouseEnter={() => setFocusedIndex(index)}
+										className={`w-full px-4 py-3 sm:px-3 sm:py-2 text-base sm:text-sm text-left transition-colors flex items-center gap-2 ${!searchable ? "first:rounded-t-xl" : ""} last:rounded-b-xl ${
+											index === focusedIndex
+												? "bg-neutral-50 dark:bg-neutral-800/50"
+												: "hover:bg-neutral-50 dark:hover:bg-neutral-800/50"
+										}`}
+									>
+										{/* Checkbox */}
+										<span className={`flex-shrink-0 w-4 h-4 rounded border ${
+											isSelected
+												? "bg-neutral-900 dark:bg-white border-neutral-900 dark:border-white"
+												: "border-neutral-300 dark:border-neutral-600"
+										} flex items-center justify-center`}>
+											{isSelected && (
+												<svg className="w-3 h-3 text-white dark:text-neutral-900" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+													<path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+												</svg>
+											)}
+										</span>
+										<span className={isSelected ? "font-medium" : ""}>{option.label}</span>
+									</button>
+								);
+							})
+						)}
+					</div>
+				</>
+			)}
+		</div>
+	);
+}

--- a/src/components/JobsGrid.tsx
+++ b/src/components/JobsGrid.tsx
@@ -255,7 +255,7 @@ function ExpandedJobView({
 													: "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
 										}`}
 									>
-										{tagLabels[tag as JobTag] ?? tag}
+										{tagLabels[tag] ?? tag}
 									</span>
 								))}
 							</div>

--- a/src/components/JobsGrid.tsx
+++ b/src/components/JobsGrid.tsx
@@ -44,6 +44,7 @@ function ExpandedJobView({
 	onViewOtherJobs,
 	otherJobsCount,
 	onApplyClick,
+	tagLabels,
 }: {
 	job: Job;
 	onClose: () => void;
@@ -51,6 +52,7 @@ function ExpandedJobView({
 	onViewOtherJobs: () => void;
 	otherJobsCount: number;
 	onApplyClick?: () => void;
+	tagLabels: Record<string, string>;
 }) {
 	const isHot = job.tags?.includes("hot");
 	const [copiedLink, setCopiedLink] = useState<"job" | "apply" | null>(null);
@@ -1376,6 +1378,7 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
           }}
           otherJobsCount={jobs.filter(j => j.company.name === expandedJob.company.name && j.id !== expandedJob.id).length}
           onApplyClick={() => trackJobApplyClick(getJobEventProps(expandedJob))}
+          tagLabels={tagLabels}
         />
       )}
     </div>

--- a/src/components/JobsGrid.tsx
+++ b/src/components/JobsGrid.tsx
@@ -253,7 +253,7 @@ function ExpandedJobView({
 													: "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
 										}`}
 									>
-										{defaultTagLabels[tag as JobTag] ?? tag}
+										{tagLabels[tag as JobTag] ?? tag}
 									</span>
 								))}
 							</div>

--- a/src/components/JobsGrid.tsx
+++ b/src/components/JobsGrid.tsx
@@ -253,7 +253,7 @@ function ExpandedJobView({
 													: "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
 										}`}
 									>
-										{tagLabels[tag] ?? tag}
+										{defaultTagLabels[tag as JobTag] ?? tag}
 									</span>
 								))}
 							</div>
@@ -1371,7 +1371,7 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
           onClose={closeJob}
           jobUrl={typeof window !== "undefined" ? `${window.location.origin}/jobs?job=${expandedJob.id}` : `/jobs?job=${expandedJob.id}`}
           onViewOtherJobs={() => {
-            handleCompanyChange(expandedJob.company.name);
+            handleCompanyChange([expandedJob.company.name]);
             closeJob();
           }}
           otherJobsCount={jobs.filter(j => j.company.name === expandedJob.company.name && j.id !== expandedJob.id).length}

--- a/src/components/PortfolioGrid.tsx
+++ b/src/components/PortfolioGrid.tsx
@@ -32,6 +32,7 @@ type SortOption = "relevance" | "alphabetical" | "alphabetical-desc";
 
 interface PortfolioGridProps {
 	investments: Investment[];
+	jobCounts?: Record<string, number>;
 }
 
 function hashString(value: string): number {
@@ -63,7 +64,7 @@ function shuffleArray<T>(array: T[], random: () => number): T[] {
 
 type FilterOption = "main" | "featured" | "all";
 
-export function PortfolioGrid({ investments }: PortfolioGridProps) {
+export function PortfolioGrid({ investments, jobCounts = {} }: PortfolioGridProps) {
 	const [sortBy, setSortBy] = useState<SortOption>("relevance");
 	const [filter, setFilter] = useState<FilterOption>("all");
 
@@ -342,6 +343,19 @@ export function PortfolioGrid({ investments }: PortfolioGridProps) {
 								</a>
 							)}
 						</div>
+						{/* Join Button - only show if there are job openings */}
+						{jobCounts[investment.title] > 0 && (
+							<a
+								href={`/jobs?company=${encodeURIComponent(investment.title)}`}
+								className="mt-3 inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium text-sm"
+								aria-label={`View ${jobCounts[investment.title]} job openings at ${investment.title}`}
+							>
+								<span>Join the team</span>
+								<span className="bg-white/20 rounded-full px-2 py-0.5 text-xs">
+									{jobCounts[investment.title]}
+								</span>
+							</a>
+						)}
 					</div>
 				))}
 			</div>

--- a/src/components/PortfolioGrid.tsx
+++ b/src/components/PortfolioGrid.tsx
@@ -369,8 +369,8 @@ export function PortfolioGrid({ investments, jobCounts = {} }: PortfolioGridProp
 								aria-label={`View ${getJobCount(investment.title, jobCounts)} job openings at ${investment.title}`}
 							>
 								<span className="relative flex h-2 w-2">
-									<span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-white opacity-75"></span>
-									<span className="relative inline-flex rounded-full h-2 w-2 bg-white"></span>
+									<span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-white dark:bg-neutral-900 opacity-75"></span>
+									<span className="relative inline-flex rounded-full h-2 w-2 bg-white dark:bg-neutral-900"></span>
 								</span>
 								<span>Hiring</span>
 								<span className="bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white rounded-full px-1.5 py-0.5 text-[10px] font-bold leading-none">

--- a/src/components/admin/Combobox.tsx
+++ b/src/components/admin/Combobox.tsx
@@ -8,6 +8,7 @@ interface ComboboxProps {
   field: string;
   placeholder?: string;
   className?: string;
+  options?: string[]; // Optional: provide options directly instead of fetching from API
 }
 
 export function Combobox({
@@ -16,6 +17,7 @@ export function Combobox({
   field,
   placeholder,
   className = "",
+  options,
 }: ComboboxProps) {
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -25,6 +27,14 @@ export function Combobox({
 
   const fetchSuggestions = useCallback(
     async (query: string) => {
+      // If options are provided, filter them locally instead of API call
+      if (options) {
+        const filtered = options.filter((opt) =>
+          opt.toLowerCase().includes(query.toLowerCase())
+        );
+        setSuggestions(filtered);
+        return;
+      }
       try {
         const res = await fetch(
           `/api/v1/autocomplete?field=${field}&q=${encodeURIComponent(query)}`
@@ -37,7 +47,7 @@ export function Combobox({
         console.error("Failed to fetch suggestions:", error);
       }
     },
-    [field]
+    [field, options]
   );
 
   useEffect(() => {
@@ -154,6 +164,8 @@ interface MultiComboboxProps {
   field: string;
   placeholder?: string;
   className?: string;
+  options?: string[]; // Optional: provide options directly instead of fetching from API
+  labelMap?: Record<string, string>; // Optional: map values to display labels
 }
 
 export function MultiCombobox({
@@ -162,6 +174,8 @@ export function MultiCombobox({
   field,
   placeholder,
   className = "",
+  options,
+  labelMap,
 }: MultiComboboxProps) {
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -180,6 +194,16 @@ export function MultiCombobox({
 
   const fetchSuggestions = useCallback(
     async (query: string) => {
+      // If options are provided, filter them locally
+      if (options) {
+        const filtered = options.filter(
+          (opt) =>
+            opt.toLowerCase().includes(query.toLowerCase()) &&
+            !existingValues.includes(opt)
+        );
+        setSuggestions(filtered);
+        return;
+      }
       try {
         const res = await fetch(
           `/api/v1/autocomplete?field=${field}&q=${encodeURIComponent(query)}`
@@ -192,7 +216,7 @@ export function MultiCombobox({
         console.error("Failed to fetch suggestions:", error);
       }
     },
-    [field]
+    [field, options, existingValues]
   );
 
   useEffect(() => {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -195,6 +195,35 @@ export const blogPosts = pgTable(
   ]
 );
 
+// Job tags (dynamic tag definitions)
+export const jobTags = pgTable(
+  "job_tags",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    slug: text("slug").notNull().unique(), // e.g., "ai", "design", "leadership"
+    label: text("label").notNull(), // e.g., "AI", "Design", "Leadership"
+    color: text("color"), // Optional color for the tag (hex or tailwind class)
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [index("job_tags_slug_idx").on(table.slug)]
+);
+
+// Job roles/departments (dynamic role definitions)
+export const jobRoles = pgTable(
+  "job_roles",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    slug: text("slug").notNull().unique(), // e.g., "engineering", "design", "product"
+    label: text("label").notNull(), // e.g., "Engineering", "Design", "Product"
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [index("job_roles_slug_idx").on(table.slug)]
+);
+
 // API keys for authentication
 export const apiKeys = pgTable(
   "api_keys",
@@ -235,3 +264,9 @@ export type NewAffiliation = typeof affiliations.$inferInsert;
 
 export type BlogPost = typeof blogPosts.$inferSelect;
 export type NewBlogPost = typeof blogPosts.$inferInsert;
+
+export type JobTag = typeof jobTags.$inferSelect;
+export type NewJobTag = typeof jobTags.$inferInsert;
+
+export type JobRole = typeof jobRoles.$inferSelect;
+export type NewJobRole = typeof jobRoles.$inferInsert;

--- a/src/lib/admin-themes.ts
+++ b/src/lib/admin-themes.ts
@@ -73,16 +73,16 @@ export const ADMIN_THEMES: Record<AdminSection, SectionTheme> = {
     primary: "bg-orange-600",
   },
   tags: {
-    headerBg: "bg-cyan-100 dark:bg-cyan-900/30",
-    buttonVariant: "sky",
-    addButtonBg: "bg-cyan-600 hover:bg-cyan-700",
-    primary: "bg-cyan-600",
+    headerBg: "bg-orange-100 dark:bg-orange-900/30",
+    buttonVariant: "orange",
+    addButtonBg: "bg-orange-600 hover:bg-orange-700",
+    primary: "bg-orange-600",
   },
   roles: {
-    headerBg: "bg-teal-100 dark:bg-teal-900/30",
-    buttonVariant: "green",
-    addButtonBg: "bg-teal-600 hover:bg-teal-700",
-    primary: "bg-teal-600",
+    headerBg: "bg-violet-100 dark:bg-violet-900/30",
+    buttonVariant: "purple",
+    addButtonBg: "bg-violet-600 hover:bg-violet-700",
+    primary: "bg-violet-600",
   },
 };
 

--- a/src/lib/admin-themes.ts
+++ b/src/lib/admin-themes.ts
@@ -7,7 +7,9 @@ export type AdminSection =
   | "affiliations"
   | "blog"
   | "news-curated"
-  | "news-announcements";
+  | "news-announcements"
+  | "tags"
+  | "roles";
 
 export type ButtonVariant =
   | "blue"
@@ -24,6 +26,7 @@ interface SectionTheme {
   headerBg: string;
   buttonVariant: ButtonVariant;
   addButtonBg: string;
+  primary: string;
 }
 
 export const ADMIN_THEMES: Record<AdminSection, SectionTheme> = {
@@ -31,36 +34,55 @@ export const ADMIN_THEMES: Record<AdminSection, SectionTheme> = {
     headerBg: "bg-blue-100 dark:bg-blue-900/30",
     buttonVariant: "blue",
     addButtonBg: "bg-blue-600 hover:bg-blue-700",
+    primary: "bg-blue-600",
   },
   candidates: {
     headerBg: "bg-green-100 dark:bg-green-900/30",
     buttonVariant: "green",
     addButtonBg: "bg-green-600 hover:bg-green-700",
+    primary: "bg-green-600",
   },
   investments: {
     headerBg: "bg-amber-100 dark:bg-amber-900/30",
     buttonVariant: "amber",
     addButtonBg: "bg-amber-600 hover:bg-amber-700",
+    primary: "bg-amber-600",
   },
   affiliations: {
     headerBg: "bg-pink-100 dark:bg-pink-900/30",
     buttonVariant: "pink",
     addButtonBg: "bg-pink-600 hover:bg-pink-700",
+    primary: "bg-pink-600",
   },
   blog: {
     headerBg: "bg-sky-100 dark:bg-sky-900/30",
     buttonVariant: "indigo",
     addButtonBg: "bg-indigo-600 hover:bg-indigo-700",
+    primary: "bg-indigo-600",
   },
   "news-curated": {
     headerBg: "bg-purple-100 dark:bg-purple-900/30",
     buttonVariant: "purple",
     addButtonBg: "bg-purple-600 hover:bg-purple-700",
+    primary: "bg-purple-600",
   },
   "news-announcements": {
     headerBg: "bg-orange-100 dark:bg-orange-900/30",
     buttonVariant: "orange",
     addButtonBg: "bg-orange-600 hover:bg-orange-700",
+    primary: "bg-orange-600",
+  },
+  tags: {
+    headerBg: "bg-cyan-100 dark:bg-cyan-900/30",
+    buttonVariant: "sky",
+    addButtonBg: "bg-cyan-600 hover:bg-cyan-700",
+    primary: "bg-cyan-600",
+  },
+  roles: {
+    headerBg: "bg-teal-100 dark:bg-teal-900/30",
+    buttonVariant: "green",
+    addButtonBg: "bg-teal-600 hover:bg-teal-700",
+    primary: "bg-teal-600",
   },
 };
 


### PR DESCRIPTION
## Summary
- Add "Join the team" button on portfolio investments that are hiring
- Implement dynamic job tags/roles system stored in database
- Add multi-company filter for jobs page with Monad umbrella org support
- Add Role filter for departments and rename Type to Affiliation
- Create admin pages for managing tags and roles
- Update OpenAPI spec with new endpoints

## Changes
- **PortfolioGrid**: Hiring badge moved to bottom-right with black styling
- **JobsGrid**: Multi-select company filter, new Role filter, larger badges
- **Database**: New `job_tags` and `job_roles` tables
- **API**: CRUD endpoints for `/job-tags` and `/job-roles`
- **Admin**: New pages under Tags (teal) and Roles (pink) sections

## Test plan
- [x] Verify hiring button appears on investments with active jobs
- [x] Test multi-company filter links from portfolio page
- [x] Test tag/role CRUD in admin dashboard
- [x] Verify filters work correctly on jobs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)