### PR TITLE
feat: add individual OpenGraph images for candidates and jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env*.local

--- a/src/app/blog/[slug]/opengraph-image.tsx
+++ b/src/app/blog/[slug]/opengraph-image.tsx
@@ -37,11 +37,11 @@ export default async function Image({ params }: Props) {
 				}}
 			>
 				{/* Top: Author info */}
-				<div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+				<div style={{ display: "flex", alignItems: "center", gap: 24 }}>
 					<div
 						style={{
-							width: 56,
-							height: 56,
+							width: 88,
+							height: 88,
 							borderRadius: "50%",
 							overflow: "hidden",
 							display: "flex",
@@ -50,16 +50,16 @@ export default async function Image({ params }: Props) {
 					<img
 							src="https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png"
 							alt="dcbuilder"
-							width={56}
-							height={56}
+							width={88}
+							height={88}
 							style={{ objectFit: "cover" }}
 						/>
 					</div>
 					<div style={{ display: "flex", flexDirection: "column" }}>
-						<span style={{ color: "#ffffff", fontSize: 24, fontWeight: 600 }}>
+						<span style={{ color: "#ffffff", fontSize: 42, fontWeight: 600 }}>
 							dcbuilder.eth
 						</span>
-						<span style={{ color: "#666", fontSize: 18 }}>dcbuilder.dev</span>
+						<span style={{ color: "#ccc", fontSize: 34 }}>dcbuilder.dev</span>
 					</div>
 				</div>
 
@@ -68,12 +68,12 @@ export default async function Image({ params }: Props) {
 					style={{
 						display: "flex",
 						flexDirection: "column",
-						gap: 16,
+						gap: 20,
 					}}
 				>
 					<div
 						style={{
-							fontSize: title.length > 50 ? 48 : 56,
+							fontSize: title.length > 50 ? 62 : 74,
 							fontWeight: 700,
 							color: "#ffffff",
 							lineHeight: 1.2,
@@ -83,7 +83,7 @@ export default async function Image({ params }: Props) {
 						{title}
 					</div>
 					{date && (
-						<div style={{ fontSize: 24, color: "#666" }}>
+						<div style={{ fontSize: 36, color: "#ddd" }}>
 							{date}
 						</div>
 					)}
@@ -93,11 +93,11 @@ export default async function Image({ params }: Props) {
 				<div style={{ display: "flex" }}>
 					<div
 						style={{
-							padding: "10px 24px",
-							borderRadius: 24,
+							padding: "16px 36px",
+							borderRadius: 32,
 							backgroundColor: "#1a1a2e",
-							color: "#888",
-							fontSize: 20,
+							color: "#ddd",
+							fontSize: 36,
 						}}
 					>
 						Blog

--- a/src/app/blog/opengraph-image.tsx
+++ b/src/app/blog/opengraph-image.tsx
@@ -28,8 +28,8 @@ export default async function Image() {
 				{/* Icon */}
 				<div
 					style={{
-						fontSize: 80,
-						marginBottom: 24,
+						fontSize: 100,
+						marginBottom: 32,
 					}}
 				>
 					📝
@@ -38,10 +38,10 @@ export default async function Image() {
 				{/* Title */}
 				<div
 					style={{
-						fontSize: 72,
+						fontSize: 84,
 						fontWeight: 700,
 						color: "#ffffff",
-						marginBottom: 16,
+						marginBottom: 20,
 					}}
 				>
 					Blog | dcbuilder.eth
@@ -50,11 +50,11 @@ export default async function Image() {
 				{/* Description */}
 				<div
 					style={{
-						fontSize: 24,
-						color: "#666",
-						marginTop: 32,
+						fontSize: 36,
+						color: "#ddd",
+						marginTop: 36,
 						textAlign: "center",
-						maxWidth: 700,
+						maxWidth: 800,
 					}}
 				>
 					Thoughts on cryptography, distributed systems, and building the future

--- a/src/app/candidates/[id]/opengraph-image.tsx
+++ b/src/app/candidates/[id]/opengraph-image.tsx
@@ -89,31 +89,84 @@ export default async function Image({ params }: Props) {
 					padding: 60,
 				}}
 			>
-				{/* Top: Site branding */}
-				<div style={{ display: "flex", alignItems: "center", gap: 24 }}>
-					<div
-						style={{
-							width: 88,
-							height: 88,
-							borderRadius: "50%",
-							overflow: "hidden",
-							display: "flex",
-						}}
-					>
-						<img
-							src="https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png"
-							alt="dcbuilder"
-							width={88}
-							height={88}
-							style={{ objectFit: "cover" }}
-						/>
+				{/* Top: Site branding + Badges */}
+				<div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between" }}>
+					{/* Left: Branding */}
+					<div style={{ display: "flex", alignItems: "center", gap: 24 }}>
+						<div
+							style={{
+								width: 88,
+								height: 88,
+								borderRadius: "50%",
+								overflow: "hidden",
+								display: "flex",
+							}}
+						>
+							<img
+								src="https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png"
+								alt="dcbuilder"
+								width={88}
+								height={88}
+								style={{ objectFit: "cover" }}
+							/>
+						</div>
+						<div style={{ display: "flex", flexDirection: "column" }}>
+							<span style={{ color: "#ffffff", fontSize: 42, fontWeight: 600 }}>
+								dcbuilder.eth
+							</span>
+							<span style={{ color: "#ccc", fontSize: 34 }}>Candidates</span>
+						</div>
 					</div>
-					<div style={{ display: "flex", flexDirection: "column" }}>
-						<span style={{ color: "#ffffff", fontSize: 42, fontWeight: 600 }}>
-							dcbuilder.eth
-						</span>
-						<span style={{ color: "#ccc", fontSize: 34 }}>Candidates</span>
-					</div>
+					{/* Right: Badges */}
+					{(isHot || isTop || isNewCandidate) && (
+						<div style={{ display: "flex", gap: 12 }}>
+							{isHot && (
+								<div
+									style={{
+										display: "flex",
+										padding: "12px 24px",
+										borderRadius: 28,
+										background: "linear-gradient(to right, #f97316, #f59e0b)",
+										color: "#ffffff",
+										fontSize: 32,
+										fontWeight: 700,
+									}}
+								>
+									<span>🔥 HOT</span>
+								</div>
+							)}
+							{isTop && (
+								<div
+									style={{
+										display: "flex",
+										padding: "12px 24px",
+										borderRadius: 28,
+										background: "linear-gradient(to right, #8b5cf6, #a855f7)",
+										color: "#ffffff",
+										fontSize: 32,
+										fontWeight: 700,
+									}}
+								>
+									<span>⭐ TOP</span>
+								</div>
+							)}
+							{isNewCandidate && (
+								<div
+									style={{
+										display: "flex",
+										padding: "12px 24px",
+										borderRadius: 28,
+										backgroundColor: "#e0f2fe",
+										color: "#0369a1",
+										fontSize: 32,
+										fontWeight: 700,
+									}}
+								>
+									<span>NEW</span>
+								</div>
+							)}
+						</div>
+					)}
 				</div>
 
 				{/* Middle: Candidate info */}
@@ -171,66 +224,17 @@ export default async function Image({ params }: Props) {
 							gap: 16,
 						}}
 					>
-						{/* Name with badges */}
-						<div style={{ display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
-							<div
-								style={{
-									fontSize: name.length > 20 ? 62 : 74,
-									fontWeight: 700,
-									color: "#ffffff",
-									lineHeight: 1.1,
-								}}
-							>
-								{name}
-							</div>
-							{/* HOT badge */}
-							{isHot && (
-								<div
-									style={{
-										display: "flex",
-										padding: "8px 20px",
-										borderRadius: 24,
-										background: "linear-gradient(to right, #f97316, #f59e0b)",
-										color: "#ffffff",
-										fontSize: 28,
-										fontWeight: 700,
-									}}
-								>
-									<span>🔥 HOT</span>
-								</div>
-							)}
-							{/* TOP badge */}
-							{isTop && (
-								<div
-									style={{
-										display: "flex",
-										padding: "8px 20px",
-										borderRadius: 24,
-										background: "linear-gradient(to right, #8b5cf6, #a855f7)",
-										color: "#ffffff",
-										fontSize: 28,
-										fontWeight: 700,
-									}}
-								>
-									<span>⭐ TOP</span>
-								</div>
-							)}
-							{/* NEW badge */}
-							{isNewCandidate && (
-								<div
-									style={{
-										display: "flex",
-										padding: "8px 20px",
-										borderRadius: 24,
-										backgroundColor: "#e0f2fe",
-										color: "#0369a1",
-										fontSize: 28,
-										fontWeight: 700,
-									}}
-								>
-									<span>NEW</span>
-								</div>
-							)}
+						{/* Name */}
+						<div
+							style={{
+								fontSize: name.length > 25 ? 54 : name.length > 20 ? 62 : 74,
+								fontWeight: 700,
+								color: "#ffffff",
+								lineHeight: 1.1,
+								maxWidth: 700,
+							}}
+						>
+							{name}
 						</div>
 						{title && (
 							<div

--- a/src/app/candidates/[id]/opengraph-image.tsx
+++ b/src/app/candidates/[id]/opengraph-image.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from "next/og";
 import { getCandidateById } from "@/lib/data";
+import { isNew } from "@/lib/shuffle";
 
 export const runtime = "nodejs";
 
@@ -9,15 +10,6 @@ export const size = {
 	height: 630,
 };
 export const contentType = "image/png";
-
-// Check if created within last 14 days
-function isNew(createdAt: Date | string | null | undefined): boolean {
-	if (!createdAt) return false;
-	const date = new Date(createdAt);
-	const now = new Date();
-	const diffDays = (now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24);
-	return diffDays <= 14;
-}
 
 interface Props {
 	params: Promise<{ id: string }>;

--- a/src/app/candidates/[id]/opengraph-image.tsx
+++ b/src/app/candidates/[id]/opengraph-image.tsx
@@ -67,11 +67,11 @@ export default async function Image({ params }: Props) {
 				}}
 			>
 				{/* Top: Site branding */}
-				<div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+				<div style={{ display: "flex", alignItems: "center", gap: 24 }}>
 					<div
 						style={{
-							width: 48,
-							height: 48,
+							width: 88,
+							height: 88,
 							borderRadius: "50%",
 							overflow: "hidden",
 							display: "flex",
@@ -80,16 +80,16 @@ export default async function Image({ params }: Props) {
 						<img
 							src="https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png"
 							alt="dcbuilder"
-							width={48}
-							height={48}
+							width={88}
+							height={88}
 							style={{ objectFit: "cover" }}
 						/>
 					</div>
 					<div style={{ display: "flex", flexDirection: "column" }}>
-						<span style={{ color: "#ffffff", fontSize: 20, fontWeight: 600 }}>
+						<span style={{ color: "#ffffff", fontSize: 42, fontWeight: 600 }}>
 							dcbuilder.eth
 						</span>
-						<span style={{ color: "#666", fontSize: 16 }}>Candidates</span>
+						<span style={{ color: "#ccc", fontSize: 34 }}>Candidates</span>
 					</div>
 				</div>
 
@@ -98,15 +98,15 @@ export default async function Image({ params }: Props) {
 					style={{
 						display: "flex",
 						alignItems: "center",
-						gap: 40,
+						gap: 48,
 					}}
 				>
 					{/* Candidate image */}
 					{image ? (
 						<div
 							style={{
-								width: 180,
-								height: 180,
+								width: 240,
+								height: 240,
 								borderRadius: "50%",
 								overflow: "hidden",
 								display: "flex",
@@ -117,22 +117,22 @@ export default async function Image({ params }: Props) {
 							<img
 								src={image}
 								alt={name}
-								width={180}
-								height={180}
+								width={240}
+								height={240}
 								style={{ objectFit: "cover" }}
 							/>
 						</div>
 					) : (
 						<div
 							style={{
-								width: 180,
-								height: 180,
+								width: 240,
+								height: 240,
 								borderRadius: "50%",
 								backgroundColor: "#1a1a2e",
 								display: "flex",
 								alignItems: "center",
 								justifyContent: "center",
-								fontSize: 72,
+								fontSize: 96,
 								flexShrink: 0,
 							}}
 						>
@@ -145,12 +145,12 @@ export default async function Image({ params }: Props) {
 						style={{
 							display: "flex",
 							flexDirection: "column",
-							gap: 12,
+							gap: 16,
 						}}
 					>
 						<div
 							style={{
-								fontSize: name.length > 20 ? 48 : 56,
+								fontSize: name.length > 20 ? 62 : 74,
 								fontWeight: 700,
 								color: "#ffffff",
 								lineHeight: 1.1,
@@ -161,8 +161,8 @@ export default async function Image({ params }: Props) {
 						{title && (
 							<div
 								style={{
-									fontSize: 28,
-									color: "#a855f7",
+									fontSize: 42,
+									color: "#c084fc",
 									lineHeight: 1.2,
 									maxWidth: 700,
 								}}
@@ -174,16 +174,16 @@ export default async function Image({ params }: Props) {
 				</div>
 
 				{/* Bottom: Skills */}
-				<div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+				<div style={{ display: "flex", gap: 18, flexWrap: "wrap" }}>
 					{skills.map((skill) => (
 						<div
 							key={skill}
 							style={{
-								padding: "8px 20px",
-								borderRadius: 20,
+								padding: "16px 36px",
+								borderRadius: 32,
 								backgroundColor: "#1a1a2e",
-								color: "#888",
-								fontSize: 18,
+								color: "#ddd",
+								fontSize: 36,
 							}}
 						>
 							{skill}

--- a/src/app/candidates/[id]/opengraph-image.tsx
+++ b/src/app/candidates/[id]/opengraph-image.tsx
@@ -1,6 +1,5 @@
 import { ImageResponse } from "next/og";
-import { db, candidates, candidateRedirects } from "@/db";
-import { eq } from "drizzle-orm";
+import { getCandidateById } from "@/lib/data";
 
 export const runtime = "nodejs";
 
@@ -15,36 +14,9 @@ interface Props {
 	params: Promise<{ id: string }>;
 }
 
-async function getCandidate(id: string) {
-	let [candidate] = await db
-		.select()
-		.from(candidates)
-		.where(eq(candidates.id, id))
-		.limit(1);
-
-	// Check for redirect if not found
-	if (!candidate) {
-		const [redirectEntry] = await db
-			.select()
-			.from(candidateRedirects)
-			.where(eq(candidateRedirects.oldId, id))
-			.limit(1);
-
-		if (redirectEntry) {
-			[candidate] = await db
-				.select()
-				.from(candidates)
-				.where(eq(candidates.id, redirectEntry.newId))
-				.limit(1);
-		}
-	}
-
-	return candidate;
-}
-
 export default async function Image({ params }: Props) {
 	const { id } = await params;
-	const candidate = await getCandidate(id);
+	const candidate = await getCandidateById(id);
 
 	const name = candidate?.name || "Candidate";
 	const title = candidate?.title || "";

--- a/src/app/candidates/[id]/opengraph-image.tsx
+++ b/src/app/candidates/[id]/opengraph-image.tsx
@@ -10,6 +10,44 @@ export const size = {
 };
 export const contentType = "image/png";
 
+// Skill priority for OG images - lower index = higher priority
+// Most relevant/recognizable skills should appear first
+const skillPriority: string[] = [
+	// Special tags
+	"hot", "top",
+	// Core blockchain languages
+	"Solidity", "Rust", "Cairo", "Move",
+	// Blockchain-specific
+	"EVM", "ZKP", "Protocol", "DeFi", "MEV", "Cryptography",
+	// Core programming languages
+	"TypeScript", "Python", "JavaScript", "Go", "Java", "C", "C++",
+	// Technical domains
+	"AI", "ML", "Security", "Research", "Infrastructure",
+	// Development roles
+	"Full Stack", "Frontend", "Backend", "Mobile",
+	// Frameworks & tools
+	"React", "Node.js", "Reth", "Alloy", "Anchor",
+];
+
+function sortSkillsByRelevance(skills: string[]): string[] {
+	return [...skills].sort((a, b) => {
+		const aIndex = skillPriority.findIndex(
+			(s) => s.toLowerCase() === a.toLowerCase()
+		);
+		const bIndex = skillPriority.findIndex(
+			(s) => s.toLowerCase() === b.toLowerCase()
+		);
+		// If both are in priority list, sort by priority
+		if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
+		// If only a is in priority list, a comes first
+		if (aIndex !== -1) return -1;
+		// If only b is in priority list, b comes first
+		if (bIndex !== -1) return 1;
+		// If neither is in priority list, maintain original order
+		return 0;
+	});
+}
+
 interface Props {
 	params: Promise<{ id: string }>;
 }
@@ -20,7 +58,8 @@ export default async function Image({ params }: Props) {
 
 	const name = candidate?.name || "Candidate";
 	const title = candidate?.title || "";
-	const skills = candidate?.skills?.slice(0, 5) || [];
+	const rawSkills = candidate?.skills || [];
+	const skills = sortSkillsByRelevance(rawSkills).slice(0, 5);
 	const image = candidate?.image;
 
 	return new ImageResponse(

--- a/src/app/candidates/[id]/opengraph-image.tsx
+++ b/src/app/candidates/[id]/opengraph-image.tsx
@@ -10,43 +10,6 @@ export const size = {
 };
 export const contentType = "image/png";
 
-// Skill priority for OG images - lower index = higher priority
-// Most relevant/recognizable skills should appear first
-// Note: "hot" and "top" are shown as special badges, not regular skills
-const skillPriority: string[] = [
-	// Core blockchain languages
-	"Solidity", "Rust", "Cairo", "Move",
-	// Blockchain-specific
-	"EVM", "ZKP", "Protocol", "DeFi", "MEV", "Cryptography",
-	// Core programming languages
-	"TypeScript", "Python", "JavaScript", "Go", "Java", "C", "C++",
-	// Technical domains
-	"AI", "ML", "Security", "Research", "Infrastructure",
-	// Development roles
-	"Full Stack", "Frontend", "Backend", "Mobile",
-	// Frameworks & tools
-	"React", "Node.js", "Reth", "Alloy", "Anchor",
-];
-
-function sortSkillsByRelevance(skills: string[]): string[] {
-	return [...skills].sort((a, b) => {
-		const aIndex = skillPriority.findIndex(
-			(s) => s.toLowerCase() === a.toLowerCase()
-		);
-		const bIndex = skillPriority.findIndex(
-			(s) => s.toLowerCase() === b.toLowerCase()
-		);
-		// If both are in priority list, sort by priority
-		if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
-		// If only a is in priority list, a comes first
-		if (aIndex !== -1) return -1;
-		// If only b is in priority list, b comes first
-		if (bIndex !== -1) return 1;
-		// If neither is in priority list, maintain original order
-		return 0;
-	});
-}
-
 // Check if created within last 14 days
 function isNew(createdAt: Date | string | null | undefined): boolean {
 	if (!createdAt) return false;
@@ -70,8 +33,10 @@ export default async function Image({ params }: Props) {
 	const isHot = allSkills.some(s => s.toLowerCase() === "hot");
 	const isTop = allSkills.some(s => s.toLowerCase() === "top");
 	const isNewCandidate = isNew(candidate?.createdAt);
-	const rawSkills = allSkills.filter(s => s.toLowerCase() !== "hot" && s.toLowerCase() !== "top");
-	const skills = sortSkillsByRelevance(rawSkills).slice(0, 5);
+	// Filter out hot/top (shown as badges) and take first 5 skills as ordered in DB
+	const skills = allSkills
+		.filter(s => s.toLowerCase() !== "hot" && s.toLowerCase() !== "top")
+		.slice(0, 5);
 	const image = candidate?.image;
 
 	return new ImageResponse(

--- a/src/app/candidates/[id]/opengraph-image.tsx
+++ b/src/app/candidates/[id]/opengraph-image.tsx
@@ -12,9 +12,8 @@ export const contentType = "image/png";
 
 // Skill priority for OG images - lower index = higher priority
 // Most relevant/recognizable skills should appear first
+// Note: "hot" and "top" are shown as special badges, not regular skills
 const skillPriority: string[] = [
-	// Special tags
-	"hot", "top",
 	// Core blockchain languages
 	"Solidity", "Rust", "Cairo", "Move",
 	// Blockchain-specific
@@ -48,6 +47,15 @@ function sortSkillsByRelevance(skills: string[]): string[] {
 	});
 }
 
+// Check if created within last 14 days
+function isNew(createdAt: Date | string | null | undefined): boolean {
+	if (!createdAt) return false;
+	const date = new Date(createdAt);
+	const now = new Date();
+	const diffDays = (now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24);
+	return diffDays <= 14;
+}
+
 interface Props {
 	params: Promise<{ id: string }>;
 }
@@ -58,7 +66,11 @@ export default async function Image({ params }: Props) {
 
 	const name = candidate?.name || "Candidate";
 	const title = candidate?.title || "";
-	const rawSkills = candidate?.skills || [];
+	const allSkills = candidate?.skills || [];
+	const isHot = allSkills.some(s => s.toLowerCase() === "hot");
+	const isTop = allSkills.some(s => s.toLowerCase() === "top");
+	const isNewCandidate = isNew(candidate?.createdAt);
+	const rawSkills = allSkills.filter(s => s.toLowerCase() !== "hot" && s.toLowerCase() !== "top");
 	const skills = sortSkillsByRelevance(rawSkills).slice(0, 5);
 	const image = candidate?.image;
 
@@ -159,15 +171,66 @@ export default async function Image({ params }: Props) {
 							gap: 16,
 						}}
 					>
-						<div
-							style={{
-								fontSize: name.length > 20 ? 62 : 74,
-								fontWeight: 700,
-								color: "#ffffff",
-								lineHeight: 1.1,
-							}}
-						>
-							{name}
+						{/* Name with badges */}
+						<div style={{ display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
+							<div
+								style={{
+									fontSize: name.length > 20 ? 62 : 74,
+									fontWeight: 700,
+									color: "#ffffff",
+									lineHeight: 1.1,
+								}}
+							>
+								{name}
+							</div>
+							{/* HOT badge */}
+							{isHot && (
+								<div
+									style={{
+										display: "flex",
+										padding: "8px 20px",
+										borderRadius: 24,
+										background: "linear-gradient(to right, #f97316, #f59e0b)",
+										color: "#ffffff",
+										fontSize: 28,
+										fontWeight: 700,
+									}}
+								>
+									<span>🔥 HOT</span>
+								</div>
+							)}
+							{/* TOP badge */}
+							{isTop && (
+								<div
+									style={{
+										display: "flex",
+										padding: "8px 20px",
+										borderRadius: 24,
+										background: "linear-gradient(to right, #8b5cf6, #a855f7)",
+										color: "#ffffff",
+										fontSize: 28,
+										fontWeight: 700,
+									}}
+								>
+									<span>⭐ TOP</span>
+								</div>
+							)}
+							{/* NEW badge */}
+							{isNewCandidate && (
+								<div
+									style={{
+										display: "flex",
+										padding: "8px 20px",
+										borderRadius: 24,
+										backgroundColor: "#e0f2fe",
+										color: "#0369a1",
+										fontSize: 28,
+										fontWeight: 700,
+									}}
+								>
+									<span>NEW</span>
+								</div>
+							)}
 						</div>
 						{title && (
 							<div

--- a/src/app/candidates/[id]/page.tsx
+++ b/src/app/candidates/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { getCandidateById } from "@/lib/data";
+import { getCandidateById, getBaseUrl } from "@/lib/data";
 
 interface Props {
 	params: Promise<{ id: string }>;
@@ -13,9 +13,23 @@ export async function generateMetadata({ params }: Props) {
 		return { title: "Candidate Not Found" };
 	}
 
+	const baseUrl = getBaseUrl();
+	const description = candidate.summary || `${candidate.name} - ${candidate.title || "Candidate"}`;
+
 	return {
 		title: `${candidate.name} | Candidates`,
-		description: candidate.summary || `${candidate.name} - ${candidate.title || "Candidate"}`,
+		description,
+		openGraph: {
+			title: `${candidate.name} | Candidates`,
+			description,
+			images: [`${baseUrl}/candidates/${candidate.id}/opengraph-image`],
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: `${candidate.name} | Candidates`,
+			description,
+			images: [`${baseUrl}/candidates/${candidate.id}/opengraph-image`],
+		},
 	};
 }
 

--- a/src/app/candidates/opengraph-image.tsx
+++ b/src/app/candidates/opengraph-image.tsx
@@ -25,24 +25,24 @@ export default async function Image() {
 						"radial-gradient(circle at 50% 100%, #2e1a2e 0%, #0a0a0a 50%)",
 				}}
 			>
-				<div style={{ fontSize: 80, marginBottom: 24 }}>🧑‍💻</div>
+				<div style={{ fontSize: 100, marginBottom: 32 }}>🧑‍💻</div>
 				<div
 					style={{
-						fontSize: 72,
+						fontSize: 84,
 						fontWeight: 700,
 						color: "#ffffff",
-						marginBottom: 16,
+						marginBottom: 20,
 					}}
 				>
 					Candidates | dcbuilder.eth
 				</div>
 				<div
 					style={{
-						fontSize: 24,
-						color: "#666",
-						marginTop: 32,
+						fontSize: 36,
+						color: "#ddd",
+						marginTop: 36,
 						textAlign: "center",
-						maxWidth: 700,
+						maxWidth: 800,
 					}}
 				>
 					Talented builders looking for new opportunities

--- a/src/app/candidates/page.tsx
+++ b/src/app/candidates/page.tsx
@@ -38,13 +38,20 @@ async function getCandidate(id: string) {
 	return candidate;
 }
 
+function getBaseUrl() {
+	if (process.env.VERCEL_URL) {
+		return `https://${process.env.VERCEL_URL}`;
+	}
+	return process.env.NEXT_PUBLIC_BASE_URL || "https://dcbuilder.dev";
+}
+
 export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
 	const { candidate: candidateId } = await searchParams;
 
 	if (candidateId) {
 		const candidate = await getCandidate(candidateId);
 		if (candidate) {
-			const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://dcbuilder.dev";
+			const baseUrl = getBaseUrl();
 			return {
 				title: `${candidate.name} | Candidates`,
 				description: candidate.summary || `${candidate.name} - ${candidate.title || "Candidate"}`,

--- a/src/app/jobs/[id]/opengraph-image.tsx
+++ b/src/app/jobs/[id]/opengraph-image.tsx
@@ -10,6 +10,38 @@ export const size = {
 };
 export const contentType = "image/png";
 
+// Tag priority for OG images - lower index = higher priority
+// Most relevant/recognizable tags should appear first
+const tagPriority: string[] = [
+	// Special tags
+	"hot", "top",
+	// Technical domains
+	"ai", "ml", "zkp", "cryptography", "mev", "defi", "protocol",
+	// Core skills
+	"rust", "solidity", "fullstack", "frontend", "backend",
+	// Infrastructure
+	"infra", "security", "research",
+	// Ecosystems
+	"solana", "monad-ecosystem", "berachain-ecosystem",
+	// Other technical
+	"trading", "gaming", "privacy", "account-abstraction",
+];
+
+function sortTagsByRelevance(tags: string[]): string[] {
+	return [...tags].sort((a, b) => {
+		const aIndex = tagPriority.indexOf(a.toLowerCase());
+		const bIndex = tagPriority.indexOf(b.toLowerCase());
+		// If both are in priority list, sort by priority
+		if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
+		// If only a is in priority list, a comes first
+		if (aIndex !== -1) return -1;
+		// If only b is in priority list, b comes first
+		if (bIndex !== -1) return 1;
+		// If neither is in priority list, maintain original order
+		return 0;
+	});
+}
+
 interface Props {
 	params: Promise<{ id: string }>;
 }
@@ -24,7 +56,8 @@ export default async function Image({ params }: Props) {
 	const remote = job?.remote || "";
 	const salary = job?.salary || "";
 	const logo = job?.companyLogo;
-	const tags = job?.tags?.slice(0, 4) || [];
+	const rawTags = job?.tags || [];
+	const tags = sortTagsByRelevance(rawTags).slice(0, 4);
 
 	const locationText = [location, remote].filter(Boolean).join(" • ");
 

--- a/src/app/jobs/[id]/opengraph-image.tsx
+++ b/src/app/jobs/[id]/opengraph-image.tsx
@@ -88,31 +88,84 @@ export default async function Image({ params }: Props) {
 					padding: 60,
 				}}
 			>
-				{/* Top: Site branding */}
-				<div style={{ display: "flex", alignItems: "center", gap: 24 }}>
-					<div
-						style={{
-							width: 88,
-							height: 88,
-							borderRadius: "50%",
-							overflow: "hidden",
-							display: "flex",
-						}}
-					>
-						<img
-							src="https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png"
-							alt="dcbuilder"
-							width={88}
-							height={88}
-							style={{ objectFit: "cover" }}
-						/>
+				{/* Top: Site branding + Badges */}
+				<div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between" }}>
+					{/* Left: Branding */}
+					<div style={{ display: "flex", alignItems: "center", gap: 24 }}>
+						<div
+							style={{
+								width: 88,
+								height: 88,
+								borderRadius: "50%",
+								overflow: "hidden",
+								display: "flex",
+							}}
+						>
+							<img
+								src="https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png"
+								alt="dcbuilder"
+								width={88}
+								height={88}
+								style={{ objectFit: "cover" }}
+							/>
+						</div>
+						<div style={{ display: "flex", flexDirection: "column" }}>
+							<span style={{ color: "#ffffff", fontSize: 42, fontWeight: 600 }}>
+								dcbuilder.eth
+							</span>
+							<span style={{ color: "#ccc", fontSize: 34 }}>Jobs</span>
+						</div>
 					</div>
-					<div style={{ display: "flex", flexDirection: "column" }}>
-						<span style={{ color: "#ffffff", fontSize: 42, fontWeight: 600 }}>
-							dcbuilder.eth
-						</span>
-						<span style={{ color: "#ccc", fontSize: 34 }}>Jobs</span>
-					</div>
+					{/* Right: Badges */}
+					{(isHot || isTop || isNewJob) && (
+						<div style={{ display: "flex", gap: 12 }}>
+							{isHot && (
+								<div
+									style={{
+										display: "flex",
+										padding: "12px 24px",
+										borderRadius: 28,
+										background: "linear-gradient(to right, #f97316, #f59e0b)",
+										color: "#ffffff",
+										fontSize: 32,
+										fontWeight: 700,
+									}}
+								>
+									<span>🔥 HOT</span>
+								</div>
+							)}
+							{isTop && (
+								<div
+									style={{
+										display: "flex",
+										padding: "12px 24px",
+										borderRadius: 28,
+										background: "linear-gradient(to right, #8b5cf6, #a855f7)",
+										color: "#ffffff",
+										fontSize: 32,
+										fontWeight: 700,
+									}}
+								>
+									<span>⭐ TOP</span>
+								</div>
+							)}
+							{isNewJob && (
+								<div
+									style={{
+										display: "flex",
+										padding: "12px 24px",
+										borderRadius: 28,
+										backgroundColor: "#e0f2fe",
+										color: "#0369a1",
+										fontSize: 32,
+										fontWeight: 700,
+									}}
+								>
+									<span>NEW</span>
+								</div>
+							)}
+						</div>
+					)}
 				</div>
 
 				{/* Middle: Job info */}
@@ -171,67 +224,16 @@ export default async function Image({ params }: Props) {
 							gap: 14,
 						}}
 					>
-						{/* Title with badges */}
-						<div style={{ display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
-							<div
-								style={{
-									fontSize: title.length > 30 ? 54 : 62,
-									fontWeight: 700,
-									color: "#ffffff",
-									lineHeight: 1.1,
-									maxWidth: 650,
-								}}
-							>
-								{title}
-							</div>
-							{/* HOT badge */}
-							{isHot && (
-								<div
-									style={{
-										display: "flex",
-										padding: "8px 20px",
-										borderRadius: 24,
-										background: "linear-gradient(to right, #f97316, #f59e0b)",
-										color: "#ffffff",
-										fontSize: 28,
-										fontWeight: 700,
-									}}
-								>
-									<span>🔥 HOT</span>
-								</div>
-							)}
-							{/* TOP badge */}
-							{isTop && (
-								<div
-									style={{
-										display: "flex",
-										padding: "8px 20px",
-										borderRadius: 24,
-										background: "linear-gradient(to right, #8b5cf6, #a855f7)",
-										color: "#ffffff",
-										fontSize: 28,
-										fontWeight: 700,
-									}}
-								>
-									<span>⭐ TOP</span>
-								</div>
-							)}
-							{/* NEW badge */}
-							{isNewJob && (
-								<div
-									style={{
-										display: "flex",
-										padding: "8px 20px",
-										borderRadius: 24,
-										backgroundColor: "#e0f2fe",
-										color: "#0369a1",
-										fontSize: 28,
-										fontWeight: 700,
-									}}
-								>
-									<span>NEW</span>
-								</div>
-							)}
+						<div
+							style={{
+								fontSize: title.length > 30 ? 54 : 62,
+								fontWeight: 700,
+								color: "#ffffff",
+								lineHeight: 1.1,
+								maxWidth: 800,
+							}}
+						>
+							{title}
 						</div>
 						{company && (
 							<div

--- a/src/app/jobs/[id]/opengraph-image.tsx
+++ b/src/app/jobs/[id]/opengraph-image.tsx
@@ -12,7 +12,7 @@ export const contentType = "image/png";
 
 // Tag priority for OG images - lower index = higher priority
 // Most relevant/recognizable tags should appear first
-// Note: "hot" and "top" are filtered out before display
+// Note: "hot" and "top" are shown as special badges, not regular tags
 const tagPriority: string[] = [
 	// Technical domains
 	"ai", "ml", "zkp", "cryptography", "mev", "defi", "protocol",
@@ -41,6 +41,15 @@ function sortTagsByRelevance(tags: string[]): string[] {
 	});
 }
 
+// Check if created within last 14 days
+function isNew(createdAt: Date | string | null | undefined): boolean {
+	if (!createdAt) return false;
+	const date = new Date(createdAt);
+	const now = new Date();
+	const diffDays = (now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24);
+	return diffDays <= 14;
+}
+
 interface Props {
 	params: Promise<{ id: string }>;
 }
@@ -55,7 +64,11 @@ export default async function Image({ params }: Props) {
 	const remote = job?.remote || "";
 	const salary = job?.salary || "";
 	const logo = job?.companyLogo;
-	const rawTags = (job?.tags || []).filter(tag => tag !== "hot" && tag !== "top");
+	const allTags = job?.tags || [];
+	const isHot = allTags.includes("hot");
+	const isTop = allTags.includes("top");
+	const isNewJob = isNew(job?.createdAt);
+	const rawTags = allTags.filter(tag => tag !== "hot" && tag !== "top");
 	const tags = sortTagsByRelevance(rawTags).slice(0, 4);
 
 	const locationText = [location, remote].filter(Boolean).join(" • ");
@@ -158,16 +171,67 @@ export default async function Image({ params }: Props) {
 							gap: 14,
 						}}
 					>
-						<div
-							style={{
-								fontSize: title.length > 30 ? 54 : 62,
-								fontWeight: 700,
-								color: "#ffffff",
-								lineHeight: 1.1,
-								maxWidth: 800,
-							}}
-						>
-							{title}
+						{/* Title with badges */}
+						<div style={{ display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
+							<div
+								style={{
+									fontSize: title.length > 30 ? 54 : 62,
+									fontWeight: 700,
+									color: "#ffffff",
+									lineHeight: 1.1,
+									maxWidth: 650,
+								}}
+							>
+								{title}
+							</div>
+							{/* HOT badge */}
+							{isHot && (
+								<div
+									style={{
+										display: "flex",
+										padding: "8px 20px",
+										borderRadius: 24,
+										background: "linear-gradient(to right, #f97316, #f59e0b)",
+										color: "#ffffff",
+										fontSize: 28,
+										fontWeight: 700,
+									}}
+								>
+									<span>🔥 HOT</span>
+								</div>
+							)}
+							{/* TOP badge */}
+							{isTop && (
+								<div
+									style={{
+										display: "flex",
+										padding: "8px 20px",
+										borderRadius: 24,
+										background: "linear-gradient(to right, #8b5cf6, #a855f7)",
+										color: "#ffffff",
+										fontSize: 28,
+										fontWeight: 700,
+									}}
+								>
+									<span>⭐ TOP</span>
+								</div>
+							)}
+							{/* NEW badge */}
+							{isNewJob && (
+								<div
+									style={{
+										display: "flex",
+										padding: "8px 20px",
+										borderRadius: 24,
+										backgroundColor: "#e0f2fe",
+										color: "#0369a1",
+										fontSize: 28,
+										fontWeight: 700,
+									}}
+								>
+									<span>NEW</span>
+								</div>
+							)}
 						</div>
 						{company && (
 							<div

--- a/src/app/jobs/[id]/opengraph-image.tsx
+++ b/src/app/jobs/[id]/opengraph-image.tsx
@@ -183,13 +183,13 @@ export default async function Image({ params }: Props) {
 						)}
 						<div style={{ display: "flex", gap: 36, marginTop: 8 }}>
 							{locationText && (
-								<div style={{ fontSize: 38, color: "#ddd" }}>
-									📍 {locationText}
+								<div style={{ display: "flex", fontSize: 38, color: "#ddd" }}>
+									<span>📍 {locationText}</span>
 								</div>
 							)}
 							{salary && (
-								<div style={{ fontSize: 38, color: "#ddd" }}>
-									💰 {salary}
+								<div style={{ display: "flex", fontSize: 38, color: "#ddd" }}>
+									<span>💰 {salary}</span>
 								</div>
 							)}
 						</div>

--- a/src/app/jobs/[id]/opengraph-image.tsx
+++ b/src/app/jobs/[id]/opengraph-image.tsx
@@ -49,11 +49,11 @@ export default async function Image({ params }: Props) {
 				}}
 			>
 				{/* Top: Site branding */}
-				<div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+				<div style={{ display: "flex", alignItems: "center", gap: 24 }}>
 					<div
 						style={{
-							width: 48,
-							height: 48,
+							width: 88,
+							height: 88,
 							borderRadius: "50%",
 							overflow: "hidden",
 							display: "flex",
@@ -62,16 +62,16 @@ export default async function Image({ params }: Props) {
 						<img
 							src="https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png"
 							alt="dcbuilder"
-							width={48}
-							height={48}
+							width={88}
+							height={88}
 							style={{ objectFit: "cover" }}
 						/>
 					</div>
 					<div style={{ display: "flex", flexDirection: "column" }}>
-						<span style={{ color: "#ffffff", fontSize: 20, fontWeight: 600 }}>
+						<span style={{ color: "#ffffff", fontSize: 42, fontWeight: 600 }}>
 							dcbuilder.eth
 						</span>
-						<span style={{ color: "#666", fontSize: 16 }}>Jobs</span>
+						<span style={{ color: "#ccc", fontSize: 34 }}>Jobs</span>
 					</div>
 				</div>
 
@@ -80,16 +80,16 @@ export default async function Image({ params }: Props) {
 					style={{
 						display: "flex",
 						alignItems: "center",
-						gap: 40,
+						gap: 48,
 					}}
 				>
 					{/* Company logo */}
 					{logo ? (
 						<div
 							style={{
-								width: 140,
-								height: 140,
-								borderRadius: 20,
+								width: 200,
+								height: 200,
+								borderRadius: 28,
 								overflow: "hidden",
 								display: "flex",
 								border: "3px solid #333",
@@ -100,22 +100,22 @@ export default async function Image({ params }: Props) {
 							<img
 								src={logo}
 								alt={company}
-								width={140}
-								height={140}
+								width={200}
+								height={200}
 								style={{ objectFit: "cover" }}
 							/>
 						</div>
 					) : (
 						<div
 							style={{
-								width: 140,
-								height: 140,
-								borderRadius: 20,
+								width: 200,
+								height: 200,
+								borderRadius: 28,
 								backgroundColor: "#1a1a2e",
 								display: "flex",
 								alignItems: "center",
 								justifyContent: "center",
-								fontSize: 56,
+								fontSize: 80,
 								flexShrink: 0,
 							}}
 						>
@@ -128,12 +128,12 @@ export default async function Image({ params }: Props) {
 						style={{
 							display: "flex",
 							flexDirection: "column",
-							gap: 12,
+							gap: 14,
 						}}
 					>
 						<div
 							style={{
-								fontSize: title.length > 30 ? 40 : 48,
+								fontSize: title.length > 30 ? 54 : 62,
 								fontWeight: 700,
 								color: "#ffffff",
 								lineHeight: 1.1,
@@ -145,22 +145,22 @@ export default async function Image({ params }: Props) {
 						{company && (
 							<div
 								style={{
-									fontSize: 32,
-									color: "#22c55e",
+									fontSize: 46,
+									color: "#4ade80",
 									lineHeight: 1.2,
 								}}
 							>
 								{company}
 							</div>
 						)}
-						<div style={{ display: "flex", gap: 24, marginTop: 8 }}>
+						<div style={{ display: "flex", gap: 36, marginTop: 8 }}>
 							{locationText && (
-								<div style={{ fontSize: 22, color: "#888" }}>
+								<div style={{ fontSize: 38, color: "#ddd" }}>
 									📍 {locationText}
 								</div>
 							)}
 							{salary && (
-								<div style={{ fontSize: 22, color: "#888" }}>
+								<div style={{ fontSize: 38, color: "#ddd" }}>
 									💰 {salary}
 								</div>
 							)}
@@ -169,16 +169,16 @@ export default async function Image({ params }: Props) {
 				</div>
 
 				{/* Bottom: Tags */}
-				<div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+				<div style={{ display: "flex", gap: 18, flexWrap: "wrap" }}>
 					{tags.map((tag) => (
 						<div
 							key={tag}
 							style={{
-								padding: "8px 20px",
-								borderRadius: 20,
+								padding: "16px 36px",
+								borderRadius: 32,
 								backgroundColor: "#1a2e1a",
-								color: "#22c55e",
-								fontSize: 18,
+								color: "#86efac",
+								fontSize: 36,
 							}}
 						>
 							{tag}

--- a/src/app/jobs/[id]/opengraph-image.tsx
+++ b/src/app/jobs/[id]/opengraph-image.tsx
@@ -1,6 +1,5 @@
 import { ImageResponse } from "next/og";
-import { db, jobs } from "@/db";
-import { eq } from "drizzle-orm";
+import { getJobById } from "@/lib/data";
 
 export const runtime = "nodejs";
 
@@ -17,11 +16,7 @@ interface Props {
 
 export default async function Image({ params }: Props) {
 	const { id } = await params;
-	const [job] = await db
-		.select()
-		.from(jobs)
-		.where(eq(jobs.id, id))
-		.limit(1);
+	const job = await getJobById(id);
 
 	const title = job?.title || "Job Opening";
 	const company = job?.company || "";

--- a/src/app/jobs/[id]/opengraph-image.tsx
+++ b/src/app/jobs/[id]/opengraph-image.tsx
@@ -10,37 +10,6 @@ export const size = {
 };
 export const contentType = "image/png";
 
-// Tag priority for OG images - lower index = higher priority
-// Most relevant/recognizable tags should appear first
-// Note: "hot" and "top" are shown as special badges, not regular tags
-const tagPriority: string[] = [
-	// Technical domains
-	"ai", "ml", "zkp", "cryptography", "mev", "defi", "protocol",
-	// Core skills
-	"rust", "solidity", "fullstack", "frontend", "backend",
-	// Infrastructure
-	"infra", "security", "research",
-	// Ecosystems
-	"solana", "monad-ecosystem", "berachain-ecosystem",
-	// Other technical
-	"trading", "gaming", "privacy", "account-abstraction",
-];
-
-function sortTagsByRelevance(tags: string[]): string[] {
-	return [...tags].sort((a, b) => {
-		const aIndex = tagPriority.indexOf(a.toLowerCase());
-		const bIndex = tagPriority.indexOf(b.toLowerCase());
-		// If both are in priority list, sort by priority
-		if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
-		// If only a is in priority list, a comes first
-		if (aIndex !== -1) return -1;
-		// If only b is in priority list, b comes first
-		if (bIndex !== -1) return 1;
-		// If neither is in priority list, maintain original order
-		return 0;
-	});
-}
-
 // Check if created within last 14 days
 function isNew(createdAt: Date | string | null | undefined): boolean {
 	if (!createdAt) return false;
@@ -68,8 +37,10 @@ export default async function Image({ params }: Props) {
 	const isHot = allTags.includes("hot");
 	const isTop = allTags.includes("top");
 	const isNewJob = isNew(job?.createdAt);
-	const rawTags = allTags.filter(tag => tag !== "hot" && tag !== "top");
-	const tags = sortTagsByRelevance(rawTags).slice(0, 4);
+	// Filter out hot/top (shown as badges) and take first 4 tags as ordered in DB
+	const tags = allTags
+		.filter(tag => tag !== "hot" && tag !== "top")
+		.slice(0, 4);
 
 	const locationText = [location, remote].filter(Boolean).join(" • ");
 

--- a/src/app/jobs/[id]/opengraph-image.tsx
+++ b/src/app/jobs/[id]/opengraph-image.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from "next/og";
 import { getJobById } from "@/lib/data";
+import { isNew } from "@/lib/shuffle";
 
 export const runtime = "nodejs";
 
@@ -9,15 +10,6 @@ export const size = {
 	height: 630,
 };
 export const contentType = "image/png";
-
-// Check if created within last 14 days
-function isNew(createdAt: Date | string | null | undefined): boolean {
-	if (!createdAt) return false;
-	const date = new Date(createdAt);
-	const now = new Date();
-	const diffDays = (now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24);
-	return diffDays <= 14;
-}
 
 interface Props {
 	params: Promise<{ id: string }>;
@@ -34,12 +26,12 @@ export default async function Image({ params }: Props) {
 	const salary = job?.salary || "";
 	const logo = job?.companyLogo;
 	const allTags = job?.tags || [];
-	const isHot = allTags.includes("hot");
-	const isTop = allTags.includes("top");
+	const isHot = allTags.some(t => t.toLowerCase() === "hot");
+	const isTop = allTags.some(t => t.toLowerCase() === "top");
 	const isNewJob = isNew(job?.createdAt);
 	// Filter out hot/top (shown as badges) and take first 4 tags as ordered in DB
 	const tags = allTags
-		.filter(tag => tag !== "hot" && tag !== "top")
+		.filter(tag => tag.toLowerCase() !== "hot" && tag.toLowerCase() !== "top")
 		.slice(0, 4);
 
 	const locationText = [location, remote].filter(Boolean).join(" • ");

--- a/src/app/jobs/[id]/opengraph-image.tsx
+++ b/src/app/jobs/[id]/opengraph-image.tsx
@@ -12,9 +12,8 @@ export const contentType = "image/png";
 
 // Tag priority for OG images - lower index = higher priority
 // Most relevant/recognizable tags should appear first
+// Note: "hot" and "top" are filtered out before display
 const tagPriority: string[] = [
-	// Special tags
-	"hot", "top",
 	// Technical domains
 	"ai", "ml", "zkp", "cryptography", "mev", "defi", "protocol",
 	// Core skills
@@ -56,7 +55,7 @@ export default async function Image({ params }: Props) {
 	const remote = job?.remote || "";
 	const salary = job?.salary || "";
 	const logo = job?.companyLogo;
-	const rawTags = job?.tags || [];
+	const rawTags = (job?.tags || []).filter(tag => tag !== "hot" && tag !== "top");
 	const tags = sortTagsByRelevance(rawTags).slice(0, 4);
 
 	const locationText = [location, remote].filter(Boolean).join(" • ");
@@ -122,7 +121,7 @@ export default async function Image({ params }: Props) {
 								display: "flex",
 								border: "3px solid #333",
 								flexShrink: 0,
-								backgroundColor: "#1a1a2e",
+								backgroundColor: "#ffffff",
 							}}
 						>
 							<img
@@ -130,7 +129,7 @@ export default async function Image({ params }: Props) {
 								alt={company}
 								width={200}
 								height={200}
-								style={{ objectFit: "cover" }}
+								style={{ objectFit: "contain" }}
 							/>
 						</div>
 					) : (

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { getJobById } from "@/lib/data";
+import { getJobById, getBaseUrl } from "@/lib/data";
 
 interface Props {
 	params: Promise<{ id: string }>;
@@ -13,9 +13,23 @@ export async function generateMetadata({ params }: Props) {
 		return { title: "Job Not Found" };
 	}
 
+	const baseUrl = getBaseUrl();
+	const description = job.description || `${job.title} position at ${job.company}`;
+
 	return {
 		title: `${job.title} at ${job.company} | Jobs`,
-		description: job.description || `${job.title} position at ${job.company}`,
+		description,
+		openGraph: {
+			title: `${job.title} at ${job.company} | Jobs`,
+			description,
+			images: [`${baseUrl}/jobs/${job.id}/opengraph-image`],
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: `${job.title} at ${job.company} | Jobs`,
+			description,
+			images: [`${baseUrl}/jobs/${job.id}/opengraph-image`],
+		},
 	};
 }
 

--- a/src/app/jobs/[id]/page.tsx
+++ b/src/app/jobs/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
-import { db, jobs } from "@/db";
-import { eq } from "drizzle-orm";
+import { getJobById } from "@/lib/data";
 
 interface Props {
 	params: Promise<{ id: string }>;
@@ -8,11 +7,7 @@ interface Props {
 
 export async function generateMetadata({ params }: Props) {
 	const { id } = await params;
-	const [job] = await db
-		.select()
-		.from(jobs)
-		.where(eq(jobs.id, id))
-		.limit(1);
+	const job = await getJobById(id);
 
 	if (!job) {
 		return { title: "Job Not Found" };
@@ -26,11 +21,7 @@ export async function generateMetadata({ params }: Props) {
 
 export default async function JobPage({ params }: Props) {
 	const { id } = await params;
-	const [job] = await db
-		.select()
-		.from(jobs)
-		.where(eq(jobs.id, id))
-		.limit(1);
+	const job = await getJobById(id);
 
 	if (!job) {
 		redirect("/jobs");

--- a/src/app/jobs/opengraph-image.tsx
+++ b/src/app/jobs/opengraph-image.tsx
@@ -25,24 +25,24 @@ export default async function Image() {
 						"radial-gradient(circle at 50% 100%, #1a2e1a 0%, #0a0a0a 50%)",
 				}}
 			>
-				<div style={{ fontSize: 80, marginBottom: 24 }}>💼</div>
+				<div style={{ fontSize: 100, marginBottom: 32 }}>💼</div>
 				<div
 					style={{
-						fontSize: 72,
+						fontSize: 84,
 						fontWeight: 700,
 						color: "#ffffff",
-						marginBottom: 16,
+						marginBottom: 20,
 					}}
 				>
 					Jobs | dcbuilder.eth
 				</div>
 				<div
 					style={{
-						fontSize: 24,
-						color: "#666",
-						marginTop: 32,
+						fontSize: 36,
+						color: "#ddd",
+						marginTop: 36,
 						textAlign: "center",
-						maxWidth: 700,
+						maxWidth: 800,
 					}}
 				>
 					Opportunities at portfolio companies and crypto network

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -2,9 +2,9 @@ import { Suspense } from "react";
 import { Metadata } from "next";
 import { Navbar } from "@/components/Navbar";
 import { JobsGrid } from "@/components/JobsGrid";
-import { getJobsFromDB } from "@/lib/data";
-import { db, jobTags, jobRoles, jobs } from "@/db";
-import { asc, eq } from "drizzle-orm";
+import { getJobsFromDB, getJobById, getBaseUrl } from "@/lib/data";
+import { db, jobTags, jobRoles } from "@/db";
+import { asc } from "drizzle-orm";
 import { TelegramIcon } from "@/components/icons/TelegramIcon";
 import { JOBS_PAGE } from "@/data/page-content";
 
@@ -15,27 +15,11 @@ interface Props {
 	searchParams: Promise<{ job?: string }>;
 }
 
-async function getJob(id: string) {
-	const [job] = await db
-		.select()
-		.from(jobs)
-		.where(eq(jobs.id, id))
-		.limit(1);
-	return job;
-}
-
-function getBaseUrl() {
-	if (process.env.VERCEL_URL) {
-		return `https://${process.env.VERCEL_URL}`;
-	}
-	return process.env.NEXT_PUBLIC_BASE_URL || "https://dcbuilder.dev";
-}
-
 export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
 	const { job: jobId } = await searchParams;
 
 	if (jobId) {
-		const job = await getJob(jobId);
+		const job = await getJobById(jobId);
 		if (job) {
 			const baseUrl = getBaseUrl();
 			const description = job.description || `${job.title} position at ${job.company}`;

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -24,13 +24,20 @@ async function getJob(id: string) {
 	return job;
 }
 
+function getBaseUrl() {
+	if (process.env.VERCEL_URL) {
+		return `https://${process.env.VERCEL_URL}`;
+	}
+	return process.env.NEXT_PUBLIC_BASE_URL || "https://dcbuilder.dev";
+}
+
 export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
 	const { job: jobId } = await searchParams;
 
 	if (jobId) {
 		const job = await getJob(jobId);
 		if (job) {
-			const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://dcbuilder.dev";
+			const baseUrl = getBaseUrl();
 			const description = job.description || `${job.title} position at ${job.company}`;
 			return {
 				title: `${job.title} at ${job.company} | Jobs`,

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -1,19 +1,60 @@
 import { Suspense } from "react";
+import { Metadata } from "next";
 import { Navbar } from "@/components/Navbar";
 import { JobsGrid } from "@/components/JobsGrid";
 import { getJobsFromDB } from "@/lib/data";
-import { db, jobTags, jobRoles } from "@/db";
-import { asc } from "drizzle-orm";
+import { db, jobTags, jobRoles, jobs } from "@/db";
+import { asc, eq } from "drizzle-orm";
 import { TelegramIcon } from "@/components/icons/TelegramIcon";
 import { JOBS_PAGE } from "@/data/page-content";
 
-export const metadata = {
-	title: "Jobs",
-	description: "Job opportunities at companies in my network",
-};
-
 // Force dynamic rendering since we need database access
 export const dynamic = "force-dynamic";
+
+interface Props {
+	searchParams: Promise<{ job?: string }>;
+}
+
+async function getJob(id: string) {
+	const [job] = await db
+		.select()
+		.from(jobs)
+		.where(eq(jobs.id, id))
+		.limit(1);
+	return job;
+}
+
+export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
+	const { job: jobId } = await searchParams;
+
+	if (jobId) {
+		const job = await getJob(jobId);
+		if (job) {
+			const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://dcbuilder.dev";
+			const description = job.description || `${job.title} position at ${job.company}`;
+			return {
+				title: `${job.title} at ${job.company} | Jobs`,
+				description,
+				openGraph: {
+					title: `${job.title} at ${job.company} | Jobs`,
+					description,
+					images: [`${baseUrl}/jobs/${job.id}/opengraph-image`],
+				},
+				twitter: {
+					card: "summary_large_image",
+					title: `${job.title} at ${job.company} | Jobs`,
+					description,
+					images: [`${baseUrl}/jobs/${job.id}/opengraph-image`],
+				},
+			};
+		}
+	}
+
+	return {
+		title: "Jobs",
+		description: "Job opportunities at companies in my network",
+	};
+}
 
 function JobsGridFallback() {
 	return (

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -28,20 +28,20 @@ export default async function Image() {
 				{/* Profile Image Circle */}
 				<div
 					style={{
-						width: 200,
-						height: 200,
+						width: 240,
+						height: 240,
 						borderRadius: "50%",
 						overflow: "hidden",
 						border: "4px solid #333",
-						marginBottom: 32,
+						marginBottom: 36,
 						display: "flex",
 					}}
 				>
 					<img
 						src="https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png"
 						alt="dcbuilder"
-						width={200}
-						height={200}
+						width={240}
+						height={240}
 						style={{ objectFit: "cover" }}
 					/>
 				</div>
@@ -49,10 +49,10 @@ export default async function Image() {
 				{/* Title */}
 				<div
 					style={{
-						fontSize: 64,
+						fontSize: 84,
 						fontWeight: 700,
 						color: "#ffffff",
-						marginBottom: 16,
+						marginBottom: 20,
 					}}
 				>
 					dcbuilder.eth
@@ -61,10 +61,10 @@ export default async function Image() {
 				{/* Subtitle */}
 				<div
 					style={{
-						fontSize: 28,
-						color: "#a0a0a0",
+						fontSize: 38,
+						color: "#ddd",
 						textAlign: "center",
-						maxWidth: 800,
+						maxWidth: 900,
 					}}
 				>
 					Research • Engineering • Angel Investing
@@ -74,19 +74,19 @@ export default async function Image() {
 				<div
 					style={{
 						display: "flex",
-						gap: 16,
-						marginTop: 32,
+						gap: 18,
+						marginTop: 36,
 					}}
 				>
 					{["Cryptography", "Distributed Systems", "AI"].map((topic) => (
 						<div
 							key={topic}
 							style={{
-								padding: "8px 20px",
-								borderRadius: 20,
+								padding: "16px 36px",
+								borderRadius: 32,
 								backgroundColor: "#1a1a2e",
-								color: "#888",
-								fontSize: 18,
+								color: "#ddd",
+								fontSize: 32,
 							}}
 						>
 							{topic}

--- a/src/app/portfolio/opengraph-image.tsx
+++ b/src/app/portfolio/opengraph-image.tsx
@@ -25,24 +25,24 @@ export default async function Image() {
 						"radial-gradient(circle at 50% 100%, #2e2e1a 0%, #0a0a0a 50%)",
 				}}
 			>
-				<div style={{ fontSize: 80, marginBottom: 24 }}>📈</div>
+				<div style={{ fontSize: 100, marginBottom: 32 }}>📈</div>
 				<div
 					style={{
-						fontSize: 72,
+						fontSize: 84,
 						fontWeight: 700,
 						color: "#ffffff",
-						marginBottom: 16,
+						marginBottom: 20,
 					}}
 				>
 					Portfolio | dcbuilder.eth
 				</div>
 				<div
 					style={{
-						fontSize: 24,
-						color: "#666",
-						marginTop: 32,
+						fontSize: 36,
+						color: "#ddd",
+						marginTop: 36,
 						textAlign: "center",
-						maxWidth: 700,
+						maxWidth: 800,
 					}}
 				>
 					Angel investments in cryptography, distributed systems, and AI

--- a/src/components/JobsGrid.tsx
+++ b/src/components/JobsGrid.tsx
@@ -189,24 +189,43 @@ function ExpandedJobView({
 						</button>
 					</div>
 
-					{/* Desktop: Close button */}
-					<button
-						onClick={handleClose}
-						className="hidden sm:block absolute top-4 right-4 z-10 p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-all active:scale-90"
-					>
-						<svg
-							className="w-6 h-6"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							strokeWidth="2"
-							strokeLinecap="round"
-							strokeLinejoin="round"
+					{/* Desktop: Copy link and close buttons */}
+					<div className="hidden sm:flex absolute top-4 right-4 z-10 gap-2">
+						<button
+							onClick={() => copyToClipboard(jobUrl, "job")}
+							className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-all active:scale-90"
+							aria-label="Copy link"
 						>
-							<line x1="18" y1="6" x2="6" y2="18" />
-							<line x1="6" y1="6" x2="18" y2="18" />
-						</svg>
-					</button>
+							{copiedLink === "job" ? (
+								<svg className="w-6 h-6 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+									<polyline points="20 6 9 17 4 12" />
+								</svg>
+							) : (
+								<svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+									<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+									<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+								</svg>
+							)}
+						</button>
+						<button
+							onClick={handleClose}
+							className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-all active:scale-90"
+							aria-label="Close"
+						>
+							<svg
+								className="w-6 h-6"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							>
+								<line x1="18" y1="6" x2="6" y2="18" />
+								<line x1="6" y1="6" x2="18" y2="18" />
+							</svg>
+						</button>
+					</div>
 
 					<div className="flex flex-col items-center sm:flex-row sm:items-start gap-4 sm:gap-6 text-center sm:text-left">
 						{/* Company Logo */}


### PR DESCRIPTION
## Summary

- Add dynamic OpenGraph images for individual candidate and job pages
- Support modal URLs (`/candidates?candidate=xxx`, `/jobs?job=xxx`) with individual OG previews
- Add HOT, TOP, and NEW badges to OG images in top right corner
- Refactor shared data functions to eliminate code duplication
- Fix various Satori compatibility issues

## Changes

### OpenGraph Images - Candidates (`/candidates/[id]`)
- Shows candidate photo, name, title, and top 5 skills
- Purple accent theme with radial gradient background
- **HOT badge**: Orange-to-amber gradient (🔥 HOT) - top right corner
- **TOP badge**: Violet-to-purple gradient (⭐ TOP) - top right corner
- **NEW badge**: Sky blue for candidates created within 14 days - top right corner
- Skills displayed in DB order (first 5, ordered by relevance in admin panel)
- Responsive font sizes for long names (>25 chars uses smaller font)
- maxWidth constraints to prevent text overflow

### OpenGraph Images - Jobs (`/jobs/[id]`)
- Shows company logo (with white background for transparent logos), job title, company, location, salary
- Green accent theme with radial gradient background
- **HOT badge**: Orange-to-amber gradient (🔥 HOT) - top right corner
- **TOP badge**: Violet-to-purple gradient (⭐ TOP) - top right corner
- **NEW badge**: Sky blue for jobs created within 14 days - top right corner
- Tags displayed in DB order (first 4, ordered by relevance in admin panel)
- HOT/TOP filtered from regular tags (shown as badges instead)

### Modal URL Support
- `/candidates?candidate=xxx` shows individual candidate OG image
- `/jobs?job=xxx` shows individual job OG image
- Both direct URLs and modal URLs show the same OG preview when shared

### Code Refactoring
- Extracted shared functions to `src/lib/data.ts`:
  - `getCandidateById()` - with redirect support for old IDs
  - `getJobById()` - fetch job by ID
  - `getBaseUrl()` - handles Vercel preview deployments correctly
- Removed duplicate functions from route files
- Removed serverside skill/tag sorting - relies on DB ordering instead

### Bug Fixes
- Fixed Satori compatibility: Added `display: flex` for emoji+text combinations
- Fixed OG image URL generation for Vercel preview deployments
- Fixed transparent logo display with white background
- Fixed badges being cut off for long names/titles - moved to top right corner

### Styling (consistent across all OG images)
- dcbuilder avatar: 88px
- dcbuilder.eth text: 42px
- Page subtitle: 34px, light gray (#ccc)
- Main title: 54-74px (responsive to length)
- Secondary text: 36-46px
- Tags/badges: 36px
- Better contrast with lighter grays throughout

## Test plan
- [x] Visit `/jobs?job=world-engineering-fellowship` and verify OG image with badges
- [x] Visit `/candidates?candidate=pia-park` and verify OG image
- [x] Test OG preview at opengraph.xyz with preview deployment URL
- [x] Verify HOT, TOP, NEW badges appear correctly in top right corner
- [x] Check company logos with transparent backgrounds display on white
- [x] Verify skills/tags use DB order (no client-side sorting)
- [x] Test with long candidate names (e.g., norswap) - badges shouldn't overflow

🤖 Generated with [Claude Code](https://claude.ai/code)