### PR TITLE
feat(loading): render static filters immediately, skeleton only for data

### DIFF
--- a/.claude/skills/add-job/SKILL.md
+++ b/.claude/skills/add-job/SKILL.md
@@ -40,11 +40,42 @@ Collect the following information from the user:
 - `companyX` - X/Twitter handle (just the handle, e.g., "@company" or "company")
 - `companyGithub` - GitHub organization name or URL
 
+**Candidate socials (when adding candidates):**
+- `x` - X/Twitter handle or URL
+- `telegram` - Telegram handle or URL
+- `github` - GitHub username or URL
+- `linkedin` - LinkedIn profile URL
+- `website` - Personal website URL
+- `email` - Email address
+
 **Assets:**
 - `companyLogo` - Logo image (URL or local file path)
 - `cv` - CV/resume (local PDF path or URL)
 
-### Step 2: Handle Company Logo
+### Step 2: Normalize Social URLs
+
+**IMPORTANT:** Always normalize social handles to full URLs before storing in the database.
+
+| Platform | Input Examples | Normalized Output |
+|----------|---------------|-------------------|
+| X/Twitter | `@username`, `username`, `x.com/username`, `twitter.com/username` | `https://x.com/username` |
+| Telegram | `@username`, `username`, `t.me/username` | `https://t.me/username` |
+| GitHub | `username`, `github.com/username` | `https://github.com/username` |
+| LinkedIn | `in/username`, `linkedin.com/in/username` | `https://linkedin.com/in/username` |
+
+**Normalization rules:**
+1. Remove `@` prefix if present
+2. If input is just a username (no domain), prepend the appropriate base URL
+3. If input already has the domain, ensure it uses `https://` protocol
+4. For X/Twitter, always use `x.com` (not `twitter.com`)
+
+**Examples:**
+- `@ciefa_eth` → `https://x.com/ciefa_eth` (for X)
+- `ciefa_eth` → `https://t.me/ciefa_eth` (for Telegram)
+- `ciefa` → `https://github.com/ciefa` (for GitHub)
+- `twitter.com/user` → `https://x.com/user`
+
+### Step 3: Handle Company Logo
 
 If a company logo is provided:
 
@@ -122,7 +153,7 @@ console.log('Logo URL:', process.env.R2_PUBLIC_URL + '/' + key);
 "
 ```
 
-### Step 3: Handle CV/Resume
+### Step 4: Handle CV/Resume
 
 If a CV is provided:
 
@@ -163,7 +194,7 @@ console.log('CV URL:', process.env.R2_PUBLIC_URL + '/' + key);
 #### Option B: CV is already online
 Use the URL directly - no upload needed. Just store the URL.
 
-### Step 4: Assign Tags
+### Step 5: Assign Tags
 
 Based on the job information, assign appropriate tags. Consider:
 
@@ -196,7 +227,7 @@ Based on the job information, assign appropriate tags. Consider:
 
 See `references/tag-mapping.md` for the full list of available tags.
 
-### Step 5: Insert Job into Database
+### Step 6: Insert Job/Candidate into Database
 
 ```bash
 bun -e "
@@ -231,7 +262,7 @@ process.exit(0);
 "
 ```
 
-### Step 6: Verify
+### Step 7: Verify
 
 After insertion, verify the job was created:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Never use npm, npx, yarn, or pnpm.
 - PostgreSQL (Drizzle ORM)
 - Cloudflare R2 (image storage)
 - PostHog (analytics)
+- class-variance-authority (CVA) for component variants
 
 ## Project Structure
 
@@ -29,14 +30,40 @@ Never use npm, npx, yarn, or pnpm.
 - `src/app/api/v1/` - REST API routes
 - `src/components/` - React components
 - `src/components/admin/` - Admin-specific components (TableSkeleton, ImagePreview, etc.)
+- `src/components/ui/` - Reusable UI primitives (Badge, Icons, SocialLinks)
 - `src/db/` - Database schema and client (Drizzle)
-- `src/lib/` - Utilities (skill-colors, source-colors, r2, posthog-api)
+- `src/hooks/` - Custom React hooks (useHotCandidates, etc.)
+- `src/lib/` - Utilities (utils, skill-colors, source-colors, r2, posthog-api)
 - `content/blog/` - MDX blog posts
 - `scripts/` - Utility scripts for data management
+- `tests/` - E2E tests (Playwright)
 
 ## Code Style
 
 - Use TypeScript strict mode
 - Prefer functional components with hooks
 - Use Tailwind for styling (no CSS modules)
+- Use `cn()` from `@/lib/utils` for conditional class merging
+- Use CVA (class-variance-authority) for component variants
+- Use reusable icon components from `@/components/ui/icons`
 - Admin UI uses section-specific color themes (blue=jobs, green=candidates, amber=investments, etc.)
+
+## UI Components
+
+### Badge Component (`src/components/ui/badge.tsx`)
+CVA-based badge with variants: `default`, `hot`, `top`, `new`, `success`, `info`, `warning`, `muted`
+Pre-configured: `HotBadge`, `TopBadge`, `NewBadge`
+
+### Icons (`src/components/ui/icons.tsx`)
+Reusable SVG icons: XIcon, GitHubIcon, LinkedInIcon, TelegramIcon, EmailIcon, WebsiteIcon, DocumentIcon, CloseIcon, ChevronDownIcon, ChevronRightIcon, LinkIcon, CheckIcon, SpinnerIcon
+
+### SocialLinks (`src/components/ui/social-links.tsx`)
+Reusable social links component with `compact` and `expanded` variants
+
+## Custom Hooks
+
+### useHotCandidates (`src/hooks/useHotCandidates.ts`)
+Manages HOT/TOP candidate status from PostHog analytics. Returns:
+- `isHotCandidate(candidate)` - Check if candidate is hot (analytics or tag)
+- `hasTopTag(candidate)` - Check if candidate has TOP skill tag
+- `showTopCardStyle(candidate)` - Check if TOP styling should show (waits for hot data to prevent flicker)

--- a/README.md
+++ b/README.md
@@ -74,12 +74,16 @@ src/
 │   └── ...              # Public pages
 ├── components/          # React components
 │   ├── admin/           # Admin-specific components
+│   ├── ui/              # Reusable UI primitives (Badge, Icons, SocialLinks)
 │   └── ...              # Shared components
 ├── db/                  # Database configuration
 │   ├── schema/          # Modular Drizzle schema definitions
 │   └── index.ts         # DB client export
+├── hooks/               # Custom React hooks (useHotCandidates, etc.)
 ├── services/            # Business logic & External clients (R2, PostHog, Auth)
-└── lib/                 # Shared utilities and helpers
+└── lib/                 # Shared utilities and helpers (cn, skill-colors, etc.)
+
+tests/                   # E2E tests (Playwright)
 
 docs/
 ├── API.md               # API documentation

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,8 @@
         "@paralleldrive/cuid2": "^3.3.0",
         "@tailwindcss/typography": "^0.5.19",
         "cheerio": "^1.2.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.1",
         "gray-matter": "^4.0.3",
         "next": "^16.1.6",
@@ -20,6 +22,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
+        "tailwind-merge": "^3.4.0",
       },
       "devDependencies": {
         "@playwright/test": "^1.58.0",
@@ -712,7 +715,11 @@
 
     "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
 
+    "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
+
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
@@ -1411,6 +1418,8 @@
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "tailwind-merge": ["tailwind-merge@3.4.0", "", {}, "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g=="],
 
     "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@paralleldrive/cuid2": "^3.3.0",
     "@tailwindcss/typography": "^0.5.19",
     "cheerio": "^1.2.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.1",
     "gray-matter": "^4.0.3",
     "next": "^16.1.6",
@@ -29,7 +31,8 @@
     "posthog-js": "^1.336.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.0",

--- a/src/app/candidates/loading.tsx
+++ b/src/app/candidates/loading.tsx
@@ -1,5 +1,5 @@
 import { Navbar } from "@/components/Navbar";
-import { CandidatesFiltersSkeleton, CandidateCardSkeleton } from "@/components/skeletons";
+import { CandidatesFiltersStatic, CandidateCardSkeleton } from "@/components/skeletons";
 import { TelegramIcon } from "@/components/icons/TelegramIcon";
 import { CANDIDATES_PAGE } from "@/data/page-content";
 
@@ -57,9 +57,12 @@ export default function CandidatesLoading() {
             </ul>
           </div>
 
-          {/* Candidates Grid - Dynamic content skeleton */}
+          {/* Candidates Grid */}
           <div className="space-y-6">
-            <CandidatesFiltersSkeleton />
+            {/* Static filters - render immediately */}
+            <CandidatesFiltersStatic />
+
+            {/* Candidates grid - skeleton for dynamic data */}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {Array.from({ length: 6 }).map((_, i) => (
                 <CandidateCardSkeleton key={i} />

--- a/src/app/jobs/loading.tsx
+++ b/src/app/jobs/loading.tsx
@@ -1,5 +1,5 @@
 import { Navbar } from "@/components/Navbar";
-import { JobsFiltersSkeleton, ListSkeleton } from "@/components/skeletons";
+import { JobsFiltersStatic, JobCardSkeleton } from "@/components/skeletons";
 import { TelegramIcon } from "@/components/icons/TelegramIcon";
 import { JOBS_PAGE } from "@/data/page-content";
 
@@ -29,10 +29,17 @@ export default function JobsLoading() {
             </p>
           </section>
 
-          {/* Jobs Grid - Dynamic content skeleton */}
-          <div className="space-y-6">
-            <JobsFiltersSkeleton />
-            <ListSkeleton count={6} />
+          {/* Jobs Grid */}
+          <div className="space-y-6" data-testid="jobs-grid">
+            {/* Static filters - render immediately */}
+            <JobsFiltersStatic />
+
+            {/* Jobs list - skeleton for dynamic data */}
+            <div className="space-y-4">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <JobCardSkeleton key={i} />
+              ))}
+            </div>
           </div>
         </div>
       </main>

--- a/src/app/news/loading.tsx
+++ b/src/app/news/loading.tsx
@@ -1,5 +1,5 @@
 import { Navbar } from "@/components/Navbar";
-import { NewsFiltersSkeleton, NewsItemSkeleton } from "@/components/skeletons";
+import { NewsFiltersStatic, NewsItemSkeleton } from "@/components/skeletons";
 import { NEWS_PAGE } from "@/data/page-content";
 
 export default function NewsLoading() {
@@ -16,9 +16,12 @@ export default function NewsLoading() {
             </p>
           </div>
 
-          {/* News Grid - Dynamic content skeleton */}
+          {/* News Grid */}
           <div className="space-y-6">
-            <NewsFiltersSkeleton />
+            {/* Static filters - render immediately */}
+            <NewsFiltersStatic />
+
+            {/* News items - skeleton for dynamic data */}
             <div className="space-y-4">
               {Array.from({ length: 8 }).map((_, i) => (
                 <NewsItemSkeleton key={i} />

--- a/src/app/portfolio/loading.tsx
+++ b/src/app/portfolio/loading.tsx
@@ -1,5 +1,5 @@
 import { Navbar } from "@/components/Navbar";
-import { PortfolioFiltersSkeleton, InvestmentCardSkeleton } from "@/components/skeletons";
+import { PortfolioFiltersStatic, InvestmentCardSkeleton } from "@/components/skeletons";
 import { PORTFOLIO_PAGE } from "@/data/page-content";
 
 export default function PortfolioLoading() {
@@ -16,11 +16,14 @@ export default function PortfolioLoading() {
             </p>
           </section>
 
-          {/* Investments - Dynamic content skeleton */}
+          {/* Investments */}
           <section className="space-y-8">
             <h2 className="text-4xl font-bold text-center">{PORTFOLIO_PAGE.investments.title}</h2>
-            <div className="space-y-6">
-              <PortfolioFiltersSkeleton />
+            <div className="space-y-6" data-testid="portfolio-grid">
+              {/* Static filters - render immediately */}
+              <PortfolioFiltersStatic />
+
+              {/* Investments grid - skeleton for dynamic data */}
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                 {Array.from({ length: 9 }).map((_, i) => (
                   <InvestmentCardSkeleton key={i} />

--- a/src/components/CandidatesGrid.tsx
+++ b/src/components/CandidatesGrid.tsx
@@ -377,29 +377,27 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 					</div>
 
 					{/* Role Type Filter */}
-					{allRoleTypes.length > 0 && (
-						<div className="flex items-center gap-2">
-							<label
-								htmlFor="role-filter"
-								className="text-sm text-neutral-600 dark:text-neutral-400 whitespace-nowrap"
-							>
-								Looking For:
-							</label>
-							<CustomSelect
-								id="role-filter"
-								value={roleFilter}
-								onChange={(value) => setRoleFilter(value as "all" | RoleType)}
-								options={[
-									{ value: "all", label: "All Roles" },
-									...allRoleTypes.map((role) => ({
-										value: role,
-										label: roleTypeLabels[role],
-									})),
-								]}
-								className="flex-1 sm:flex-none sm:min-w-[160px]"
-							/>
-						</div>
-					)}
+					<div className="flex items-center gap-2">
+						<label
+							htmlFor="role-filter"
+							className="text-sm text-neutral-600 dark:text-neutral-400 whitespace-nowrap"
+						>
+							Looking For:
+						</label>
+						<CustomSelect
+							id="role-filter"
+							value={roleFilter}
+							onChange={(value) => setRoleFilter(value as "all" | RoleType)}
+							options={[
+								{ value: "all", label: "All Roles" },
+								...allRoleTypes.map((role) => ({
+									value: role,
+									label: roleTypeLabels[role],
+								})),
+							]}
+							className="flex-1 sm:flex-none sm:min-w-[160px]"
+						/>
+					</div>
 				</div>
 
 				{/* Row 2: Search */}

--- a/src/components/CandidatesGrid.tsx
+++ b/src/components/CandidatesGrid.tsx
@@ -678,23 +678,23 @@ function CandidateCard({
 					<p className="text-sm text-neutral-600 dark:text-neutral-400 truncate">
 						{candidate.title}
 					</p>
-					<div className="flex items-center justify-center gap-1.5 mt-1 flex-nowrap">
+					<div className="flex items-center justify-center gap-1.5 mt-1 flex-wrap">
 						<span
 							className={`inline-block px-2 py-0.5 text-xs rounded-full whitespace-nowrap ${availabilityColor[candidate.availability]}`}
 						>
 							{availabilityLabels[candidate.availability]}
 						</span>
-						{isNew(candidate.createdAt) && !isTop && (
-							<span className="px-1.5 py-0.5 text-xs font-semibold rounded-full bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400 whitespace-nowrap animate-pulse-new">
-								NEW
+						{isHot && (
+							<span className="px-1.5 py-0.5 text-xs font-semibold rounded-full bg-gradient-to-r from-orange-500 to-amber-500 text-white whitespace-nowrap">
+								🔥 HOT
 							</span>
 						)}
 						{isTop && (
 							<span className="px-1.5 py-0.5 text-xs font-semibold rounded-full bg-gradient-to-r from-violet-500 to-purple-500 text-white whitespace-nowrap">
-								⭐️ TOP
+								🔝 TOP
 							</span>
 						)}
-						{isNew(candidate.createdAt) && isTop && (
+						{isNew(candidate.createdAt) && (
 							<span className="px-1.5 py-0.5 text-xs font-semibold rounded-full bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400 whitespace-nowrap animate-pulse-new">
 								NEW
 							</span>
@@ -1208,7 +1208,7 @@ function ExpandedCandidateView({
 								)}
 								{isTop && (
 									<span className="px-2 py-1 text-xs font-semibold rounded-full bg-gradient-to-r from-violet-500 to-purple-500 text-white shadow-[0_0_10px_rgba(139,92,246,0.5)]">
-										⭐️ TOP
+										🔝 TOP
 									</span>
 								)}
 								{isNew(candidate.createdAt) && (

--- a/src/components/CandidatesGrid.tsx
+++ b/src/components/CandidatesGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useRef, useCallback } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback, memo } from "react";
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
 import {
@@ -23,6 +23,17 @@ import {
 	trackCandidateContactClick,
 } from "@/lib/posthog";
 import { hashString, seededRandom, shuffleArray, isNew } from "@/lib/shuffle";
+import { cn } from "@/lib/utils";
+import { useHotCandidates } from "@/hooks/useHotCandidates";
+import { HotBadge, TopBadge, NewBadge, Badge } from "./ui/badge";
+import { SocialLinks } from "./ui/social-links";
+import {
+	CloseIcon,
+	ChevronDownIcon,
+	ChevronRightIcon,
+	SpinnerIcon,
+	TelegramIcon,
+} from "./ui/icons";
 
 interface CandidatesGridProps {
 	candidates: Candidate[];
@@ -48,48 +59,9 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 	});
 	const lastActiveRef = useRef<HTMLElement | null>(null);
 	const loadMoreRef = useRef<HTMLDivElement>(null);
-	const [dataHotCandidateIds, setDataHotCandidateIds] = useState<Set<string>>(new Set());
-	const [hotDataLoaded, setHotDataLoaded] = useState(false);
 
-	// Fetch data-driven hot candidates from analytics
-	useEffect(() => {
-		fetch("/api/hot-candidates")
-			.then((res) => res.json())
-			.then((data) => {
-				if (data.hotCandidateIds) {
-					setDataHotCandidateIds(new Set(data.hotCandidateIds));
-				}
-			})
-			.catch(() => {
-				// Silently fail - hot candidates badge is non-critical
-			})
-			.finally(() => {
-				setHotDataLoaded(true);
-			});
-	}, []);
-
-	// Helper to check if candidate is hot (manual flag OR data-driven OR has hot skill tag)
-	const isHotCandidate = useCallback(
-		(candidate: Candidate) => candidate.hot || dataHotCandidateIds.has(candidate.id) || candidate.skills?.includes("hot" as SkillTag),
-		[dataHotCandidateIds]
-	);
-
-	// Helper to check if candidate has TOP skill tag (for badge display)
-	const hasTopTag = useCallback(
-		(candidate: Candidate) => candidate.skills?.includes("top" as SkillTag) ?? false,
-		[]
-	);
-
-	// Helper to check if candidate should show TOP card styling (background/border)
-	// Wait for hot data to prevent purple→orange flicker
-	const showTopCardStyle = useCallback(
-		(candidate: Candidate) => {
-			if (!hotDataLoaded) return false;
-			if (!hasTopTag(candidate)) return false;
-			return !isHotCandidate(candidate);
-		},
-		[hotDataLoaded, hasTopTag, isHotCandidate]
-	);
+	// Use custom hook for hot candidates logic (better separation of concerns)
+	const { isHotCandidate, hasTopTag, showTopCardStyle } = useHotCandidates();
 
 	// Helper to update URL params without React re-render
 	const updateUrlParams = useCallback((updates: Record<string, string | null>) => {
@@ -438,10 +410,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 								className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
 								aria-label="Clear search"
 							>
-								<svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-									<line x1="18" y1="6" x2="6" y2="18" />
-									<line x1="6" y1="6" x2="18" y2="18" />
-								</svg>
+								<CloseIcon className="size-4" />
 							</button>
 						)}
 					</div>
@@ -463,14 +432,9 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 							className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-full border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
 						>
 							<span>Filter by skills</span>
-							<svg
-								className={`w-4 h-4 transition-transform ${tagsExpanded ? 'rotate-180' : ''}`}
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke="currentColor"
-							>
-								<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-							</svg>
+							<ChevronDownIcon
+								className={cn("transition-transform", tagsExpanded && "rotate-180")}
+							/>
 						</button>
 						{/* Selected tags as pills */}
 						{selectedTags.map((tag) => (
@@ -490,9 +454,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 									className="ml-1 hover:opacity-70"
 									aria-label={`Remove ${tagLabels[tag] ?? tag} filter`}
 								>
-									<svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-										<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-									</svg>
+									<CloseIcon className="size-3.5" />
 								</button>
 							</span>
 						))}
@@ -534,9 +496,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 								onClick={() => setTagsExpanded(false)}
 								className="ml-auto px-3 py-1.5 text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 flex items-center gap-1"
 							>
-								<svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-								</svg>
+								<CloseIcon className="size-4" />
 								Close
 							</button>
 						</div>
@@ -592,16 +552,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 					className="flex justify-center py-8"
 				>
 					<div className="flex items-center gap-2 text-neutral-500">
-						<svg
-							className="w-5 h-5 animate-spin"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							strokeWidth="2"
-						>
-							<circle cx="12" cy="12" r="10" strokeOpacity="0.25" />
-							<path d="M12 2a10 10 0 0 1 10 10" strokeLinecap="round" />
-						</svg>
+						<SpinnerIcon />
 						<span className="text-sm">Loading more candidates...</span>
 					</div>
 				</div>
@@ -610,48 +561,54 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 	);
 }
 
-function CandidateCard({
-	candidate,
-	isHot,
-	isTop,
-	isTopStyle,
-	onExpand,
-}: {
+// Constants for image URLs (hoisted to avoid recreating on each render)
+const ANONYMOUS_PLACEHOLDER =
+	"https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg";
+
+// Card style variants (hoisted for performance)
+const CARD_STYLES = {
+	hot: "border-orange-500 dark:border-orange-400 bg-gradient-to-r from-orange-100 to-amber-100 dark:from-orange-900/40 dark:to-amber-900/40 shadow-[0_0_8px_rgba(251,146,60,0.5)] dark:shadow-[0_0_10px_rgba(251,146,60,0.4)]",
+	top: "border-violet-500 dark:border-violet-400 bg-gradient-to-r from-violet-100 to-purple-100 dark:from-violet-900/40 dark:to-purple-900/40 shadow-[0_0_8px_rgba(139,92,246,0.5)] dark:shadow-[0_0_10px_rgba(139,92,246,0.4)]",
+	default: "border-neutral-200 dark:border-neutral-800 hover:border-neutral-400 dark:hover:border-neutral-600",
+} as const;
+
+interface CandidateCardProps {
 	candidate: Candidate;
 	isHot: boolean;
 	isTop: boolean;
 	isTopStyle: boolean;
 	onExpand: () => void;
-}) {
+}
+
+/**
+ * Memoized candidate card component to prevent unnecessary re-renders.
+ * Uses React.memo for performance optimization in large lists.
+ */
+const CandidateCard = memo(function CandidateCard({
+	candidate,
+	isHot,
+	isTop,
+	isTopStyle,
+	onExpand,
+}: CandidateCardProps) {
 	const isAnonymous = candidate.visibility === "anonymous";
 	const displayName = isAnonymous
 		? candidate.anonymousAlias || "Anonymous"
 		: candidate.name;
 	const profileImage = isAnonymous
-		? "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg"
-		: candidate.profileImage || "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg";
-	const availabilityColor = {
-		looking:
-			"bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
-		open: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
-		"not-looking":
-			"bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400",
-	};
+		? ANONYMOUS_PLACEHOLDER
+		: candidate.profileImage || ANONYMOUS_PLACEHOLDER;
 
 	// Determine card styling based on status (uses isTopStyle to prevent flicker)
-	const getCardClassName = () => {
-		if (isHot) {
-			return "border-orange-500 dark:border-orange-400 bg-gradient-to-r from-orange-100 to-amber-100 dark:from-orange-900/40 dark:to-amber-900/40 shadow-[0_0_8px_rgba(251,146,60,0.5)] dark:shadow-[0_0_10px_rgba(251,146,60,0.4)]";
-		}
-		if (isTopStyle) {
-			return "border-violet-500 dark:border-violet-400 bg-gradient-to-r from-violet-100 to-purple-100 dark:from-violet-900/40 dark:to-purple-900/40 shadow-[0_0_8px_rgba(139,92,246,0.5)] dark:shadow-[0_0_10px_rgba(139,92,246,0.4)]";
-		}
-		return "border-neutral-200 dark:border-neutral-800 hover:border-neutral-400 dark:hover:border-neutral-600";
-	};
+	const cardStyle = isHot
+		? CARD_STYLES.hot
+		: isTopStyle
+			? CARD_STYLES.top
+			: CARD_STYLES.default;
 
 	return (
 		<div
-			className={`p-4 rounded-xl border transition-all overflow-hidden ${getCardClassName()}`}
+			className={cn("p-4 rounded-xl border transition-all overflow-hidden", cardStyle)}
 		>
 			{/* Header */}
 			<div className="flex flex-col items-center gap-3 text-center">
@@ -700,26 +657,15 @@ function CandidateCard({
 						{candidate.title}
 					</p>
 					<div className="flex items-center justify-center gap-1.5 mt-1 flex-wrap">
-						<span
-							className={`inline-block px-2 py-0.5 text-xs rounded-full whitespace-nowrap ${availabilityColor[candidate.availability]}`}
+						<Badge
+							variant={candidate.availability === "looking" ? "success" : candidate.availability === "open" ? "info" : "muted"}
+							size="sm"
 						>
 							{availabilityLabels[candidate.availability]}
-						</span>
-						{isHot && (
-							<span className="px-1.5 py-0.5 text-xs font-semibold rounded-full bg-gradient-to-r from-orange-500 to-amber-500 text-white whitespace-nowrap">
-								🔥 HOT
-							</span>
-						)}
-						{isTop && (
-							<span className="px-1.5 py-0.5 text-xs font-semibold rounded-full bg-gradient-to-r from-violet-500 to-purple-500 text-white whitespace-nowrap">
-								✨ TOP
-							</span>
-						)}
-						{isNew(candidate.createdAt) && (
-							<span className="px-1.5 py-0.5 text-xs font-semibold rounded-full bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400 whitespace-nowrap animate-pulse-new">
-								NEW
-							</span>
-						)}
+						</Badge>
+						{isHot && <HotBadge size="sm" />}
+						{isTop && <TopBadge size="sm" />}
+						{isNew(candidate.createdAt) && <NewBadge size="sm" />}
 					</div>
 				</div>
 			</div>
@@ -738,8 +684,8 @@ function CandidateCard({
 				{candidate.experience && <span>{experienceLabels[candidate.experience]}</span>}
 			</div>
 
-			{/* Skills - fixed height for consistent card sizing */}
-			<div className="mt-3 h-[52px] flex flex-wrap items-start justify-center gap-1.5 overflow-hidden">
+			{/* Skills - min-height for consistent card sizing, allows expansion if needed */}
+			<div className="mt-3 min-h-[52px] flex flex-wrap items-start justify-center gap-1.5 overflow-hidden">
 				{(() => {
 					const displaySkills = (candidate.skills || []).filter((tag) => tag !== "hot" && tag !== "top");
 					const maxTags = 4;
@@ -774,17 +720,7 @@ function CandidateCard({
 					className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-700 dark:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-700 hover:border-neutral-400 dark:hover:border-neutral-500 transition-all"
 				>
 					<span>View Details</span>
-					<svg
-						className="w-4 h-4"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth="2.5"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-					>
-						<polyline points="9 18 15 12 9 6" />
-					</svg>
+					<ChevronRightIcon />
 				</button>
 			</div>
 
@@ -797,164 +733,23 @@ function CandidateCard({
 						rel="noopener noreferrer"
 						className="flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-neutral-900 text-white dark:bg-white dark:text-neutral-900 hover:opacity-90 transition-opacity"
 					>
-						<svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-							<path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
-						</svg>
+						<TelegramIcon className="size-4" />
 						Request Introduction
 					</a>
 				) : (
-					<div className="flex items-center justify-center">
-						<div className="flex items-center gap-1">
-						{candidate.socials?.x && (
-							<a
-								href={candidate.socials.x}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="p-2.5 sm:p-2 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
-								title="X"
-								aria-label={`X profile for ${displayName}`}
-							>
-								<svg
-									className="w-5 h-5 sm:w-4 sm:h-4"
-									viewBox="0 0 24 24"
-									fill="currentColor"
-								>
-									<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-								</svg>
-							</a>
-						)}
-						{candidate.socials?.github && (
-							<a
-								href={candidate.socials.github}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="p-2.5 sm:p-2 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
-								title="GitHub"
-								aria-label={`GitHub profile for ${displayName}`}
-							>
-								<svg
-									className="w-5 h-5 sm:w-4 sm:h-4"
-									viewBox="0 0 24 24"
-									fill="currentColor"
-								>
-									<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-								</svg>
-							</a>
-						)}
-						{candidate.socials?.linkedin && (
-							<a
-								href={candidate.socials.linkedin}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="p-2.5 sm:p-2 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
-								title="LinkedIn"
-								aria-label={`LinkedIn profile for ${displayName}`}
-							>
-								<svg
-									className="w-5 h-5 sm:w-4 sm:h-4"
-									viewBox="0 0 24 24"
-									fill="currentColor"
-								>
-									<path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-								</svg>
-							</a>
-						)}
-						{candidate.socials?.email && (
-							<a
-								href={`mailto:${candidate.socials.email}`}
-								className="p-2.5 sm:p-2 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
-								title="Email"
-								aria-label={`Email ${displayName}`}
-							>
-								<svg
-									className="w-5 h-5 sm:w-4 sm:h-4"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-								>
-									<rect x="2" y="4" width="20" height="16" rx="2" />
-									<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
-								</svg>
-							</a>
-						)}
-						{candidate.socials?.website && (
-							<a
-								href={candidate.socials.website}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="p-2.5 sm:p-2 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
-								title="Website"
-								aria-label={`Website for ${displayName}`}
-							>
-								<svg
-									className="w-5 h-5 sm:w-4 sm:h-4"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-								>
-									<circle cx="12" cy="12" r="10" />
-									<line x1="2" y1="12" x2="22" y2="12" />
-									<path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
-								</svg>
-							</a>
-						)}
-						{candidate.socials?.telegram && (
-							<a
-								href={candidate.socials.telegram}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="p-2.5 sm:p-2 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
-								title="Telegram"
-								aria-label={`Telegram for ${displayName}`}
-							>
-								<svg
-									className="w-5 h-5 sm:w-4 sm:h-4"
-									viewBox="0 0 24 24"
-									fill="currentColor"
-								>
-									<path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
-								</svg>
-							</a>
-						)}
-						{candidate.socials?.cv && (
-							<a
-								href={candidate.socials.cv}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="p-2.5 sm:p-2 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
-								title="CV / Resume"
-								aria-label={`CV or resume for ${displayName}`}
-							>
-								<svg
-									className="w-5 h-5 sm:w-4 sm:h-4"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-								>
-									<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-									<polyline points="14 2 14 8 20 8" />
-									<line x1="16" y1="13" x2="8" y2="13" />
-									<line x1="16" y1="17" x2="8" y2="17" />
-									<polyline points="10 9 9 9 8 9" />
-								</svg>
-							</a>
-						)}
-						</div>
-					</div>
+					candidate.socials && (
+						<SocialLinks
+							socials={candidate.socials}
+							displayName={displayName}
+							variant="compact"
+							className="justify-center"
+						/>
+					)
 				)}
 			</div>
 		</div>
 	);
-}
+});
 
 function ExpandedCandidateView({
 	candidate,
@@ -1227,6 +1022,11 @@ function ExpandedCandidateView({
 										◇
 									</span>
 								)}
+							</div>
+							<div className="flex flex-wrap items-center justify-center sm:justify-start gap-2 mb-3">
+								<p className="text-base sm:text-lg text-neutral-600 dark:text-neutral-400">
+									{candidate.title}
+								</p>
 								{isHot && (
 									<span className="px-2 py-1 text-xs font-semibold rounded-full bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-[0_0_10px_rgba(251,146,60,0.5)]">
 										🔥 HOT
@@ -1238,14 +1038,11 @@ function ExpandedCandidateView({
 									</span>
 								)}
 								{isNew(candidate.createdAt) && (
-									<span className="px-3 py-1 text-sm font-semibold rounded-full bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400 animate-pulse-new">
+									<span className="px-2 py-1 text-xs font-semibold rounded-full bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400 animate-pulse-new">
 										NEW
 									</span>
 								)}
 							</div>
-							<p className="text-base sm:text-lg text-neutral-600 dark:text-neutral-400 mb-3">
-								{candidate.title}
-							</p>
 							<div className="flex flex-wrap justify-center sm:justify-start gap-2">
 								<span
 									className={`px-3 py-1 text-sm rounded-full ${availabilityColor[candidate.availability]}`}

--- a/src/components/CandidatesGrid.tsx
+++ b/src/components/CandidatesGrid.tsx
@@ -75,17 +75,12 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 	);
 
 	// Helper to check if candidate should show TOP badge
-	// Only show TOP after we've loaded hot data and confirmed they're not hot
+	// Shows for anyone with "top" skill tag (can show alongside HOT)
 	const isTopCandidate = useCallback(
 		(candidate: Candidate) => {
-			const hasTopTag = candidate.skills?.includes("top" as SkillTag) ?? false;
-			if (!hasTopTag) return false;
-			// Wait for hot data to load before showing TOP (prevents flicker)
-			if (!hotDataLoaded) return false;
-			// Don't show TOP if they're hot
-			return !isHotCandidate(candidate);
+			return candidate.skills?.includes("top" as SkillTag) ?? false;
 		},
-		[hotDataLoaded, isHotCandidate]
+		[]
 	);
 
 	// Helper to update URL params without React re-render

--- a/src/components/CandidatesGrid.tsx
+++ b/src/components/CandidatesGrid.tsx
@@ -535,7 +535,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 							key={candidate.id}
 							candidate={candidate}
 							isHot={isHotCandidate(candidate)}
-							isTop={hasSkillTag(candidate, "top") && !hasSkillTag(candidate, "hot")}
+							isTop={hasSkillTag(candidate, "top") && !hasSkillTag(candidate, "hot") && !isHotCandidate(candidate)}
 							onExpand={() => openCandidate(candidate)}
 						/>
 					))
@@ -547,7 +547,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 				<ExpandedCandidateView
 					candidate={expandedCandidate}
 					isHot={isHotCandidate(expandedCandidate)}
-					isTop={hasSkillTag(expandedCandidate, "top") && !hasSkillTag(expandedCandidate, "hot")}
+					isTop={hasSkillTag(expandedCandidate, "top") && !hasSkillTag(expandedCandidate, "hot") && !isHotCandidate(expandedCandidate)}
 					onClose={closeCandidate}
 					onCVClick={() => trackCandidateCVClick(getCandidateEventProps(expandedCandidate))}
 					onSocialClick={(platform, url) => trackCandidateSocialClick({
@@ -718,17 +718,17 @@ function CandidateCard({
 				const displaySkills = candidate.skills.filter((tag) => tag !== "hot" && tag !== "top");
 				const maxTags = 3;
 				return displaySkills.length > 0 && (
-					<div className="mt-3 flex items-center justify-center gap-1">
+					<div className="mt-3 flex flex-wrap items-center justify-center gap-1.5">
 						{displaySkills.slice(0, maxTags).map((tag) => (
 							<span
 								key={tag}
-								className="px-2 py-0.5 text-xs rounded-full bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400"
+								className="px-2 py-1 text-xs leading-none rounded-full bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400"
 							>
 								{tagLabels[tag] ?? tag}
 							</span>
 						))}
 						{displaySkills.length > maxTags && (
-							<span className="px-2 py-0.5 text-xs text-neutral-500">
+							<span className="px-2 py-1 text-xs leading-none text-neutral-500">
 								+{displaySkills.length - maxTags} more
 							</span>
 						)}

--- a/src/components/CandidatesGrid.tsx
+++ b/src/components/CandidatesGrid.tsx
@@ -49,6 +49,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 	const lastActiveRef = useRef<HTMLElement | null>(null);
 	const loadMoreRef = useRef<HTMLDivElement>(null);
 	const [dataHotCandidateIds, setDataHotCandidateIds] = useState<Set<string>>(new Set());
+	const [hotDataLoaded, setHotDataLoaded] = useState(false);
 
 	// Fetch data-driven hot candidates from analytics
 	useEffect(() => {
@@ -61,6 +62,9 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 			})
 			.catch(() => {
 				// Silently fail - hot candidates badge is non-critical
+			})
+			.finally(() => {
+				setHotDataLoaded(true);
 			});
 	}, []);
 
@@ -535,7 +539,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 							key={candidate.id}
 							candidate={candidate}
 							isHot={isHotCandidate(candidate)}
-							isTop={hasSkillTag(candidate, "top") && !hasSkillTag(candidate, "hot") && !isHotCandidate(candidate)}
+							isTop={hotDataLoaded && hasSkillTag(candidate, "top") && !hasSkillTag(candidate, "hot") && !isHotCandidate(candidate)}
 							onExpand={() => openCandidate(candidate)}
 						/>
 					))
@@ -547,7 +551,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 				<ExpandedCandidateView
 					candidate={expandedCandidate}
 					isHot={isHotCandidate(expandedCandidate)}
-					isTop={hasSkillTag(expandedCandidate, "top") && !hasSkillTag(expandedCandidate, "hot") && !isHotCandidate(expandedCandidate)}
+					isTop={hotDataLoaded && hasSkillTag(expandedCandidate, "top") && !hasSkillTag(expandedCandidate, "hot") && !isHotCandidate(expandedCandidate)}
 					onClose={closeCandidate}
 					onCVClick={() => trackCandidateCVClick(getCandidateEventProps(expandedCandidate))}
 					onSocialClick={(platform, url) => trackCandidateSocialClick({

--- a/src/components/skeletons/GridSkeleton.tsx
+++ b/src/components/skeletons/GridSkeleton.tsx
@@ -1,5 +1,6 @@
 /**
  * Reusable skeleton loading components for grids and cards.
+ * Also includes static filter components that render immediately while data loads.
  */
 
 export function CardSkeleton({ className = "" }: { className?: string }) {
@@ -45,7 +46,303 @@ export function ListSkeleton({ count = 6 }: { count?: number }) {
   );
 }
 
-// Generic filter row skeleton
+// ============================================================================
+// Static Filter Components (render immediately, no data dependency)
+// ============================================================================
+
+/**
+ * Static select component that matches CustomSelect styling
+ * Used in loading states to show filter UI immediately
+ */
+function StaticSelect({
+  label,
+  placeholder,
+  className = "",
+}: {
+  label: string;
+  placeholder: string;
+  className?: string;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <label className="text-sm text-neutral-600 dark:text-neutral-400 whitespace-nowrap">
+        {label}
+      </label>
+      <div className={`relative ${className}`}>
+        <div className="flex items-center justify-between gap-2 px-3 py-2 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-400 dark:text-neutral-500 cursor-default min-w-[120px]">
+          <span className="truncate">{placeholder}</span>
+          <svg
+            className="w-4 h-4 flex-shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Static search input that's fully functional (no data dependency)
+ */
+function StaticSearchInput({ placeholder = "Search..." }: { placeholder?: string }) {
+  return (
+    <div className="flex-1 relative">
+      <input
+        type="text"
+        placeholder={placeholder}
+        disabled
+        className="w-full px-3 py-2 pr-9 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 placeholder-neutral-400 dark:placeholder-neutral-500 cursor-default"
+      />
+      <svg
+        className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        />
+      </svg>
+    </div>
+  );
+}
+
+/**
+ * Static button component for filter toggles
+ */
+function StaticButton({
+  children,
+  active = false,
+  className = "",
+}: {
+  children: React.ReactNode;
+  active?: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`px-3 py-1.5 text-sm font-medium rounded-full border transition-colors cursor-default ${
+        active
+          ? "bg-neutral-100 dark:bg-neutral-800 border-neutral-300 dark:border-neutral-600"
+          : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-400"
+      } ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ============================================================================
+// Jobs Page Static Filters
+// ============================================================================
+
+export function JobsFiltersStatic() {
+  return (
+    <div className="space-y-4">
+      {/* Row 1: Affiliation, Role, Company */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <StaticSelect label="Affiliation:" placeholder="All" className="sm:min-w-[120px]" />
+        <StaticSelect label="Role:" placeholder="All Roles" className="sm:min-w-[140px]" />
+        <StaticSelect label="Company:" placeholder="All Companies" className="sm:min-w-[160px]" />
+      </div>
+
+      {/* Row 2: Location and Search */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <StaticSelect label="Location:" placeholder="All Locations" className="sm:min-w-[160px]" />
+        <StaticSearchInput placeholder="Search jobs..." />
+      </div>
+
+      {/* Results count placeholder */}
+      <div className="flex items-center gap-3">
+        <span className="text-sm text-neutral-400 dark:text-neutral-500">
+          Loading jobs...
+        </span>
+      </div>
+
+      {/* Tag Filters */}
+      <div className="flex flex-wrap items-center gap-2">
+        <StaticButton>
+          <span className="flex items-center gap-2">
+            <span className="text-amber-500">★</span>
+            <span>Featured only</span>
+          </span>
+        </StaticButton>
+        <StaticButton>
+          <span className="flex items-center gap-2">
+            <span>Filter by tags</span>
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </span>
+        </StaticButton>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Candidates Page Static Filters
+// ============================================================================
+
+export function CandidatesFiltersStatic() {
+  return (
+    <div className="space-y-4">
+      {/* Row 1: Status, Experience, Looking For */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <StaticSelect label="Status:" placeholder="All Statuses" className="sm:min-w-[160px]" />
+        <StaticSelect label="Experience:" placeholder="All Levels" className="sm:min-w-[140px]" />
+        <StaticSelect label="Looking For:" placeholder="All Roles" className="sm:min-w-[140px]" />
+      </div>
+
+      {/* Row 2: Search */}
+      <div className="flex flex-col sm:flex-row gap-3 items-center">
+        <StaticSearchInput placeholder="Search candidates..." />
+        <span className="text-sm text-neutral-400 dark:text-neutral-500 whitespace-nowrap">
+          Loading candidates...
+        </span>
+      </div>
+
+      {/* Skills filter button */}
+      <div className="flex items-center gap-2">
+        <StaticButton>
+          <span className="flex items-center gap-2">
+            <span>Filter by skills</span>
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </span>
+        </StaticButton>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Portfolio Page Static Filters
+// ============================================================================
+
+export function PortfolioFiltersStatic() {
+  return (
+    <div className="space-y-6">
+      {/* Sort and filter buttons */}
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-neutral-600 dark:text-neutral-400">
+            Sort by:
+          </label>
+          <select
+            disabled
+            className="px-3 py-1.5 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-600 dark:text-neutral-400 cursor-default"
+            defaultValue="relevance"
+          >
+            <option value="relevance">Relevance</option>
+            <option value="alphabetical">A → Z</option>
+            <option value="alphabetical-desc">Z → A</option>
+          </select>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <StaticButton active>Main</StaticButton>
+          <StaticButton>Featured</StaticButton>
+          <StaticButton>All</StaticButton>
+        </div>
+      </div>
+
+      {/* Category filters - show loading placeholder */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm text-neutral-600 dark:text-neutral-400">
+          Categories:
+        </span>
+        <div className="flex flex-wrap gap-2">
+          {/* Skeleton category pills */}
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-7 rounded-full bg-neutral-100 dark:bg-neutral-800 animate-pulse"
+              style={{ width: `${60 + (i % 3) * 20}px` }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// News Page Static Filters
+// ============================================================================
+
+export function NewsFiltersStatic() {
+  return (
+    <div className="space-y-4">
+      {/* Row 1: Type, Category */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-neutral-600 dark:text-neutral-400 whitespace-nowrap">
+            Type:
+          </label>
+          <select
+            disabled
+            className="px-3 py-2 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-600 dark:text-neutral-400 cursor-default min-w-[140px]"
+            defaultValue="all"
+          >
+            <option value="all">All</option>
+            <option value="blog">Blog Posts</option>
+            <option value="curated">Curated Links</option>
+            <option value="announcement">Announcements</option>
+          </select>
+        </div>
+        <StaticSelect label="Category:" placeholder="All Categories" className="sm:min-w-[140px]" />
+      </div>
+
+      {/* Row 2: Search + Count */}
+      <div className="flex flex-col sm:flex-row gap-3 items-center">
+        <StaticSearchInput placeholder="Search news..." />
+        <span className="text-sm text-neutral-400 dark:text-neutral-500 whitespace-nowrap">
+          Loading news...
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Legacy Skeleton Components (kept for backwards compatibility)
+// ============================================================================
+
+// Generic filter row skeleton (legacy - use static versions instead)
 export function FiltersSkeleton() {
   return (
     <div className="space-y-4 animate-pulse">
@@ -59,121 +356,29 @@ export function FiltersSkeleton() {
   );
 }
 
-// Jobs-specific filters skeleton (matches JobsGrid filter layout)
+// Jobs-specific filters skeleton (legacy)
 export function JobsFiltersSkeleton() {
-  return (
-    <div className="space-y-4 animate-pulse">
-      {/* Row 1: Affiliation, Role, Company, Location */}
-      <div className="flex flex-wrap gap-3">
-        <div className="flex items-center gap-2">
-          <div className="h-4 w-16 rounded bg-neutral-200 dark:bg-neutral-800" />
-          <div className="h-10 w-32 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="h-4 w-10 rounded bg-neutral-200 dark:bg-neutral-800" />
-          <div className="h-10 w-36 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="h-4 w-16 rounded bg-neutral-200 dark:bg-neutral-800" />
-          <div className="h-10 w-40 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="h-4 w-16 rounded bg-neutral-200 dark:bg-neutral-800" />
-          <div className="h-10 w-36 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        </div>
-      </div>
-      {/* Row 2: Search + Featured + Count */}
-      <div className="flex flex-wrap gap-3 items-center">
-        <div className="flex-1 h-10 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        <div className="h-10 w-32 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        <div className="h-5 w-16 rounded bg-neutral-200 dark:bg-neutral-800" />
-      </div>
-    </div>
-  );
+  return <JobsFiltersStatic />;
 }
 
-// Candidates-specific filters skeleton
+// Candidates-specific filters skeleton (legacy)
 export function CandidatesFiltersSkeleton() {
-  return (
-    <div className="space-y-4 animate-pulse">
-      {/* Row 1: Status, Experience, Looking For */}
-      <div className="flex flex-wrap gap-3">
-        <div className="flex items-center gap-2">
-          <div className="h-4 w-12 rounded bg-neutral-200 dark:bg-neutral-800" />
-          <div className="h-10 w-44 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="h-4 w-20 rounded bg-neutral-200 dark:bg-neutral-800" />
-          <div className="h-10 w-40 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="h-4 w-20 rounded bg-neutral-200 dark:bg-neutral-800" />
-          <div className="h-10 w-40 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        </div>
-      </div>
-      {/* Row 2: Search + Count */}
-      <div className="flex flex-wrap gap-3 items-center">
-        <div className="flex-1 h-10 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        <div className="h-5 w-24 rounded bg-neutral-200 dark:bg-neutral-800" />
-      </div>
-      {/* Skills filter button */}
-      <div className="flex items-center gap-2">
-        <div className="h-9 w-32 rounded-full bg-neutral-200 dark:bg-neutral-800" />
-      </div>
-    </div>
-  );
+  return <CandidatesFiltersStatic />;
 }
 
-// Portfolio-specific controls skeleton
+// Portfolio-specific controls skeleton (legacy)
 export function PortfolioFiltersSkeleton() {
-  return (
-    <div className="space-y-6 animate-pulse">
-      {/* Sort and filter buttons */}
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="flex items-center gap-2">
-          <div className="h-4 w-14 rounded bg-neutral-200 dark:bg-neutral-800" />
-          <div className="h-9 w-28 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="h-9 w-24 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-          <div className="h-9 w-28 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-          <div className="h-9 w-20 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        </div>
-      </div>
-      {/* Category filters */}
-      <div className="flex flex-wrap items-center gap-2">
-        <div className="h-4 w-16 rounded bg-neutral-200 dark:bg-neutral-800" />
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="h-7 w-20 rounded-full bg-neutral-200 dark:bg-neutral-800" />
-        ))}
-      </div>
-    </div>
-  );
+  return <PortfolioFiltersStatic />;
 }
 
-// News-specific filters skeleton
+// News-specific filters skeleton (legacy)
 export function NewsFiltersSkeleton() {
-  return (
-    <div className="space-y-4 animate-pulse">
-      {/* Row 1: Type, Category */}
-      <div className="flex flex-wrap gap-3">
-        <div className="flex items-center gap-2">
-          <div className="h-4 w-10 rounded bg-neutral-200 dark:bg-neutral-800" />
-          <div className="h-10 w-40 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="h-4 w-16 rounded bg-neutral-200 dark:bg-neutral-800" />
-          <div className="h-10 w-40 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        </div>
-      </div>
-      {/* Row 2: Search + Count */}
-      <div className="flex flex-wrap gap-3 items-center">
-        <div className="flex-1 h-10 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
-        <div className="h-5 w-16 rounded bg-neutral-200 dark:bg-neutral-800" />
-      </div>
-    </div>
-  );
+  return <NewsFiltersStatic />;
 }
+
+// ============================================================================
+// Card/Item Skeletons (for actual data loading)
+// ============================================================================
 
 // News item skeleton (matches NewsGrid item layout)
 export function NewsItemSkeleton() {
@@ -281,6 +486,36 @@ export function InvestmentCardSkeleton() {
         <div className="h-8 w-8 rounded bg-neutral-200 dark:bg-neutral-800" />
         <div className="h-8 w-8 rounded bg-neutral-200 dark:bg-neutral-800" />
         <div className="h-8 w-8 rounded bg-neutral-200 dark:bg-neutral-800" />
+      </div>
+    </div>
+  );
+}
+
+// Job card skeleton (matches JobsGrid job item layout)
+export function JobCardSkeleton() {
+  return (
+    <div className="animate-pulse p-4 rounded-xl border border-neutral-200 dark:border-neutral-800">
+      <div className="flex flex-col sm:flex-row sm:items-start gap-4">
+        {/* Company Logo */}
+        <div className="w-full sm:w-auto flex justify-center sm:justify-start">
+          <div className="w-20 h-20 sm:w-16 sm:h-16 rounded-lg bg-neutral-200 dark:bg-neutral-800" />
+        </div>
+        {/* Job Details */}
+        <div className="flex-1 min-w-0 text-center sm:text-left space-y-2">
+          <div className="h-5 w-3/4 mx-auto sm:mx-0 rounded bg-neutral-200 dark:bg-neutral-800" />
+          <div className="h-4 w-1/2 mx-auto sm:mx-0 rounded bg-neutral-200 dark:bg-neutral-800" />
+          <div className="h-3 w-2/3 mx-auto sm:mx-0 rounded bg-neutral-200 dark:bg-neutral-800" />
+          {/* Tags */}
+          <div className="mt-2 flex flex-wrap justify-center sm:justify-start gap-1">
+            <div className="h-6 w-16 rounded-full bg-neutral-200 dark:bg-neutral-800" />
+            <div className="h-6 w-20 rounded-full bg-neutral-200 dark:bg-neutral-800" />
+          </div>
+          {/* Buttons */}
+          <div className="mt-3 flex items-center justify-center sm:justify-end gap-2">
+            <div className="h-9 w-24 rounded-full bg-neutral-200 dark:bg-neutral-800" />
+            <div className="h-9 w-20 rounded-full bg-neutral-200 dark:bg-neutral-800" />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/skeletons/index.ts
+++ b/src/components/skeletons/index.ts
@@ -3,12 +3,20 @@ export {
   GridSkeleton,
   ListSkeleton,
   FiltersSkeleton,
+  // Static filter components (render immediately)
+  JobsFiltersStatic,
+  CandidatesFiltersStatic,
+  PortfolioFiltersStatic,
+  NewsFiltersStatic,
+  // Legacy skeleton names (now use static versions)
   JobsFiltersSkeleton,
   CandidatesFiltersSkeleton,
   PortfolioFiltersSkeleton,
   NewsFiltersSkeleton,
+  // Card/Item skeletons
   NewsItemSkeleton,
   BlogArticleSkeleton,
   CandidateCardSkeleton,
   InvestmentCardSkeleton,
+  JobCardSkeleton,
 } from "./GridSkeleton";

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,75 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+/**
+ * Badge variants using CVA (Class Variance Authority) for type-safe styling.
+ * Provides consistent badge styles across the application.
+ */
+const badgeVariants = cva(
+	"inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold whitespace-nowrap transition-colors",
+	{
+		variants: {
+			variant: {
+				default: "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300",
+				hot: "bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-[0_0_10px_rgba(251,146,60,0.5)]",
+				top: "bg-gradient-to-r from-violet-500 to-purple-500 text-white shadow-[0_0_10px_rgba(139,92,246,0.5)]",
+				new: "bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400 animate-pulse-new",
+				success: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+				info: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+				warning: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+				muted: "bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400",
+			},
+			size: {
+				sm: "px-1.5 py-0.5 text-xs",
+				md: "px-2 py-0.5 text-xs",
+				lg: "px-3 py-1 text-sm",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "md",
+		},
+	}
+);
+
+export interface BadgeProps
+	extends React.HTMLAttributes<HTMLSpanElement>,
+		VariantProps<typeof badgeVariants> {}
+
+/**
+ * A versatile badge component for status indicators, tags, and labels.
+ */
+export function Badge({ className, variant, size, ...props }: BadgeProps) {
+	return (
+		<span className={cn(badgeVariants({ variant, size }), className)} {...props} />
+	);
+}
+
+/**
+ * Pre-configured badges for common use cases
+ */
+export function HotBadge({ className, ...props }: Omit<BadgeProps, "variant">) {
+	return (
+		<Badge variant="hot" className={className} {...props}>
+			🔥 HOT
+		</Badge>
+	);
+}
+
+export function TopBadge({ className, ...props }: Omit<BadgeProps, "variant">) {
+	return (
+		<Badge variant="top" className={className} {...props}>
+			✨ TOP
+		</Badge>
+	);
+}
+
+export function NewBadge({ className, ...props }: Omit<BadgeProps, "variant">) {
+	return (
+		<Badge variant="new" className={className} {...props}>
+			NEW
+		</Badge>
+	);
+}
+
+export { badgeVariants };

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -1,0 +1,225 @@
+/**
+ * Reusable SVG icon components to reduce duplication and improve bundle size.
+ * All icons use currentColor for easy theming with Tailwind text colors.
+ */
+
+import { cn } from "@/lib/utils";
+
+interface IconProps extends React.SVGProps<SVGSVGElement> {
+	className?: string;
+}
+
+// Social media icons
+export function XIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-5", className)}
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			{...props}
+		>
+			<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+		</svg>
+	);
+}
+
+export function GitHubIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-5", className)}
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			{...props}
+		>
+			<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+		</svg>
+	);
+}
+
+export function LinkedInIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-5", className)}
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			{...props}
+		>
+			<path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+		</svg>
+	);
+}
+
+export function TelegramIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-5", className)}
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			{...props}
+		>
+			<path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
+		</svg>
+	);
+}
+
+// UI icons
+export function EmailIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-5", className)}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			{...props}
+		>
+			<rect x="2" y="4" width="20" height="16" rx="2" />
+			<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+		</svg>
+	);
+}
+
+export function WebsiteIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-5", className)}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			{...props}
+		>
+			<circle cx="12" cy="12" r="10" />
+			<line x1="2" y1="12" x2="22" y2="12" />
+			<path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+		</svg>
+	);
+}
+
+export function DocumentIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-5", className)}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			{...props}
+		>
+			<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+			<polyline points="14 2 14 8 20 8" />
+			<line x1="16" y1="13" x2="8" y2="13" />
+			<line x1="16" y1="17" x2="8" y2="17" />
+			<polyline points="10 9 9 9 8 9" />
+		</svg>
+	);
+}
+
+export function CloseIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-5", className)}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			{...props}
+		>
+			<line x1="18" y1="6" x2="6" y2="18" />
+			<line x1="6" y1="6" x2="18" y2="18" />
+		</svg>
+	);
+}
+
+export function ChevronDownIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-4", className)}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			{...props}
+		>
+			<path d="M19 9l-7 7-7-7" />
+		</svg>
+	);
+}
+
+export function ChevronRightIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-4", className)}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			{...props}
+		>
+			<polyline points="9 18 15 12 9 6" />
+		</svg>
+	);
+}
+
+export function LinkIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-5", className)}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			{...props}
+		>
+			<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+			<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+		</svg>
+	);
+}
+
+export function CheckIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-5", className)}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			{...props}
+		>
+			<polyline points="20 6 9 17 4 12" />
+		</svg>
+	);
+}
+
+export function SpinnerIcon({ className, ...props }: IconProps) {
+	return (
+		<svg
+			className={cn("size-5 animate-spin", className)}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			{...props}
+		>
+			<circle cx="12" cy="12" r="10" strokeOpacity="0.25" />
+			<path d="M12 2a10 10 0 0 1 10 10" strokeLinecap="round" />
+		</svg>
+	);
+}

--- a/src/components/ui/social-links.tsx
+++ b/src/components/ui/social-links.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import {
+	XIcon,
+	GitHubIcon,
+	LinkedInIcon,
+	TelegramIcon,
+	EmailIcon,
+	WebsiteIcon,
+	DocumentIcon,
+} from "./icons";
+
+interface Socials {
+	x?: string;
+	github?: string;
+	linkedin?: string;
+	telegram?: string;
+	email?: string;
+	website?: string;
+	cv?: string;
+}
+
+interface SocialLinksProps {
+	socials: Socials;
+	displayName: string;
+	variant?: "compact" | "expanded";
+	onSocialClick?: (platform: string, url: string) => void;
+	onCVClick?: () => void;
+	className?: string;
+}
+
+const linkBaseStyles =
+	"text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors";
+const compactLinkStyles = "p-2.5 sm:p-2";
+const expandedLinkStyles =
+	"flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700";
+
+/**
+ * Reusable social links component with consistent styling and accessibility.
+ * Supports both compact (icons only) and expanded (icons with labels) variants.
+ */
+export function SocialLinks({
+	socials,
+	displayName,
+	variant = "compact",
+	onSocialClick,
+	onCVClick,
+	className,
+}: SocialLinksProps) {
+	const isCompact = variant === "compact";
+	const linkStyles = isCompact
+		? cn(linkBaseStyles, compactLinkStyles)
+		: expandedLinkStyles;
+	const iconSize = isCompact ? "size-5 sm:size-4" : "size-5";
+
+	return (
+		<div
+			className={cn(
+				"flex items-center",
+				isCompact ? "gap-1" : "flex-wrap justify-center gap-3",
+				className
+			)}
+		>
+			{socials.x && (
+				<a
+					href={socials.x}
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={() => onSocialClick?.("x", socials.x!)}
+					className={linkStyles}
+					title="X"
+					aria-label={`X profile for ${displayName}`}
+				>
+					<XIcon className={iconSize} />
+					{!isCompact && <span>X</span>}
+				</a>
+			)}
+
+			{socials.github && (
+				<a
+					href={socials.github}
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={() => onSocialClick?.("github", socials.github!)}
+					className={linkStyles}
+					title="GitHub"
+					aria-label={`GitHub profile for ${displayName}`}
+				>
+					<GitHubIcon className={iconSize} />
+					{!isCompact && <span>GitHub</span>}
+				</a>
+			)}
+
+			{socials.linkedin && (
+				<a
+					href={socials.linkedin}
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={() => onSocialClick?.("linkedin", socials.linkedin!)}
+					className={linkStyles}
+					title="LinkedIn"
+					aria-label={`LinkedIn profile for ${displayName}`}
+				>
+					<LinkedInIcon className={iconSize} />
+					{!isCompact && <span>LinkedIn</span>}
+				</a>
+			)}
+
+			{socials.email && (
+				<a
+					href={`mailto:${socials.email}`}
+					onClick={() => onSocialClick?.("email", socials.email!)}
+					className={linkStyles}
+					title="Email"
+					aria-label={`Email ${displayName}`}
+				>
+					<EmailIcon className={iconSize} />
+					{!isCompact && <span>Email</span>}
+				</a>
+			)}
+
+			{socials.website && (
+				<a
+					href={socials.website}
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={() => onSocialClick?.("website", socials.website!)}
+					className={linkStyles}
+					title="Website"
+					aria-label={`Website for ${displayName}`}
+				>
+					<WebsiteIcon className={iconSize} />
+					{!isCompact && <span>Website</span>}
+				</a>
+			)}
+
+			{socials.telegram && (
+				<a
+					href={socials.telegram}
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={() => onSocialClick?.("telegram", socials.telegram!)}
+					className={linkStyles}
+					title="Telegram"
+					aria-label={`Telegram for ${displayName}`}
+				>
+					<TelegramIcon className={iconSize} />
+					{!isCompact && <span>Telegram</span>}
+				</a>
+			)}
+
+			{socials.cv && (
+				<a
+					href={socials.cv}
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={onCVClick}
+					className={cn(
+						linkStyles,
+						!isCompact && "bg-blue-600 text-white hover:bg-blue-700"
+					)}
+					title="CV / Resume"
+					aria-label={`CV or resume for ${displayName}`}
+				>
+					<DocumentIcon className={iconSize} />
+					{!isCompact && <span>View CV / Resume</span>}
+				</a>
+			)}
+		</div>
+	);
+}

--- a/src/hooks/useHotCandidates.ts
+++ b/src/hooks/useHotCandidates.ts
@@ -1,0 +1,90 @@
+import { useState, useEffect, useCallback } from "react";
+import type { Candidate, SkillTag } from "@/data/candidates";
+
+interface UseHotCandidatesReturn {
+	/** Set of candidate IDs that are currently "hot" based on analytics */
+	dataHotCandidateIds: Set<string>;
+	/** Whether the hot candidates data has finished loading */
+	hotDataLoaded: boolean;
+	/** Check if a candidate is hot (analytics-driven OR has hot skill tag) */
+	isHotCandidate: (candidate: Candidate) => boolean;
+	/** Check if a candidate has the TOP skill tag (for badge display) */
+	hasTopTag: (candidate: Candidate) => boolean;
+	/** Check if a candidate should show TOP card styling (waits for hot data to prevent flicker) */
+	showTopCardStyle: (candidate: Candidate) => boolean;
+}
+
+/**
+ * Hook to fetch and manage "hot" candidate status.
+ *
+ * Hot candidates are determined by:
+ * 1. Analytics data from PostHog (candidates with high recent views)
+ * 2. Explicit "hot" skill tag in the database
+ *
+ * This hook also manages TOP badge styling logic to prevent the purple→orange
+ * flicker that would occur if we showed TOP styling before knowing if a
+ * candidate is also HOT.
+ */
+export function useHotCandidates(): UseHotCandidatesReturn {
+	const [dataHotCandidateIds, setDataHotCandidateIds] = useState<Set<string>>(new Set());
+	const [hotDataLoaded, setHotDataLoaded] = useState(false);
+
+	// Fetch data-driven hot candidates from analytics
+	useEffect(() => {
+		const controller = new AbortController();
+
+		fetch("/api/hot-candidates", { signal: controller.signal })
+			.then((res) => res.json())
+			.then((data) => {
+				if (data.hotCandidateIds) {
+					setDataHotCandidateIds(new Set(data.hotCandidateIds));
+				}
+			})
+			.catch((error) => {
+				// Silently fail - hot candidates badge is non-critical
+				// Only log if not aborted
+				if (error.name !== "AbortError") {
+					console.debug("Failed to fetch hot candidates:", error);
+				}
+			})
+			.finally(() => {
+				setHotDataLoaded(true);
+			});
+
+		return () => controller.abort();
+	}, []);
+
+	// Check if candidate is hot (data-driven OR has hot skill tag)
+	const isHotCandidate = useCallback(
+		(candidate: Candidate) =>
+			dataHotCandidateIds.has(candidate.id) ||
+			candidate.skills?.includes("hot" as SkillTag) === true,
+		[dataHotCandidateIds]
+	);
+
+	// Check if candidate has TOP skill tag (for badge display)
+	const hasTopTag = useCallback(
+		(candidate: Candidate) =>
+			candidate.skills?.includes("top" as SkillTag) === true,
+		[]
+	);
+
+	// Check if candidate should show TOP card styling (background/border)
+	// Wait for hot data to prevent purple→orange flicker
+	const showTopCardStyle = useCallback(
+		(candidate: Candidate) => {
+			if (!hotDataLoaded) return false;
+			if (!hasTopTag(candidate)) return false;
+			return !isHotCandidate(candidate);
+		},
+		[hotDataLoaded, hasTopTag, isHotCandidate]
+	);
+
+	return {
+		dataHotCandidateIds,
+		hotDataLoaded,
+		isHotCandidate,
+		hasTopTag,
+		showTopCardStyle,
+	};
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,21 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Merge Tailwind CSS classes with proper precedence.
+ * Uses clsx for conditional classes and tailwind-merge to resolve conflicts.
+ */
+export function cn(...inputs: ClassValue[]) {
+	return twMerge(clsx(inputs));
+}
+
+/**
+ * Standard focus ring styles for consistent accessibility.
+ */
+export const focusRing =
+	"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 dark:focus-visible:ring-neutral-600 focus-visible:ring-offset-2";
+
+/**
+ * Standard disabled styles for form elements and buttons.
+ */
+export const disabledStyles = "disabled:pointer-events-none disabled:opacity-50";

--- a/tests/candidates.spec.ts
+++ b/tests/candidates.spec.ts
@@ -72,3 +72,232 @@ test.describe("Candidates Page", () => {
     await expect(searchInput).toHaveValue("");
   });
 });
+
+test.describe("HOT/TOP Badge Display", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/candidates");
+    // Wait for hydration
+    await page.waitForSelector('[data-testid="candidates-grid"][data-hydrated="true"]');
+  });
+
+  test("should display HOT badge with fire emoji and orange gradient", async ({ page }) => {
+    // Look for any HOT badges on the page
+    const hotBadges = page.locator('span:has-text("🔥 HOT")');
+    const hotBadgeCount = await hotBadges.count();
+
+    if (hotBadgeCount > 0) {
+      const firstHotBadge = hotBadges.first();
+      await expect(firstHotBadge).toBeVisible();
+
+      // Verify the badge has the correct gradient classes
+      await expect(firstHotBadge).toHaveClass(/from-orange-500/);
+      await expect(firstHotBadge).toHaveClass(/to-amber-500/);
+    }
+    // If no HOT candidates, test passes (they may not exist in test data)
+  });
+
+  test("should display TOP badge with sparkle emoji and purple gradient", async ({ page }) => {
+    // Look for any TOP badges on the page
+    const topBadges = page.locator('span:has-text("✨ TOP")');
+    const topBadgeCount = await topBadges.count();
+
+    if (topBadgeCount > 0) {
+      const firstTopBadge = topBadges.first();
+      await expect(firstTopBadge).toBeVisible();
+
+      // Verify the badge has the correct gradient classes
+      await expect(firstTopBadge).toHaveClass(/from-violet-500/);
+      await expect(firstTopBadge).toHaveClass(/to-purple-500/);
+    }
+    // If no TOP candidates, test passes (they may not exist in test data)
+  });
+
+  test("should display both HOT and TOP badges when candidate has both tags", async ({ page }) => {
+    // Find cards that have both badges
+    const cards = page.locator('.rounded-xl.border');
+    const cardCount = await cards.count();
+
+    for (let i = 0; i < cardCount; i++) {
+      const card = cards.nth(i);
+      const hasHot = await card.locator('span:has-text("🔥 HOT")').count() > 0;
+      const hasTop = await card.locator('span:has-text("✨ TOP")').count() > 0;
+
+      if (hasHot && hasTop) {
+        // Found a card with both badges - verify both are visible
+        await expect(card.locator('span:has-text("🔥 HOT")')).toBeVisible();
+        await expect(card.locator('span:has-text("✨ TOP")')).toBeVisible();
+        break;
+      }
+    }
+    // If no candidates with both tags, test passes
+  });
+
+  test("HOT candidates should have orange card styling", async ({ page }) => {
+    // Wait for the hot candidates API to respond
+    await page.waitForResponse(
+      (response) => response.url().includes("/api/hot-candidates"),
+      { timeout: 5000 }
+    ).catch(() => {
+      // API may not be called if mocked or unavailable
+    });
+
+    // Find cards with HOT badge
+    const hotCards = page.locator('.rounded-xl.border:has(span:has-text("🔥 HOT"))');
+    const count = await hotCards.count();
+
+    if (count > 0) {
+      const firstHotCard = hotCards.first();
+      // Hot cards should have orange border styling
+      await expect(firstHotCard).toHaveClass(/border-orange-500|from-orange-100/);
+    }
+  });
+
+  test("should filter by HOT skill tag", async ({ page }) => {
+    // Open skill filter
+    const filterButton = page.getByRole("button", { name: /Filter by skills/ });
+
+    if (await filterButton.isVisible()) {
+      await filterButton.click();
+
+      // Look for HOT filter button in expanded tags
+      const hotTagButton = page.locator('button:has-text("HOT")').first();
+
+      if (await hotTagButton.isVisible()) {
+        await hotTagButton.click();
+
+        // Wait for filter to apply
+        await page.waitForTimeout(300);
+
+        // All visible candidates should have the hot tag badge
+        const candidateCards = page.locator('.rounded-xl.border');
+        const count = await candidateCards.count();
+
+        // If there are results, each should have HOT badge
+        if (count > 0) {
+          for (let i = 0; i < Math.min(count, 3); i++) {
+            const card = candidateCards.nth(i);
+            await expect(card.locator('span:has-text("🔥 HOT")')).toBeVisible();
+          }
+        }
+      }
+    }
+  });
+
+  test("should filter by TOP skill tag", async ({ page }) => {
+    // Open skill filter
+    const filterButton = page.getByRole("button", { name: /Filter by skills/ });
+
+    if (await filterButton.isVisible()) {
+      await filterButton.click();
+
+      // Look for TOP filter button in expanded tags
+      const topTagButton = page.locator('button:has-text("TOP")').first();
+
+      if (await topTagButton.isVisible()) {
+        await topTagButton.click();
+
+        // Wait for filter to apply
+        await page.waitForTimeout(300);
+
+        // All visible candidates should have the top tag badge
+        const candidateCards = page.locator('.rounded-xl.border');
+        const count = await candidateCards.count();
+
+        // If there are results, each should have TOP badge
+        if (count > 0) {
+          for (let i = 0; i < Math.min(count, 3); i++) {
+            const card = candidateCards.nth(i);
+            await expect(card.locator('span:has-text("✨ TOP")')).toBeVisible();
+          }
+        }
+      }
+    }
+  });
+});
+
+test.describe("Candidate Card Expanded View Badges", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/candidates");
+    await page.waitForSelector('[data-testid="candidates-grid"][data-hydrated="true"]');
+  });
+
+  test("should show badges in expanded view", async ({ page }) => {
+    // Find first candidate card and click View Details
+    const viewDetailsButton = page.getByRole("button", { name: "View Details" }).first();
+
+    if (await viewDetailsButton.isVisible()) {
+      await viewDetailsButton.click();
+
+      // Wait for modal to open
+      await expect(page.locator('[role="dialog"]')).toBeVisible();
+
+      // Check if badges are visible in the expanded view (if candidate has them)
+      const modal = page.locator('[role="dialog"]');
+      const hasHotBadge = await modal.locator('span:has-text("🔥 HOT")').count() > 0;
+      const hasTopBadge = await modal.locator('span:has-text("✨ TOP")').count() > 0;
+
+      // Verify badges match between card and expanded view
+      // (The presence/absence should be consistent)
+      if (hasHotBadge) {
+        await expect(modal.locator('span:has-text("🔥 HOT")')).toBeVisible();
+      }
+      if (hasTopBadge) {
+        await expect(modal.locator('span:has-text("✨ TOP")')).toBeVisible();
+      }
+
+      // Close modal
+      await page.keyboard.press("Escape");
+    }
+  });
+
+  test("expanded view header should have correct gradient for HOT candidates", async ({ page }) => {
+    // Find a HOT candidate card
+    const hotCard = page.locator('.rounded-xl.border:has(span:has-text("🔥 HOT"))').first();
+
+    if (await hotCard.isVisible()) {
+      // Click View Details
+      await hotCard.getByRole("button", { name: "View Details" }).click();
+
+      // Wait for modal
+      await expect(page.locator('[role="dialog"]')).toBeVisible();
+
+      // The header section should have orange gradient
+      const headerSection = page.locator('[role="dialog"] .bg-gradient-to-r').first();
+      await expect(headerSection).toHaveClass(/from-orange-100|from-orange-900/);
+
+      await page.keyboard.press("Escape");
+    }
+  });
+
+  test("expanded view header should have correct gradient for TOP-only candidates", async ({ page }) => {
+    // Wait for hot candidates API to load
+    await page.waitForResponse(
+      (response) => response.url().includes("/api/hot-candidates"),
+      { timeout: 5000 }
+    ).catch(() => {});
+
+    // Find a card that has TOP but not HOT badge
+    const cards = page.locator('.rounded-xl.border');
+    const cardCount = await cards.count();
+
+    for (let i = 0; i < cardCount; i++) {
+      const card = cards.nth(i);
+      const hasHot = await card.locator('span:has-text("🔥 HOT")').count() > 0;
+      const hasTop = await card.locator('span:has-text("✨ TOP")').count() > 0;
+
+      if (hasTop && !hasHot) {
+        // Found TOP-only card
+        await card.getByRole("button", { name: "View Details" }).click();
+
+        await expect(page.locator('[role="dialog"]')).toBeVisible();
+
+        // The header section should have purple gradient
+        const headerSection = page.locator('[role="dialog"] .bg-gradient-to-r').first();
+        await expect(headerSection).toHaveClass(/from-violet-100|from-violet-900/);
+
+        await page.keyboard.press("Escape");
+        break;
+      }
+    }
+  });
+});


### PR DESCRIPTION
Improved loading experience by pre-rendering filter UI immediately:
- Filters (selects, buttons, search inputs) now render as static elements without animation, making the page feel more responsive
- Only actual data items (jobs, candidates, investments, news) show loading skeletons
- Added new static filter components: JobsFiltersStatic, CandidatesFiltersStatic, PortfolioFiltersStatic, NewsFiltersStatic
- Added JobCardSkeleton for job list items

This makes the site feel snappier since users see the full filter UI immediately and only wait for the actual data to load.