### PR TITLE
feat: add category filter to portfolio investments

### DIFF
--- a/drizzle/0001_add_categories_to_investments.sql
+++ b/drizzle/0001_add_categories_to_investments.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "job_roles" (
+	"id" text PRIMARY KEY NOT NULL,
+	"slug" text NOT NULL,
+	"label" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "job_roles_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "job_tags" (
+	"id" text PRIMARY KEY NOT NULL,
+	"slug" text NOT NULL,
+	"label" text NOT NULL,
+	"color" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "job_tags_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+DROP INDEX "candidates_availability_idx";--> statement-breakpoint
+ALTER TABLE "candidates" ADD COLUMN "available" boolean DEFAULT true;--> statement-breakpoint
+ALTER TABLE "investments" ADD COLUMN "categories" text[];--> statement-breakpoint
+CREATE INDEX "job_roles_slug_idx" ON "job_roles" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "job_tags_slug_idx" ON "job_tags" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "candidates_available_idx" ON "candidates" USING btree ("available");

--- a/drizzle/0002_small_red_hulk.sql
+++ b/drizzle/0002_small_red_hulk.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "investment_categories" (
+	"id" text PRIMARY KEY NOT NULL,
+	"slug" text NOT NULL,
+	"label" text NOT NULL,
+	"color" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "investment_categories_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE INDEX "investment_categories_slug_idx" ON "investment_categories" USING btree ("slug");

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1166 @@
+{
+  "id": "a18c5221-4bbf-407b-9071-1b6c42b01607",
+  "prevId": "b9af846e-d0f7-449d-ba5e-6614f3a7c84c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_begin": {
+          "name": "date_begin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_title_idx": {
+          "name": "affiliations_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_company_idx": {
+          "name": "announcements_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_date_idx": {
+          "name": "announcements_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blog_posts": {
+      "name": "blog_posts",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blog_posts_date_idx": {
+          "name": "blog_posts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_posts_published_idx": {
+          "name": "blog_posts_published_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidates": {
+      "name": "candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience": {
+          "name": "experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education": {
+          "name": "education",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cv": {
+          "name": "cv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'looking'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendly": {
+          "name": "calendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidates_featured_idx": {
+          "name": "candidates_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidates_available_idx": {
+          "name": "candidates_available_idx",
+          "columns": [
+            {
+              "expression": "available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_links": {
+      "name": "curated_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curated_links_category_idx": {
+          "name": "curated_links_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "curated_links_date_idx": {
+          "name": "curated_links_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investments_tier_idx": {
+          "name": "investments_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investments_featured_idx": {
+          "name": "investments_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_roles": {
+      "name": "job_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_roles_slug_idx": {
+          "name": "job_roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_roles_slug_unique": {
+          "name": "job_roles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_tags": {
+      "name": "job_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_tags_slug_idx": {
+          "name": "job_tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_tags_slug_unique": {
+          "name": "job_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote": {
+          "name": "remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary": {
+          "name": "salary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_x": {
+          "name": "company_x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_github": {
+          "name": "company_github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_company_idx": {
+          "name": "jobs_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_category_idx": {
+          "name": "jobs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_featured_idx": {
+          "name": "jobs_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1234 @@
+{
+  "id": "e0bffad6-25f1-4140-a01d-734b2032426f",
+  "prevId": "a18c5221-4bbf-407b-9071-1b6c42b01607",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_begin": {
+          "name": "date_begin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_title_idx": {
+          "name": "affiliations_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_company_idx": {
+          "name": "announcements_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_date_idx": {
+          "name": "announcements_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blog_posts": {
+      "name": "blog_posts",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blog_posts_date_idx": {
+          "name": "blog_posts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_posts_published_idx": {
+          "name": "blog_posts_published_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidates": {
+      "name": "candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience": {
+          "name": "experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education": {
+          "name": "education",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cv": {
+          "name": "cv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'looking'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendly": {
+          "name": "calendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidates_featured_idx": {
+          "name": "candidates_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidates_available_idx": {
+          "name": "candidates_available_idx",
+          "columns": [
+            {
+              "expression": "available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_links": {
+      "name": "curated_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curated_links_category_idx": {
+          "name": "curated_links_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "curated_links_date_idx": {
+          "name": "curated_links_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investment_categories": {
+      "name": "investment_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investment_categories_slug_idx": {
+          "name": "investment_categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "investment_categories_slug_unique": {
+          "name": "investment_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investments_tier_idx": {
+          "name": "investments_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investments_featured_idx": {
+          "name": "investments_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_roles": {
+      "name": "job_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_roles_slug_idx": {
+          "name": "job_roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_roles_slug_unique": {
+          "name": "job_roles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_tags": {
+      "name": "job_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_tags_slug_idx": {
+          "name": "job_tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_tags_slug_unique": {
+          "name": "job_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote": {
+          "name": "remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary": {
+          "name": "salary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_x": {
+          "name": "company_x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_github": {
+          "name": "company_github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_company_idx": {
+          "name": "jobs_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_category_idx": {
+          "name": "jobs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_featured_idx": {
+          "name": "jobs_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1769893509073,
       "tag": "0001_add_categories_to_investments",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1769898563430,
+      "tag": "0002_small_red_hulk",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1769814349520,
       "tag": "0000_clammy_iron_monger",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1769893509073,
+      "tag": "0001_add_categories_to_investments",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/assign-investment-categories.ts
+++ b/scripts/assign-investment-categories.ts
@@ -1,0 +1,99 @@
+/**
+ * Script to assign categories to all investments
+ * Run with: bunx dotenv -e .env.local -- bun run scripts/assign-investment-categories.ts
+ */
+
+import { db, investments } from "../src/db";
+import { eq } from "drizzle-orm";
+
+// Category assignments based on investment focus
+const categoryAssignments: Record<string, string[]> = {
+  // Tier 1 Featured
+  "Exo": ["AI", "Hardware"],
+  "Lighter": ["DeFi", "Crypto"],
+  "Lucis": ["Health/Longevity"],
+  "MegaETH": ["L2", "Crypto"],
+  "Monad": ["L1", "Crypto"],
+  "Morpho": ["DeFi", "Crypto"],
+  "Prime Intellect": ["AI"],
+
+  // Tier 1
+  "Accountable": ["DeFi", "ZK"],
+  "Dria": ["AI"],
+  "Edison": ["AI", "Security", "Agents"],
+  "Friend": ["AI", "Social"],
+  "Octet": ["ZK", "Crypto"],
+  "OWN": ["DeFi", "Crypto"],
+  "Phylax": ["Security"],
+
+  // Tier 2
+  "Agora": ["Governance", "Crypto"],
+  "Aligned Layer": ["ZK", "L2"],
+  "Delta": ["Crypto", "L1"],
+  "Fabric Cryptography": ["Hardware", "ZK"],
+  "Giza": ["AI", "Agents"],
+  "Praxis": ["Network States"],
+  "Rhinestone": ["Devtools", "Crypto"],
+  "Sorella": ["MEV", "DeFi"],
+  "Succinct": ["ZK"],
+  "Wildcat": ["DeFi"],
+
+  // Tier 3
+  "Berachain": ["L1", "DeFi", "Crypto"],
+  "Clique": ["Devtools", "Crypto"],
+  "Herodotus": ["ZK"],
+  "Inco": ["Privacy", "L2"],
+  "Intuition": ["Social", "Crypto"],
+  "Pimlico": ["Devtools", "Crypto"],
+  "Ritual": ["AI", "L1"],
+  "Zenith": ["Crypto"],
+
+  // Tier 4
+  "Astria": ["L2", "Crypto"],
+  "Atoma": ["AI", "Privacy"],
+  "blocksense": ["ZK", "Crypto"],
+  "Eclipse": ["L2", "Crypto"],
+  "GasHawk": ["MEV", "Devtools"],
+  "Happy Chain": ["L2", "Social"],
+  "JokeRace": ["Social", "Governance"],
+  "Mind Palace": ["AI"],
+  "Mizu": ["DeFi", "Crypto"],
+  "Mode": ["L2", "DeFi", "AI", "Agents"],
+  "Movement": ["L2", "Crypto"],
+  "Nebra": ["ZK"],
+  "Nillion": ["Privacy", "Crypto"],
+  "OnlyDust": ["Devtools"],
+  "OpenQ": ["Devtools"],
+  "PIN AI": ["AI", "Privacy"],
+  "Pluto": ["ZK", "Devtools"],
+  "Pragma": ["DeFi", "Crypto"],
+};
+
+async function assignCategories() {
+  console.log("Assigning categories to investments...\n");
+
+  const allInvestments = await db.select().from(investments);
+  let updated = 0;
+  let skipped = 0;
+
+  for (const inv of allInvestments) {
+    const categories = categoryAssignments[inv.title];
+
+    if (categories) {
+      await db
+        .update(investments)
+        .set({ categories })
+        .where(eq(investments.id, inv.id));
+      console.log(`  ✓ ${inv.title}: ${categories.join(", ")}`);
+      updated++;
+    } else {
+      console.log(`  - ${inv.title}: No categories defined (skipped)`);
+      skipped++;
+    }
+  }
+
+  console.log(`\nDone! Updated: ${updated}, Skipped: ${skipped}`);
+  process.exit(0);
+}
+
+assignCategories();

--- a/scripts/create-investment-categories-table.ts
+++ b/scripts/create-investment-categories-table.ts
@@ -1,0 +1,42 @@
+/**
+ * Script to create the investment_categories table
+ * Run with: bunx dotenv -e .env.local -- bun run scripts/create-investment-categories-table.ts
+ */
+
+import postgres from "postgres";
+
+const connectionString = process.env.DATABASE_URL!;
+const sql = postgres(connectionString);
+
+async function createTable() {
+  console.log("Creating investment_categories table...\n");
+
+  try {
+    await sql`
+      CREATE TABLE IF NOT EXISTS "investment_categories" (
+        "id" text PRIMARY KEY NOT NULL,
+        "slug" text NOT NULL,
+        "label" text NOT NULL,
+        "color" text,
+        "created_at" timestamp DEFAULT now() NOT NULL,
+        CONSTRAINT "investment_categories_slug_unique" UNIQUE("slug")
+      )
+    `;
+    console.log("  ✓ Table created (or already exists)");
+
+    await sql`
+      CREATE INDEX IF NOT EXISTS "investment_categories_slug_idx"
+      ON "investment_categories" USING btree ("slug")
+    `;
+    console.log("  ✓ Index created (or already exists)");
+
+    console.log("\nDone!");
+  } catch (error) {
+    console.error("Error:", error);
+  } finally {
+    await sql.end();
+    process.exit(0);
+  }
+}
+
+createTable();

--- a/scripts/seed-investment-categories.ts
+++ b/scripts/seed-investment-categories.ts
@@ -1,0 +1,60 @@
+/**
+ * Seed script to populate investment_categories table from existing INVESTMENT_CATEGORIES constant
+ * Run with: bunx dotenv -e .env.local -- bun run scripts/seed-investment-categories.ts
+ */
+
+import { db, investmentCategories, INVESTMENT_CATEGORIES } from "../src/db";
+
+// Color assignments for categories (matching common semantic associations)
+const categoryColors: Record<string, string> = {
+  "Crypto": "amber",
+  "AI": "violet",
+  "DeFi": "green",
+  "MEV": "orange",
+  "Privacy": "slate",
+  "Health/Longevity": "rose",
+  "Security": "red",
+  "L1": "blue",
+  "L2": "sky",
+  "Governance": "purple",
+  "Agents": "fuchsia",
+  "Hardware": "neutral",
+  "Devtools": "teal",
+  "Social": "pink",
+  "Network States": "indigo",
+  "ZK": "cyan",
+};
+
+function toSlug(label: string): string {
+  return label.toLowerCase().replace(/\//g, "-").replace(/\s+/g, "-");
+}
+
+async function seed() {
+  console.log("Seeding investment categories...\n");
+
+  for (const label of INVESTMENT_CATEGORIES) {
+    const slug = toSlug(label);
+    const color = categoryColors[label] || null;
+
+    try {
+      const [inserted] = await db
+        .insert(investmentCategories)
+        .values({ slug, label, color })
+        .onConflictDoNothing()
+        .returning();
+
+      if (inserted) {
+        console.log(`  ✓ Created: ${label} (slug: ${slug}, color: ${color || "none"})`);
+      } else {
+        console.log(`  - Skipped (exists): ${label}`);
+      }
+    } catch (error) {
+      console.error(`  ✗ Error creating ${label}:`, error);
+    }
+  }
+
+  console.log("\nSeeding complete!");
+  process.exit(0);
+}
+
+seed();

--- a/src/app/admin/investment-categories/page.tsx
+++ b/src/app/admin/investment-categories/page.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { TableSkeleton } from "@/components/admin/TableSkeleton";
+import { EditButton, DeleteButton, ErrorAlert } from "@/components/admin/ActionButtons";
+import { getAdminApiKey, adminFetch, withMinDelay } from "@/lib/admin-utils";
+import { ADMIN_THEMES } from "@/lib/admin-themes";
+
+interface InvestmentCategory {
+  id: string;
+  slug: string;
+  label: string;
+  color: string | null;
+  createdAt: string;
+}
+
+const emptyCategory: Partial<InvestmentCategory> = {
+  slug: "",
+  label: "",
+  color: "",
+};
+
+const theme = ADMIN_THEMES.investments;
+
+const COLOR_OPTIONS = [
+  "red", "orange", "amber", "yellow", "lime", "green", "emerald", "teal",
+  "cyan", "sky", "blue", "indigo", "violet", "purple", "fuchsia", "pink", "rose", "slate", "gray"
+];
+
+const CATEGORY_COLOR_CLASSES: Record<string, string> = {
+  red: "bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400",
+  orange: "bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400",
+  amber: "bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400",
+  yellow: "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400",
+  lime: "bg-lime-100 dark:bg-lime-900/30 text-lime-700 dark:text-lime-400",
+  green: "bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400",
+  emerald: "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400",
+  teal: "bg-teal-100 dark:bg-teal-900/30 text-teal-700 dark:text-teal-400",
+  cyan: "bg-cyan-100 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-400",
+  sky: "bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400",
+  blue: "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400",
+  indigo: "bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400",
+  violet: "bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400",
+  purple: "bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400",
+  fuchsia: "bg-fuchsia-100 dark:bg-fuchsia-900/30 text-fuchsia-700 dark:text-fuchsia-400",
+  pink: "bg-pink-100 dark:bg-pink-900/30 text-pink-700 dark:text-pink-400",
+  rose: "bg-rose-100 dark:bg-rose-900/30 text-rose-700 dark:text-rose-400",
+  slate: "bg-slate-100 dark:bg-slate-900/30 text-slate-700 dark:text-slate-400",
+  gray: "bg-gray-100 dark:bg-gray-900/30 text-gray-700 dark:text-gray-400",
+  neutral: "bg-neutral-100 dark:bg-neutral-900/30 text-neutral-700 dark:text-neutral-400",
+};
+
+const DEFAULT_CATEGORY_COLOR_CLASS = "bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400";
+
+export default function AdminInvestmentCategories() {
+  const [categories, setCategories] = useState<InvestmentCategory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editingCategory, setEditingCategory] = useState<Partial<InvestmentCategory> | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  useEffect(() => {
+    document.title = "Admin | dcbuilder.eth";
+  }, []);
+
+  const fetchCategories = useCallback(async () => {
+    try {
+      const { data, error } = await withMinDelay(adminFetch<InvestmentCategory[]>("/api/v1/investment-categories"));
+      if (error) {
+        setError(error);
+      } else if (data) {
+        setCategories(data);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch categories");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCategories();
+  }, [fetchCategories]);
+
+  const handleSave = async () => {
+    if (!editingCategory) return;
+    const apiKey = getAdminApiKey();
+
+    try {
+      if (isCreating) {
+        const { data: newCategory, error } = await adminFetch<InvestmentCategory>("/api/v1/investment-categories", {
+          method: "POST",
+          headers: { "x-api-key": apiKey, "Content-Type": "application/json" },
+          body: JSON.stringify(editingCategory),
+        });
+        if (error) {
+          setError(error);
+          return;
+        }
+        if (newCategory) {
+          setCategories([...categories, newCategory].sort((a, b) => a.label.localeCompare(b.label)));
+        }
+      } else {
+        const { data: updated, error } = await adminFetch<InvestmentCategory>("/api/v1/investment-categories", {
+          method: "PATCH",
+          headers: { "x-api-key": apiKey, "Content-Type": "application/json" },
+          body: JSON.stringify(editingCategory),
+        });
+        if (error) {
+          setError(error);
+          return;
+        }
+        if (updated) {
+          setCategories(categories.map((c) => (c.id === updated.id ? updated : c)));
+        }
+      }
+      setEditingCategory(null);
+      setIsCreating(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save category");
+    }
+  };
+
+  const handleDelete = async (category: InvestmentCategory) => {
+    if (!confirm(`Delete category "${category.label}"?`)) return;
+    const apiKey = getAdminApiKey();
+
+    try {
+      await adminFetch(`/api/v1/investment-categories?id=${category.id}`, {
+        method: "DELETE",
+        headers: { "x-api-key": apiKey },
+      });
+      setCategories(categories.filter((c) => c.id !== category.id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete category");
+    }
+  };
+
+  const filteredCategories = categories.filter((category) =>
+    category.label.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    category.slug.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  if (loading) return <TableSkeleton headers={["Slug", "Label", "Color", "Preview", "Actions"]} rows={10} />;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Investment Categories</h1>
+        <button
+          onClick={() => {
+            setEditingCategory(emptyCategory);
+            setIsCreating(true);
+          }}
+          className={`px-4 py-2 ${theme.primary} text-white rounded-lg hover:opacity-90 transition-opacity`}
+        >
+          + Add Category
+        </button>
+      </div>
+
+      {error && <ErrorAlert message={error} onRetry={() => { setError(null); fetchCategories(); }} />}
+
+      {/* Search */}
+      <div className="flex gap-4">
+        <input
+          type="text"
+          placeholder="Search categories..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="flex-1 px-4 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-900"
+        />
+      </div>
+
+      {/* Edit Modal */}
+      {editingCategory && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-neutral-900 rounded-xl p-6 w-full max-w-md space-y-4">
+            <h2 className="text-xl font-bold">
+              {isCreating ? "Add Category" : "Edit Category"}
+            </h2>
+            <div>
+              <label className="block text-sm font-medium mb-1">Slug</label>
+              <input
+                type="text"
+                value={editingCategory.slug || ""}
+                onChange={(e) => setEditingCategory({ ...editingCategory, slug: e.target.value })}
+                placeholder="e.g., defi, ai, mev"
+                className="w-full px-3 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+              />
+              <p className="text-xs text-neutral-500 mt-1">Used internally, lowercase with hyphens</p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Label</label>
+              <input
+                type="text"
+                value={editingCategory.label || ""}
+                onChange={(e) => setEditingCategory({ ...editingCategory, label: e.target.value })}
+                placeholder="e.g., DeFi, AI, MEV"
+                className="w-full px-3 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+              />
+              <p className="text-xs text-neutral-500 mt-1">Displayed to users</p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Color</label>
+              <select
+                value={editingCategory.color || ""}
+                onChange={(e) => setEditingCategory({ ...editingCategory, color: e.target.value })}
+                className="w-full px-3 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800"
+              >
+                <option value="">No color (uses default)</option>
+                {COLOR_OPTIONS.map((color) => (
+                  <option key={color} value={color}>{color}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex justify-end gap-2 pt-4">
+              <button
+                onClick={() => {
+                  setEditingCategory(null);
+                  setIsCreating(false);
+                }}
+                className="px-4 py-2 border border-neutral-200 dark:border-neutral-700 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSave}
+                className={`px-4 py-2 ${theme.primary} text-white rounded-lg hover:opacity-90`}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Categories Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-neutral-200 dark:border-neutral-700">
+              <th className="text-left py-3 px-4 font-medium">Slug</th>
+              <th className="text-left py-3 px-4 font-medium">Label</th>
+              <th className="text-left py-3 px-4 font-medium">Color</th>
+              <th className="text-left py-3 px-4 font-medium">Preview</th>
+              <th className="text-right py-3 px-4 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredCategories.map((category) => (
+              <tr
+                key={category.id}
+                className="border-b border-neutral-100 dark:border-neutral-800 hover:bg-neutral-50 dark:hover:bg-neutral-800/50"
+              >
+                <td className="py-3 px-4 font-mono text-sm">{category.slug}</td>
+                <td className="py-3 px-4">{category.label}</td>
+                <td className="py-3 px-4">{category.color || "-"}</td>
+                <td className="py-3 px-4">
+                  <span
+                    className={`px-2 py-1 text-xs rounded-full ${
+                      category.color ? CATEGORY_COLOR_CLASSES[category.color] ?? DEFAULT_CATEGORY_COLOR_CLASS : DEFAULT_CATEGORY_COLOR_CLASS
+                    }`}
+                  >
+                    {category.label}
+                  </span>
+                </td>
+                <td className="py-3 px-4">
+                  <div className="flex justify-end gap-2">
+                    <EditButton
+                      onClick={() => {
+                        setEditingCategory(category);
+                        setIsCreating(false);
+                      }}
+                      variant={theme.buttonVariant}
+                    />
+                    <DeleteButton onClick={() => handleDelete(category)} />
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-sm text-neutral-500">
+        {filteredCategories.length} categor{filteredCategories.length !== 1 ? "ies" : "y"}
+      </p>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -90,13 +90,14 @@ export default function AdminLayout({
     setIsAuthenticated(false);
   };
 
-  // Order: Dashboard, Affiliations (About page), Blog, News, Portfolio, Jobs, Candidates, Tags, Roles
+  // Order: Dashboard, Affiliations (About page), Blog, News, Portfolio, Categories, Jobs, Candidates, Tags, Roles
   const navItems = [
     { href: "/admin", label: "Dashboard", color: "neutral", bg: "bg-neutral-100 dark:bg-neutral-800", bgHover: "hover:bg-neutral-200 dark:hover:bg-neutral-700", bgActive: "bg-neutral-700 dark:bg-neutral-600", text: "text-neutral-600 dark:text-neutral-400" },
     { href: "/admin/affiliations", label: "Affiliations", color: "pink", bg: "bg-pink-100 dark:bg-pink-900/30", bgHover: "hover:bg-pink-200 dark:hover:bg-pink-800/40", bgActive: "bg-pink-500 dark:bg-pink-600", text: "text-pink-600 dark:text-pink-400" },
     { href: "/admin/blog", label: "Blog", color: "indigo", bg: "bg-indigo-100 dark:bg-indigo-900/30", bgHover: "hover:bg-indigo-200 dark:hover:bg-indigo-800/40", bgActive: "bg-indigo-500 dark:bg-indigo-600", text: "text-indigo-600 dark:text-indigo-400" },
     { href: "/admin/news", label: "News", color: "purple", bg: "bg-purple-100 dark:bg-purple-900/30", bgHover: "hover:bg-purple-200 dark:hover:bg-purple-800/40", bgActive: "bg-purple-500 dark:bg-purple-600", text: "text-purple-600 dark:text-purple-400" },
     { href: "/admin/investments", label: "Portfolio", color: "amber", bg: "bg-amber-100 dark:bg-amber-900/30", bgHover: "hover:bg-amber-200 dark:hover:bg-amber-800/40", bgActive: "bg-amber-500 dark:bg-amber-600", text: "text-amber-600 dark:text-amber-400" },
+    { href: "/admin/investment-categories", label: "Categories", color: "yellow", bg: "bg-yellow-100 dark:bg-yellow-900/30", bgHover: "hover:bg-yellow-200 dark:hover:bg-yellow-800/40", bgActive: "bg-yellow-500 dark:bg-yellow-600", text: "text-yellow-600 dark:text-yellow-400" },
     { href: "/admin/jobs", label: "Jobs", color: "blue", bg: "bg-blue-100 dark:bg-blue-900/30", bgHover: "hover:bg-blue-200 dark:hover:bg-blue-800/40", bgActive: "bg-blue-500 dark:bg-blue-600", text: "text-blue-600 dark:text-blue-400" },
     { href: "/admin/candidates", label: "Candidates", color: "green", bg: "bg-green-100 dark:bg-green-900/30", bgHover: "hover:bg-green-200 dark:hover:bg-green-800/40", bgActive: "bg-green-500 dark:bg-green-600", text: "text-green-600 dark:text-green-400" },
     { href: "/admin/job-tags", label: "Tags", color: "orange", bg: "bg-orange-100 dark:bg-orange-900/30", bgHover: "hover:bg-orange-200 dark:hover:bg-orange-800/40", bgActive: "bg-orange-500 dark:bg-orange-600", text: "text-orange-600 dark:text-orange-400" },

--- a/src/app/api/v1/investment-categories/route.ts
+++ b/src/app/api/v1/investment-categories/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db, investmentCategories } from "@/db";
+import { eq, asc } from "drizzle-orm";
+import { requireAuth } from "@/lib/api-auth";
+
+// GET all investment categories
+export async function GET() {
+  try {
+    const categories = await db.select().from(investmentCategories).orderBy(asc(investmentCategories.label));
+    return NextResponse.json(categories);
+  } catch (error) {
+    console.error("Error fetching investment categories:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch investment categories" },
+      { status: 500 }
+    );
+  }
+}
+
+// POST create a new investment category
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request, "investments:write");
+  if (auth instanceof Response) return auth;
+
+  try {
+    const body = await request.json();
+    const { slug, label, color } = body;
+
+    if (!slug || !label) {
+      return NextResponse.json(
+        { error: "slug and label are required" },
+        { status: 400 }
+      );
+    }
+
+    // Normalize slug
+    const normalizedSlug = slug.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+
+    const [category] = await db
+      .insert(investmentCategories)
+      .values({ slug: normalizedSlug, label, color })
+      .returning();
+
+    return NextResponse.json(category, { status: 201 });
+  } catch (error: unknown) {
+    console.error("Error creating investment category:", error);
+    if (error && typeof error === "object" && "code" in error && error.code === "23505") {
+      return NextResponse.json(
+        { error: "A category with this slug already exists" },
+        { status: 409 }
+      );
+    }
+    return NextResponse.json(
+      { error: "Failed to create investment category" },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE an investment category
+export async function DELETE(request: NextRequest) {
+  const auth = await requireAuth(request, "investments:write");
+  if (auth instanceof Response) return auth;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get("id");
+
+    if (!id) {
+      return NextResponse.json(
+        { error: "id is required" },
+        { status: 400 }
+      );
+    }
+
+    await db.delete(investmentCategories).where(eq(investmentCategories.id, id));
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting investment category:", error);
+    return NextResponse.json(
+      { error: "Failed to delete investment category" },
+      { status: 500 }
+    );
+  }
+}
+
+// PATCH update an investment category
+export async function PATCH(request: NextRequest) {
+  const auth = await requireAuth(request, "investments:write");
+  if (auth instanceof Response) return auth;
+
+  try {
+    const body = await request.json();
+    const { id, slug, label, color } = body;
+
+    if (!id) {
+      return NextResponse.json(
+        { error: "id is required" },
+        { status: 400 }
+      );
+    }
+
+    const updates: Partial<{ slug: string; label: string; color: string | null }> = {};
+    if (slug) updates.slug = slug.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
+    if (label) updates.label = label;
+    if (color !== undefined) updates.color = color;
+
+    const [category] = await db
+      .update(investmentCategories)
+      .set(updates)
+      .where(eq(investmentCategories.id, id))
+      .returning();
+
+    return NextResponse.json(category);
+  } catch (error) {
+    console.error("Error updating investment category:", error);
+    return NextResponse.json(
+      { error: "Failed to update investment category" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/investments/route.ts
+++ b/src/app/api/v1/investments/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { db, investments, NewInvestment } from "@/db";
-import { eq, desc, and, SQL } from "drizzle-orm";
+import { eq, desc, and, SQL, arrayContains } from "drizzle-orm";
 import { requireAuth, parsePaginationParams } from "@/lib/api-auth";
 
 // GET /api/v1/investments - List investments
@@ -9,6 +9,7 @@ export async function GET(request: NextRequest) {
   const tier = searchParams.get("tier");
   const featured = searchParams.get("featured");
   const status = searchParams.get("status");
+  const category = searchParams.get("category");
   const { limit, offset } = parsePaginationParams(searchParams);
 
   try {
@@ -22,6 +23,9 @@ export async function GET(request: NextRequest) {
     }
     if (status) {
       conditions.push(eq(investments.status, status));
+    }
+    if (category) {
+      conditions.push(arrayContains(investments.categories, [category]));
     }
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -23,6 +23,7 @@ const getInvestments = unstable_cache(
       ...inv,
       tier: (parseInt(inv.tier || "2") || 2) as 1 | 2 | 3 | 4,
       featured: inv.featured ?? false,
+      categories: inv.categories ?? [],
     }));
   },
   ["investments"],

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,6 +1,6 @@
 import { Navbar } from "@/components/Navbar";
 import { PortfolioGrid } from "@/components/PortfolioGrid";
-import { db, investments as investmentsTable, jobs as jobsTable } from "@/db";
+import { db, investments as investmentsTable, jobs as jobsTable, investmentCategories as categoriesTable } from "@/db";
 import { desc, asc, sql } from "drizzle-orm";
 import { unstable_cache } from "next/cache";
 
@@ -46,10 +46,19 @@ const getJobCountsByCompany = unstable_cache(
   { revalidate: 300, tags: ["jobs"] }
 );
 
+const getInvestmentCategories = unstable_cache(
+  async () => {
+    return db.select().from(categoriesTable).orderBy(asc(categoriesTable.label));
+  },
+  ["investment-categories"],
+  { revalidate: 300, tags: ["investment-categories"] }
+);
+
 export default async function Portfolio() {
-  const [investments, jobCounts] = await Promise.all([
+  const [investments, jobCounts, categories] = await Promise.all([
     getInvestments(),
     getJobCountsByCompany(),
+    getInvestmentCategories(),
   ]);
 
   return (
@@ -73,7 +82,7 @@ export default async function Portfolio() {
           {/* Investments */}
           <section className="space-y-8">
             <h2 className="text-4xl font-bold text-center">Investments</h2>
-            <PortfolioGrid investments={investments} jobCounts={jobCounts} />
+            <PortfolioGrid investments={investments} jobCounts={jobCounts} categories={categories} />
           </section>
         </div>
       </main>

--- a/src/components/PortfolioGrid.tsx
+++ b/src/components/PortfolioGrid.tsx
@@ -107,7 +107,7 @@ export function PortfolioGrid({ investments, jobCounts = {}, categories = [] }: 
 	);
 	const tier4Count = investments.length - mainCount;
 
-	// Get categories that have at least one investment
+	// Get categories with their investment counts
 	const categoriesWithCounts = useMemo(() => {
 		const counts: Record<string, number> = {};
 		investments.forEach((inv) => {
@@ -115,11 +115,11 @@ export function PortfolioGrid({ investments, jobCounts = {}, categories = [] }: 
 				counts[cat] = (counts[cat] || 0) + 1;
 			});
 		});
-		// Use dynamic categories from props, filter to those with counts
-		const categoryLabels = categories.map((c) => c.label);
-		return categoryLabels
-			.filter((cat) => counts[cat] > 0)
-			.map((cat) => ({ category: cat, count: counts[cat] }));
+		// Show all categories from props, with their counts (including 0)
+		return categories.map((c) => ({
+			category: c.label,
+			count: counts[c.label] || 0,
+		}));
 	}, [investments, categories]);
 
 	// Filtered investments based on filter option and category (multi-select)
@@ -275,7 +275,7 @@ export function PortfolioGrid({ investments, jobCounts = {}, categories = [] }: 
 			</div>
 
 			{/* Category Filters (Multi-select) */}
-			{categoriesWithCounts.length > 0 && (
+			{categories.length > 0 && (
 				<div className="flex flex-wrap items-center gap-2">
 					<span className="text-sm text-neutral-600 dark:text-neutral-400 mr-1">
 						Category:

--- a/src/components/PortfolioGrid.tsx
+++ b/src/components/PortfolioGrid.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useMemo } from "react";
 import Image from "next/image";
-import { INVESTMENT_CATEGORIES } from "@/db/schema";
 
 // Investment interface matching what comes from the database
 interface Investment {
@@ -32,9 +31,17 @@ const isNew = (createdAt: string | Date | null | undefined): boolean => {
 
 type SortOption = "relevance" | "alphabetical" | "alphabetical-desc";
 
+interface InvestmentCategory {
+	id: string;
+	slug: string;
+	label: string;
+	color: string | null;
+}
+
 interface PortfolioGridProps {
 	investments: Investment[];
 	jobCounts?: Record<string, number>;
+	categories?: InvestmentCategory[];
 }
 
 function hashString(value: string): number {
@@ -84,10 +91,10 @@ function getJobsUrl(title: string): string {
 	return `/jobs?${params}`;
 }
 
-export function PortfolioGrid({ investments, jobCounts = {} }: PortfolioGridProps) {
+export function PortfolioGrid({ investments, jobCounts = {}, categories = [] }: PortfolioGridProps) {
 	const [sortBy, setSortBy] = useState<SortOption>("relevance");
 	const [filter, setFilter] = useState<FilterOption>("all");
-	const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+	const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
 
 	// Count investments by tier/featured
 	const mainCount = useMemo(
@@ -108,13 +115,14 @@ export function PortfolioGrid({ investments, jobCounts = {} }: PortfolioGridProp
 				counts[cat] = (counts[cat] || 0) + 1;
 			});
 		});
-		// Only include categories that exist in INVESTMENT_CATEGORIES and have counts
-		return INVESTMENT_CATEGORIES
+		// Use dynamic categories from props, filter to those with counts
+		const categoryLabels = categories.map((c) => c.label);
+		return categoryLabels
 			.filter((cat) => counts[cat] > 0)
 			.map((cat) => ({ category: cat, count: counts[cat] }));
-	}, [investments]);
+	}, [investments, categories]);
 
-	// Filtered investments based on filter option and category
+	// Filtered investments based on filter option and category (multi-select)
 	const filteredInvestments = useMemo(() => {
 		let result = investments;
 
@@ -125,13 +133,15 @@ export function PortfolioGrid({ investments, jobCounts = {} }: PortfolioGridProp
 			result = result.filter((i) => i.tier <= 3);
 		}
 
-		// Apply category filter
-		if (selectedCategory) {
-			result = result.filter((i) => i.categories?.includes(selectedCategory));
+		// Apply category filter (match ANY selected category)
+		if (selectedCategories.length > 0) {
+			result = result.filter((i) =>
+				selectedCategories.some((cat) => i.categories?.includes(cat))
+			);
 		}
 
 		return result;
-	}, [investments, filter, selectedCategory]);
+	}, [investments, filter, selectedCategories]);
 
 	// Deterministic sort (no shuffle - that happens in useEffect)
 	// Deterministic display order (stable between server/client)
@@ -157,7 +167,7 @@ export function PortfolioGrid({ investments, jobCounts = {} }: PortfolioGridProp
 		const featured = active.filter((i) => i.featured);
 		const nonFeatured = active.filter((i) => !i.featured);
 
-		const seedBase = `${filter}|${sortBy}|${selectedCategory || "all"}`;
+		const seedBase = `${filter}|${sortBy}|${selectedCategories.join(",") || "all"}`;
 
 		// Group featured by tier and shuffle each group
 		const featuredTierGroups: Record<number, Investment[]> = {};
@@ -199,7 +209,7 @@ export function PortfolioGrid({ investments, jobCounts = {} }: PortfolioGridProp
 		);
 
 		return [...shuffledFeatured, ...shuffledNonFeatured, ...shuffledDefunct];
-	}, [filteredInvestments, sortBy, filter, selectedCategory]);
+	}, [filteredInvestments, sortBy, filter, selectedCategories]);
 
 	// Split into active and defunct for rendering with separator
 	const activeInvestments = displayInvestments.filter((i) => i.status !== "defunct");
@@ -264,35 +274,42 @@ export function PortfolioGrid({ investments, jobCounts = {} }: PortfolioGridProp
 				</div>
 			</div>
 
-			{/* Category Filters */}
+			{/* Category Filters (Multi-select) */}
 			{categoriesWithCounts.length > 0 && (
 				<div className="flex flex-wrap items-center gap-2">
 					<span className="text-sm text-neutral-600 dark:text-neutral-400 mr-1">
 						Category:
 					</span>
-					<button
-						onClick={() => setSelectedCategory(null)}
-						className={`px-3 py-1 text-xs rounded-full border transition-colors ${
-							selectedCategory === null
-								? "bg-neutral-900 text-white dark:bg-white dark:text-neutral-900 border-transparent"
-								: "border-neutral-200 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
-						}`}
-					>
-						All
-					</button>
-					{categoriesWithCounts.map(({ category, count }) => (
+					{selectedCategories.length > 0 && (
 						<button
-							key={category}
-							onClick={() => setSelectedCategory(category)}
-							className={`px-3 py-1 text-xs rounded-full border transition-colors ${
-								selectedCategory === category
-									? "bg-neutral-900 text-white dark:bg-white dark:text-neutral-900 border-transparent"
-									: "border-neutral-200 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
-							}`}
+							onClick={() => setSelectedCategories([])}
+							className="px-3 py-1 text-xs rounded-full border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
 						>
-							{category} ({count})
+							Clear ({selectedCategories.length})
 						</button>
-					))}
+					)}
+					{categoriesWithCounts.map(({ category, count }) => {
+						const isSelected = selectedCategories.includes(category);
+						return (
+							<button
+								key={category}
+								onClick={() => {
+									if (isSelected) {
+										setSelectedCategories(selectedCategories.filter((c) => c !== category));
+									} else {
+										setSelectedCategories([...selectedCategories, category]);
+									}
+								}}
+								className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+									isSelected
+										? "bg-neutral-900 text-white dark:bg-white dark:text-neutral-900 border-transparent"
+										: "border-neutral-200 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+								}`}
+							>
+								{category} ({count})
+							</button>
+						);
+					})}
 				</div>
 			)}
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -126,6 +126,27 @@ export const announcements = pgTable(
   ]
 );
 
+// Investment categories
+export const INVESTMENT_CATEGORIES = [
+  "Crypto",
+  "AI",
+  "DeFi",
+  "MEV",
+  "Privacy",
+  "Health/Longevity",
+  "Security",
+  "L1",
+  "L2",
+  "Governance",
+  "Agents",
+  "Hardware",
+  "Devtools",
+  "Social",
+  "Network States",
+  "ZK",
+] as const;
+export type InvestmentCategory = (typeof INVESTMENT_CATEGORIES)[number];
+
 // Investments table
 export const investments = pgTable(
   "investments",
@@ -140,6 +161,7 @@ export const investments = pgTable(
     tier: text("tier"), // 1, 2, 3, 4
     featured: boolean("featured").default(false),
     status: text("status").default("active"), // active, inactive, acquired
+    categories: text("categories").array(), // Array of category tags
     website: text("website"),
     x: text("x"),
     github: text("github"),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -145,7 +145,7 @@ export const INVESTMENT_CATEGORIES = [
   "Network States",
   "ZK",
 ] as const;
-export type InvestmentCategory = (typeof INVESTMENT_CATEGORIES)[number];
+export type InvestmentCategoryLabel = (typeof INVESTMENT_CATEGORIES)[number];
 
 // Investments table
 export const investments = pgTable(
@@ -215,6 +215,21 @@ export const blogPosts = pgTable(
     index("blog_posts_date_idx").on(table.date),
     index("blog_posts_published_idx").on(table.published),
   ]
+);
+
+// Investment categories (dynamic category definitions)
+export const investmentCategories = pgTable(
+  "investment_categories",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    slug: text("slug").notNull().unique(),
+    label: text("label").notNull(),
+    color: text("color"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [index("investment_categories_slug_idx").on(table.slug)]
 );
 
 // Job tags (dynamic tag definitions)
@@ -292,3 +307,6 @@ export type NewJobTag = typeof jobTags.$inferInsert;
 
 export type JobRole = typeof jobRoles.$inferSelect;
 export type NewJobRole = typeof jobRoles.$inferInsert;
+
+export type InvestmentCategory = typeof investmentCategories.$inferSelect;
+export type NewInvestmentCategory = typeof investmentCategories.$inferInsert;


### PR DESCRIPTION
## Summary
- Add categories field (text array) to investments table with 16 predefined categories
- Add category filter pills to the portfolio page for filtering investments by category
- Add categories multi-select to admin investments form and table view
- Add category query parameter support to investments API

## Categories
Crypto, AI, DeFi, MEV, Privacy, Health/Longevity, Security, L1, L2, Governance, Agents, Hardware, Devtools, Social, Network States, ZK

## Test plan
- [ ] Visit /portfolio and verify category filter pills appear (once investments are tagged)
- [ ] Filter by category and confirm only matching investments show
- [ ] Visit /admin/investments and verify categories column appears
- [ ] Edit an investment and verify category multi-select works
- [ ] Test API: `GET /api/v1/investments?category=DeFi`

Closes CON-5

🤖 Generated with [Claude Code](https://claude.ai/code)