### PR TITLE
Refactor: move admin sub-pages into parent page buttons

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+.next
+node_modules
+dist
+build
+pnpm-lock.yaml
+package-lock.json
+yarn.lock
+bun.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 100
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/admin/investments/page.tsx
+++ b/src/app/admin/investments/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
+import Link from "next/link";
 import { ImageInput } from "@/components/admin/ImagePreview";
 import {
   SearchableHeader,
@@ -429,15 +430,23 @@ export default function AdminInvestments() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Investments ({investments.length})</h1>
-        <button
-          onClick={() => {
-            setEditingInvestment(emptyInvestment);
-            setIsNew(true);
-          }}
-          className={`px-4 py-2 ${theme.addButtonBg} text-white rounded-lg font-medium`}
-        >
-          Add Investment
-        </button>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/admin/investment-categories"
+            className="px-4 py-2 border border-amber-300 dark:border-amber-700 text-amber-600 dark:text-amber-400 rounded-lg font-medium hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors"
+          >
+            Manage Categories
+          </Link>
+          <button
+            onClick={() => {
+              setEditingInvestment(emptyInvestment);
+              setIsNew(true);
+            }}
+            className={`px-4 py-2 ${theme.addButtonBg} text-white rounded-lg font-medium`}
+          >
+            Add Investment
+          </button>
+        </div>
       </div>
 
       {/* Error Alert */}

--- a/src/app/admin/jobs/page.tsx
+++ b/src/app/admin/jobs/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
+import Link from "next/link";
 import { Combobox, MultiCombobox } from "@/components/admin/Combobox";
 import { ImageInput } from "@/components/admin/ImagePreview";
 import { MultiSelectHeader, SearchableMultiSelectHeader, useColumnFilters } from "@/components/admin/ColumnFilters";
@@ -625,16 +626,30 @@ export default function AdminJobs() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Jobs ({jobs.length})</h1>
-        <button
-          onClick={() => {
-            setEditingJob(emptyJob);
-            setIsNew(true);
-            setTagsInput("");
-          }}
-          className={`px-4 py-2 ${theme.addButtonBg} text-white rounded-lg font-medium`}
-        >
-          Add Job
-        </button>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/admin/job-tags"
+            className="px-4 py-2 border border-blue-300 dark:border-blue-700 text-blue-600 dark:text-blue-400 rounded-lg font-medium hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+          >
+            Manage Tags
+          </Link>
+          <Link
+            href="/admin/job-roles"
+            className="px-4 py-2 border border-blue-300 dark:border-blue-700 text-blue-600 dark:text-blue-400 rounded-lg font-medium hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+          >
+            Manage Roles
+          </Link>
+          <button
+            onClick={() => {
+              setEditingJob(emptyJob);
+              setIsNew(true);
+              setTagsInput("");
+            }}
+            className={`px-4 py-2 ${theme.addButtonBg} text-white rounded-lg font-medium`}
+          >
+            Add Job
+          </button>
+        </div>
       </div>
 
       {/* Error Alert */}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -90,18 +90,15 @@ export default function AdminLayout({
     setIsAuthenticated(false);
   };
 
-  // Order: Dashboard, Affiliations (About page), Blog, News, Portfolio, Categories, Jobs, Candidates, Tags, Roles
+  // Order: Dashboard, Affiliations (About page), Blog, News, Portfolio, Jobs, Candidates
   const navItems = [
     { href: "/admin", label: "Dashboard", color: "neutral", bg: "bg-neutral-100 dark:bg-neutral-800", bgHover: "hover:bg-neutral-200 dark:hover:bg-neutral-700", bgActive: "bg-neutral-700 dark:bg-neutral-600", text: "text-neutral-600 dark:text-neutral-400" },
     { href: "/admin/affiliations", label: "Affiliations", color: "pink", bg: "bg-pink-100 dark:bg-pink-900/30", bgHover: "hover:bg-pink-200 dark:hover:bg-pink-800/40", bgActive: "bg-pink-500 dark:bg-pink-600", text: "text-pink-600 dark:text-pink-400" },
     { href: "/admin/blog", label: "Blog", color: "indigo", bg: "bg-indigo-100 dark:bg-indigo-900/30", bgHover: "hover:bg-indigo-200 dark:hover:bg-indigo-800/40", bgActive: "bg-indigo-500 dark:bg-indigo-600", text: "text-indigo-600 dark:text-indigo-400" },
     { href: "/admin/news", label: "News", color: "purple", bg: "bg-purple-100 dark:bg-purple-900/30", bgHover: "hover:bg-purple-200 dark:hover:bg-purple-800/40", bgActive: "bg-purple-500 dark:bg-purple-600", text: "text-purple-600 dark:text-purple-400" },
     { href: "/admin/investments", label: "Portfolio", color: "amber", bg: "bg-amber-100 dark:bg-amber-900/30", bgHover: "hover:bg-amber-200 dark:hover:bg-amber-800/40", bgActive: "bg-amber-500 dark:bg-amber-600", text: "text-amber-600 dark:text-amber-400" },
-    { href: "/admin/investment-categories", label: "Categories", color: "yellow", bg: "bg-yellow-100 dark:bg-yellow-900/30", bgHover: "hover:bg-yellow-200 dark:hover:bg-yellow-800/40", bgActive: "bg-yellow-500 dark:bg-yellow-600", text: "text-yellow-600 dark:text-yellow-400" },
     { href: "/admin/jobs", label: "Jobs", color: "blue", bg: "bg-blue-100 dark:bg-blue-900/30", bgHover: "hover:bg-blue-200 dark:hover:bg-blue-800/40", bgActive: "bg-blue-500 dark:bg-blue-600", text: "text-blue-600 dark:text-blue-400" },
     { href: "/admin/candidates", label: "Candidates", color: "green", bg: "bg-green-100 dark:bg-green-900/30", bgHover: "hover:bg-green-200 dark:hover:bg-green-800/40", bgActive: "bg-green-500 dark:bg-green-600", text: "text-green-600 dark:text-green-400" },
-    { href: "/admin/job-tags", label: "Tags", color: "orange", bg: "bg-orange-100 dark:bg-orange-900/30", bgHover: "hover:bg-orange-200 dark:hover:bg-orange-800/40", bgActive: "bg-orange-500 dark:bg-orange-600", text: "text-orange-600 dark:text-orange-400" },
-    { href: "/admin/job-roles", label: "Roles", color: "violet", bg: "bg-violet-100 dark:bg-violet-900/30", bgHover: "hover:bg-violet-200 dark:hover:bg-violet-800/40", bgActive: "bg-violet-500 dark:bg-violet-600", text: "text-violet-600 dark:text-violet-400" },
   ];
 
   if (isLoading) {


### PR DESCRIPTION
## Summary
- Remove Categories, Tags, and Roles from admin navbar
- Add "Manage Categories" button to Portfolio/Investments page
- Add "Manage Tags" and "Manage Roles" buttons to Jobs page
- Simplifies navbar from 10 items to 7

## Test plan
- [ ] Visit `/admin/investments` - verify "Manage Categories" button appears and links to `/admin/investment-categories`
- [ ] Visit `/admin/jobs` - verify "Manage Tags" and "Manage Roles" buttons appear and link correctly
- [ ] Verify navbar only shows 7 items: Dashboard, Affiliations, Blog, News, Portfolio, Jobs, Candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)