### PR TITLE
Improve UX accessibility and frontend performance

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,10 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: "https",
+        hostname: "unavatar.io",
+      },
+      {
+        protocol: "https",
         hostname: "**.githubusercontent.com",
       },
     ],

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -79,7 +79,7 @@ export default async function About() {
 	return (
 		<>
 			<Navbar />
-			<main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+			<main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
 				<div className="max-w-4xl mx-auto py-8 sm:py-12 space-y-12 sm:space-y-20">
 					{/* Bio Section */}
 					<section className="flex flex-col md:flex-row items-center gap-8 md:gap-12 text-center md:text-left">

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -194,7 +194,7 @@ export default function AdminLayout({
       </nav>
 
       {/* Main Content */}
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-8">{children}</main>
+      <main id="main-content" className="max-w-7xl mx-auto px-4 sm:px-6 py-8">{children}</main>
     </div>
   );
 }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -163,7 +163,7 @@ export default function AdminLayout({
                   <Link
                     key={item.href}
                     href={item.href}
-                    className={`px-3 py-2 rounded-lg text-sm font-medium transition-all ${
+                    className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                       pathname === item.href
                         ? `${item.bgActive} text-white`
                         : `${item.bg} ${item.text} ${item.bgHover}`

--- a/src/app/blog/[slug]/error.tsx
+++ b/src/app/blog/[slug]/error.tsx
@@ -18,7 +18,7 @@ export default function BlogPostError({
 	return (
 		<>
 			<Navbar />
-			<main className="min-h-screen pt-24 px-6 flex items-center justify-center">
+			<main id="main-content" className="min-h-screen pt-24 px-6 flex items-center justify-center">
 				<div className="text-center space-y-4 max-w-md">
 					<h1 className="text-2xl font-bold">Unable to load article</h1>
 					<p className="text-neutral-600 dark:text-neutral-400">

--- a/src/app/blog/[slug]/loading.tsx
+++ b/src/app/blog/[slug]/loading.tsx
@@ -4,7 +4,7 @@ export default function Loading() {
 	return (
 		<>
 			<Navbar />
-			<main className="min-h-screen pt-24 px-[7.5vw]">
+			<main id="main-content" className="min-h-screen pt-24 px-[7.5vw]">
 				<div className="max-w-3xl mx-auto py-12 animate-pulse space-y-4">
 					<div className="h-4 bg-neutral-200 dark:bg-neutral-700 rounded w-24" />
 					<div className="h-10 bg-neutral-200 dark:bg-neutral-700 rounded w-3/4" />

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -37,7 +37,7 @@ export default async function BlogPostPage({ params }: Props) {
 	return (
 		<>
 			<Navbar />
-			<main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-[7.5vw] overflow-x-hidden">
+			<main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-[7.5vw] overflow-x-hidden">
 				<article className="max-w-3xl mx-auto py-12">
 					<Link
 						href="/blog"

--- a/src/app/blog/loading.tsx
+++ b/src/app/blog/loading.tsx
@@ -6,7 +6,7 @@ export default function BlogLoading() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
         <div className="max-w-3xl mx-auto py-8 sm:py-12">
           {/* Header - Static content */}
           <h1 className="text-4xl font-bold mb-8">{BLOG_PAGE.title}</h1>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -16,7 +16,7 @@ export default async function BlogPage() {
 	return (
 		<>
 			<Navbar />
-			<main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+			<main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
 				<div className="max-w-3xl mx-auto py-8 sm:py-12">
 					<h1 className="text-4xl font-bold mb-8">Blog</h1>
 

--- a/src/app/candidates/loading.tsx
+++ b/src/app/candidates/loading.tsx
@@ -7,7 +7,7 @@ export default function CandidatesLoading() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
         <div className="max-w-5xl mx-auto py-8 sm:py-12 space-y-6 sm:space-y-8">
           {/* Header - Static content */}
           <section className="text-center space-y-4">

--- a/src/app/candidates/page.tsx
+++ b/src/app/candidates/page.tsx
@@ -47,7 +47,7 @@ export default async function Candidates() {
 	return (
 		<>
 			<Navbar />
-			<main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+			<main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
 				<div className="max-w-5xl mx-auto py-8 sm:py-12 space-y-6 sm:space-y-8">
 					{/* Header */}
 					<section className="text-center space-y-4">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,6 +28,30 @@ body {
   font-family: var(--font-inter), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 }
 
+.skip-link {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 1000;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  background: #111827;
+  color: #ffffff;
+  transform: translateY(-140%);
+  transition: transform 0.2s ease;
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
+  outline: 2px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+:where(a, button, [role="button"], [role="link"], input, select, textarea):focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
 code, pre, .font-mono {
   font-family: var(--font-mono), ui-monospace, monospace;
 }
@@ -356,3 +380,17 @@ code, pre, .font-mono {
   box-shadow: 0 0 10px rgba(139, 92, 246, 0.4);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .animate-pulse-new,
+  .animate-pulse-hot,
+  .animate-pulse-top {
+    animation: none !important;
+  }
+}

--- a/src/app/jobs/loading.tsx
+++ b/src/app/jobs/loading.tsx
@@ -7,7 +7,7 @@ export default function JobsLoading() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
         <div className="max-w-4xl mx-auto py-8 sm:py-12 space-y-6 sm:space-y-8">
           {/* Header - Static content */}
           <section className="text-center space-y-4">

--- a/src/app/jobs/loading.tsx
+++ b/src/app/jobs/loading.tsx
@@ -30,7 +30,7 @@ export default function JobsLoading() {
           </section>
 
           {/* Jobs Grid */}
-          <div className="space-y-6" data-testid="jobs-grid">
+          <div className="space-y-6">
             {/* Static filters - render immediately */}
             <JobsFiltersStatic />
 

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -77,7 +77,7 @@ export default async function Jobs() {
 	return (
 		<>
 			<Navbar />
-			<main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+			<main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
 				<div className="max-w-4xl mx-auto py-8 sm:py-12 space-y-6 sm:space-y-8">
 					{/* Header */}
 					<section className="text-center space-y-4">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,6 +58,9 @@ export default function RootLayout({
 	return (
 		<html lang="en" suppressHydrationWarning>
 			<body className={`${inter.variable} ${jetbrainsMono.variable} ${lora.variable} antialiased`}>
+				<a href="#main-content" className="skip-link">
+					Skip to main content
+				</a>
 				<PostHogProvider>
 					<ThemeProvider>{children}</ThemeProvider>
 				</PostHogProvider>

--- a/src/app/news/loading.tsx
+++ b/src/app/news/loading.tsx
@@ -6,7 +6,7 @@ export default function NewsLoading() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
         <div className="max-w-4xl mx-auto py-8 sm:py-12">
           {/* Header - Static content */}
           <div className="text-center mb-8 sm:mb-12">

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -18,7 +18,7 @@ export default async function NewsPage() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
         <div className="max-w-4xl mx-auto py-8 sm:py-12">
           {/* Header */}
           <div className="text-center mb-8 sm:mb-12">

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,7 +5,7 @@ export default function NotFound() {
 	return (
 		<>
 			<Navbar />
-			<main className="min-h-screen pt-24 px-6 flex items-center justify-center">
+			<main id="main-content" className="min-h-screen pt-24 px-6 flex items-center justify-center">
 				<div className="text-center space-y-4">
 					<h1 className="text-6xl font-bold">404</h1>
 					<h2 className="text-2xl font-semibold">Page not found</h2>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-[7.5vw]">
+      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-[7.5vw]">
         <div className="flex flex-col-reverse lg:flex-row items-center gap-6 sm:gap-8 py-8 sm:py-12">
           {/* Image */}
           <div className="w-full lg:w-[65%]">

--- a/src/app/portfolio/loading.tsx
+++ b/src/app/portfolio/loading.tsx
@@ -19,7 +19,7 @@ export default function PortfolioLoading() {
           {/* Investments */}
           <section className="space-y-8">
             <h2 className="text-4xl font-bold text-center">{PORTFOLIO_PAGE.investments.title}</h2>
-            <div className="space-y-6" data-testid="portfolio-grid">
+            <div className="space-y-6">
               {/* Static filters - render immediately */}
               <PortfolioFiltersStatic />
 

--- a/src/app/portfolio/loading.tsx
+++ b/src/app/portfolio/loading.tsx
@@ -6,7 +6,7 @@ export default function PortfolioLoading() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
         <div className="max-w-6xl mx-auto py-8 sm:py-12 space-y-10 sm:space-y-16">
           {/* Disclaimer - Static content */}
           <section className="text-center space-y-6">

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -64,7 +64,7 @@ export default async function Portfolio() {
   return (
     <>
       <Navbar />
-      <main className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
         <div className="max-w-6xl mx-auto py-8 sm:py-12 space-y-10 sm:space-y-16">
           {/* Disclaimer */}
           <section className="text-center space-y-6">

--- a/src/components/CandidatesGrid.tsx
+++ b/src/components/CandidatesGrid.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useMemo, useEffect, useRef, useCallback, memo } from "react";
+import dynamic from "next/dynamic";
+import { useState, useMemo, useEffect, useRef, useCallback, memo, useDeferredValue } from "react";
 import Image from "next/image";
-import { useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
 	Candidate,
 	AvailabilityStatus,
@@ -35,11 +36,18 @@ import {
 	TelegramIcon,
 } from "./ui/icons";
 
+const ExpandedCandidateView = dynamic(
+	() => import("./ExpandedCandidateView").then((mod) => mod.ExpandedCandidateView),
+	{ ssr: false }
+);
+
 interface CandidatesGridProps {
 	candidates: Candidate[];
 }
 
 export function CandidatesGrid({ candidates }: CandidatesGridProps) {
+	const router = useRouter();
+	const pathname = usePathname();
 	const searchParams = useSearchParams();
 	const [availabilityFilter, setAvailabilityFilter] = useState<
 		"all" | AvailabilityStatus
@@ -51,6 +59,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 	const [selectedTags, setSelectedTags] = useState<SkillTag[]>([]);
 	const [tagsExpanded, setTagsExpanded] = useState(false);
 	const [searchQuery, setSearchQuery] = useState("");
+	const deferredSearchQuery = useDeferredValue(searchQuery);
 	const [displayCount, setDisplayCount] = useState(12);
 	const [expandedCandidate, setExpandedCandidate] = useState<Candidate | null>(() => {
 		const candidateId = searchParams.get("candidate");
@@ -63,18 +72,23 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 	// Use custom hook for hot candidates logic (better separation of concerns)
 	const { isHotCandidate, hasTopTag, showTopCardStyle } = useHotCandidates();
 
-	// Helper to update URL params without React re-render
+	const replaceSearchParams = useCallback((nextParams: URLSearchParams) => {
+		const queryString = nextParams.toString();
+		if (queryString === searchParams.toString()) return;
+		router.replace(queryString ? `${pathname}?${queryString}` : pathname, { scroll: false });
+	}, [pathname, router, searchParams]);
+
 	const updateUrlParams = useCallback((updates: Record<string, string | null>) => {
-		const url = new URL(window.location.href);
+		const nextParams = new URLSearchParams(searchParams.toString());
 		Object.entries(updates).forEach(([key, value]) => {
 			if (value === null || value === "") {
-				url.searchParams.delete(key);
+				nextParams.delete(key);
 			} else {
-				url.searchParams.set(key, value);
+				nextParams.set(key, value);
 			}
 		});
-		window.history.replaceState(null, "", url.pathname + url.search);
-	}, []);
+		replaceSearchParams(nextParams);
+	}, [replaceSearchParams, searchParams]);
 
 	// Helper to build candidate event properties for analytics
 	const getCandidateEventProps = useCallback((candidate: Candidate) => ({
@@ -166,6 +180,25 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 		);
 	};
 
+	const candidateSearchIndex = useMemo(() => {
+		const index = new Map<string, string>();
+		candidates.forEach((candidate) => {
+			const displayName =
+				candidate.visibility === "anonymous"
+					? candidate.anonymousAlias || "Anonymous"
+					: candidate.name;
+			const tagText = candidate.skills?.map((t) => tagLabels[t]).join(" ") || "";
+			index.set(
+				candidate.id,
+				[displayName, candidate.title, candidate.bio, candidate.location, tagText]
+					.filter(Boolean)
+					.join(" ")
+					.toLowerCase(),
+			);
+		});
+		return index;
+	}, [candidates]);
+
 	const filteredCandidates = useMemo(() => {
 		return candidates.filter((candidate) => {
 			// Availability filter
@@ -202,24 +235,9 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 			}
 
 			// Search filter (name, alias, title, bio, skills)
-			if (searchQuery) {
-				const query = searchQuery.toLowerCase();
-				const displayName =
-					candidate.visibility === "anonymous"
-						? candidate.anonymousAlias || "Anonymous"
-						: candidate.name;
-				const tagText =
-					candidate.skills?.map((t) => tagLabels[t]).join(" ") || "";
-				const searchableText = [
-					displayName,
-					candidate.title,
-					candidate.bio,
-					candidate.location,
-					tagText,
-				]
-					.filter(Boolean)
-					.join(" ")
-					.toLowerCase();
+			if (deferredSearchQuery) {
+				const query = deferredSearchQuery.toLowerCase();
+				const searchableText = candidateSearchIndex.get(candidate.id) || "";
 				if (!searchableText.includes(query)) {
 					return false;
 				}
@@ -227,7 +245,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 
 			return true;
 		});
-	}, [candidates, availabilityFilter, experienceFilter, roleFilter, searchQuery, selectedTags]);
+	}, [candidates, availabilityFilter, experienceFilter, roleFilter, deferredSearchQuery, selectedTags, candidateSearchIndex]);
 
 	// Include today's date so shuffle changes daily (stable after hydration)
 	const [shuffleSeed] = useState(() => new Date().toISOString().split("T")[0]);
@@ -235,14 +253,14 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 	const filterKey = useMemo(
 		() =>
 			[
-				availabilityFilter,
-				experienceFilter,
-				roleFilter,
-				searchQuery,
-				selectedTags.join(","),
-				shuffleSeed,
-			].join("|"),
-		[availabilityFilter, experienceFilter, roleFilter, searchQuery, selectedTags, shuffleSeed]
+					availabilityFilter,
+					experienceFilter,
+					roleFilter,
+					deferredSearchQuery,
+					selectedTags.join(","),
+					shuffleSeed,
+				].join("|"),
+		[availabilityFilter, experienceFilter, roleFilter, deferredSearchQuery, selectedTags, shuffleSeed]
 	);
 
 	// Helper to check skill tags
@@ -751,611 +769,3 @@ const CandidateCard = memo(function CandidateCard({
 		</div>
 	);
 });
-
-function ExpandedCandidateView({
-	candidate,
-	isHot,
-	isTop,
-	isTopStyle,
-	onClose,
-	onCVClick,
-	onSocialClick,
-	onContactClick,
-}: {
-	candidate: Candidate;
-	isHot: boolean;
-	isTop: boolean;
-	isTopStyle: boolean;
-	onClose: () => void;
-	onCVClick?: () => void;
-	onSocialClick?: (platform: string, url: string) => void;
-	onContactClick?: (contactType: "email" | "telegram" | "calendly") => void;
-}) {
-	const isAnonymous = candidate.visibility === "anonymous";
-	const displayName = isAnonymous
-		? candidate.anonymousAlias || "Anonymous"
-		: candidate.name;
-	const profileImage = isAnonymous
-		? "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg"
-		: candidate.profileImage || "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg";
-	const dialogRef = useRef<HTMLDivElement>(null);
-	const closeButtonRef = useRef<HTMLButtonElement>(null);
-	const titleId = `candidate-${candidate.id}-title`;
-	const descriptionId = `candidate-${candidate.id}-bio`;
-	const [copySuccess, setCopySuccess] = useState(false);
-	const [isClosing, setIsClosing] = useState(false);
-	const [isOpen, setIsOpen] = useState(false);
-
-	useEffect(() => {
-		// Trigger open animation after mount
-		requestAnimationFrame(() => setIsOpen(true));
-	}, []);
-
-	const handleClose = useCallback(() => {
-		setIsClosing(true);
-		setTimeout(() => {
-			onClose();
-		}, 300);
-	}, [onClose]);
-
-	const availabilityColor = {
-		looking:
-			"bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
-		open: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
-		"not-looking":
-			"bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400",
-	};
-
-	const handleCopyLink = useCallback(async () => {
-		const url = new URL(window.location.href);
-		url.searchParams.set("candidate", candidate.id);
-		try {
-			await navigator.clipboard.writeText(url.toString());
-			setCopySuccess(true);
-			setTimeout(() => setCopySuccess(false), 2000);
-		} catch (err) {
-			console.error("Failed to copy link:", err);
-		}
-	}, [candidate.id]);
-
-	useEffect(() => {
-		closeButtonRef.current?.focus();
-	}, []);
-
-	const handleDialogKeyDown = useCallback((e: React.KeyboardEvent) => {
-		if (e.key !== "Tab") return;
-
-		const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
-			'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
-		);
-		if (!focusable || focusable.length === 0) return;
-
-		const first = focusable[0];
-		const last = focusable[focusable.length - 1];
-		if (e.shiftKey && document.activeElement === first) {
-			e.preventDefault();
-			last.focus();
-		} else if (!e.shiftKey && document.activeElement === last) {
-			e.preventDefault();
-			first.focus();
-		}
-	}, []);
-
-	return (
-		<div
-			className={`fixed inset-0 z-50 min-h-screen flex sm:items-center sm:justify-center backdrop-blur-sm transition-colors duration-300 ${
-				isClosing ? "bg-black/0" : isOpen ? "bg-black/50" : "bg-black/0"
-			}`}
-			onClick={handleClose}
-		>
-			<div
-				ref={dialogRef}
-				role="dialog"
-				aria-modal="true"
-				aria-labelledby={titleId}
-				aria-describedby={descriptionId}
-				tabIndex={-1}
-				onKeyDown={handleDialogKeyDown}
-				className={`fixed inset-0 sm:relative sm:inset-auto w-full h-[100dvh] sm:h-auto sm:max-w-4xl sm:max-h-[90vh] overflow-y-auto sm:rounded-2xl bg-white dark:bg-neutral-900 shadow-2xl transition-[transform,opacity] duration-300 ${
-					isClosing
-						? "translate-y-full sm:translate-y-0 sm:scale-95 sm:opacity-0 ease-out"
-						: isOpen
-							? "translate-y-0 sm:scale-100 sm:opacity-100 ease-out"
-							: "translate-y-full sm:translate-y-0 sm:scale-95 sm:opacity-0 ease-in"
-				} ${
-					isHot
-						? "sm:ring-2 sm:ring-orange-500 sm:dark:ring-orange-400"
-						: isTopStyle
-							? "sm:ring-2 sm:ring-violet-500 sm:dark:ring-violet-400"
-							: "sm:ring-1 sm:ring-neutral-200 sm:dark:ring-neutral-700"
-				}`}
-				onClick={(e) => e.stopPropagation()}
-			>
-					{/* Desktop action buttons - Copy Link and Close */}
-				<div className="hidden sm:flex absolute top-4 right-4 z-10 items-center gap-2">
-					{/* Copy Link Button */}
-					<button
-						onClick={handleCopyLink}
-						className={`p-2 rounded-full transition-colors active:scale-90 ${
-							copySuccess
-								? "bg-green-100 dark:bg-green-900/50 text-green-600 dark:text-green-400"
-								: "bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400"
-						}`}
-						aria-label={copySuccess ? "Link copied!" : "Copy link to profile"}
-						title={copySuccess ? "Link copied!" : "Copy link to profile"}
-					>
-						{copySuccess ? (
-							<svg
-								className="w-6 h-6"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-							>
-								<polyline points="20 6 9 17 4 12" />
-							</svg>
-						) : (
-							<svg
-								className="w-6 h-6"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-							>
-								<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-								<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-							</svg>
-						)}
-					</button>
-
-					{/* Close Button */}
-					<button
-						onClick={handleClose}
-						className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
-						aria-label="Close profile"
-					>
-						<svg
-							className="w-6 h-6"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							strokeWidth="2"
-							strokeLinecap="round"
-							strokeLinejoin="round"
-						>
-							<line x1="18" y1="6" x2="6" y2="18" />
-							<line x1="6" y1="6" x2="18" y2="18" />
-						</svg>
-					</button>
-				</div>
-
-				{/* Header Section */}
-				<div
-					className={`p-6 sm:p-8 ${
-						isHot
-							? "bg-gradient-to-r from-orange-100 to-amber-100 dark:from-orange-900/40 dark:to-amber-900/40"
-							: isTopStyle
-								? "bg-gradient-to-r from-violet-100 to-purple-100 dark:from-violet-900/40 dark:to-purple-900/40"
-								: "bg-neutral-50 dark:bg-neutral-800/50"
-					}`}
-				>
-					{/* Mobile: Copy link and close buttons */}
-					<div className="sm:hidden flex items-center justify-end gap-2 mb-4 -mt-2">
-						<button
-							onClick={handleCopyLink}
-							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
-							aria-label={copySuccess ? "Link copied!" : "Copy link"}
-						>
-							{copySuccess ? (
-								<svg className="w-6 h-6 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
-									<polyline points="20 6 9 17 4 12" />
-								</svg>
-							) : (
-								<svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-									<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-									<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-								</svg>
-							)}
-						</button>
-						<button
-							ref={closeButtonRef}
-							onClick={handleClose}
-							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
-							aria-label="Close"
-						>
-							<svg
-								className="w-6 h-6"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2.5"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-							>
-								<line x1="18" y1="6" x2="6" y2="18" />
-								<line x1="6" y1="6" x2="18" y2="18" />
-							</svg>
-						</button>
-					</div>
-
-					<div className="flex flex-col items-center sm:flex-row sm:items-start gap-4 sm:gap-6 text-center sm:text-left">
-						{/* Profile Image */}
-						<div className="w-20 h-20 sm:w-32 sm:h-32 flex-shrink-0 rounded-full overflow-hidden bg-neutral-100 dark:bg-neutral-800 ring-4 ring-white dark:ring-neutral-900 hover:scale-[1.08] transition-transform duration-150">
-							<Image
-								src={profileImage}
-								alt={displayName}
-								width={128}
-								height={128}
-								className="object-cover w-full h-full"
-								onError={(e) => {
-									e.currentTarget.onerror = null;
-									e.currentTarget.src = "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg";
-								}}
-							/>
-						</div>
-
-						<div className="flex-1">
-							<div className="flex flex-wrap items-center justify-center sm:justify-start gap-2 mb-2">
-								<h2 id={titleId} className="text-xl sm:text-3xl font-bold">
-									{displayName}
-								</h2>
-								{candidate.featured && (
-									<span className="text-lg text-amber-600 dark:text-amber-400">
-										★
-									</span>
-								)}
-								{candidate.vouched !== false ? (
-									<span
-										className="text-lg text-green-600 dark:text-green-400"
-										title="Personally vouched"
-									>
-										✓
-									</span>
-								) : (
-									<span
-										className="text-lg text-amber-600 dark:text-amber-400"
-										title="Referred (not personally known)"
-									>
-										◇
-									</span>
-								)}
-							</div>
-							<div className="flex flex-wrap items-center justify-center sm:justify-start gap-2 mb-3">
-								<p className="text-base sm:text-lg text-neutral-600 dark:text-neutral-400">
-									{candidate.title}
-								</p>
-								{isHot && (
-									<span className="px-2 py-1 text-xs font-semibold rounded-full bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-[0_0_10px_rgba(251,146,60,0.5)]">
-										🔥 HOT
-									</span>
-								)}
-								{isTop && (
-									<span className="px-2 py-1 text-xs font-semibold rounded-full bg-gradient-to-r from-violet-500 to-purple-500 text-white shadow-[0_0_10px_rgba(139,92,246,0.5)]">
-										✨ TOP
-									</span>
-								)}
-								{isNew(candidate.createdAt) && (
-									<span className="px-2 py-1 text-xs font-semibold rounded-full bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400 animate-pulse-new">
-										NEW
-									</span>
-								)}
-							</div>
-							<div className="flex flex-wrap justify-center sm:justify-start gap-2">
-								<span
-									className={`px-3 py-1 text-sm rounded-full ${availabilityColor[candidate.availability]}`}
-								>
-									{availabilityLabels[candidate.availability]}
-								</span>
-								{candidate.experience && (
-									<span className="px-3 py-1 text-sm rounded-full bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400">
-										{experienceLabels[candidate.experience]}
-									</span>
-								)}
-								{candidate.location && (
-									<span className="px-3 py-1 text-sm rounded-full bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400">
-										{candidate.location}
-									</span>
-								)}
-								{candidate.remote && (
-									<span className="px-3 py-1 text-sm rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">
-										Remote OK
-									</span>
-								)}
-							</div>
-						</div>
-					</div>
-				</div>
-
-				{/* Content Section */}
-				<div className="p-6 sm:p-8 space-y-6 sm:space-y-8 text-center">
-					{/* Bio */}
-					<div>
-						<h3 className="text-lg font-semibold mb-3">About</h3>
-						<p
-							id={descriptionId}
-							className="text-neutral-600 dark:text-neutral-400 leading-relaxed"
-						>
-							{candidate.bio}
-						</p>
-					</div>
-
-					{/* Skills */}
-					{candidate.skills && candidate.skills.length > 0 && (() => {
-						const displaySkills = candidate.skills.filter((tag) => tag !== "hot" && tag !== "top");
-						return displaySkills.length > 0 && (
-							<div>
-								<h3 className="text-lg font-semibold mb-3">Skills</h3>
-								<div className="flex flex-wrap justify-center gap-2">
-									{displaySkills.map((tag) => (
-										<span
-											key={tag}
-											className="px-3 py-1.5 text-sm rounded-full bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
-										>
-											{tagLabels[tag] ?? tag}
-										</span>
-									))}
-								</div>
-							</div>
-						);
-					})()}
-
-					{/* Preferred Roles */}
-					{candidate.preferredRoles && candidate.preferredRoles.length > 0 && (
-						<div>
-							<h3 className="text-lg font-semibold mb-3">Looking For</h3>
-							<div className="flex flex-wrap justify-center gap-2">
-								{candidate.preferredRoles.map((role) => (
-									<span
-										key={role}
-										className="px-3 py-1.5 text-sm rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
-									>
-										{role}
-									</span>
-								))}
-							</div>
-						</div>
-					)}
-
-					{/* Previous Companies */}
-					{candidate.companies && candidate.companies.length > 0 && (
-						<div>
-							<h3 className="text-lg font-semibold mb-3">Experience</h3>
-							<div className="flex flex-wrap justify-center gap-3">
-								{candidate.companies.map((company) => (
-									<a
-										key={company.name}
-										href={company.url}
-										target="_blank"
-										rel="noopener noreferrer"
-										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-50 dark:bg-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
-									>
-										{company.logo && (
-											<Image
-												src={company.logo || "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg"}
-												alt={company.name}
-												width={24}
-												height={24}
-												className="rounded"
-												onError={(e) => {
-													e.currentTarget.onerror = null;
-													e.currentTarget.style.display = "none";
-												}}
-											/>
-										)}
-										<span className="font-medium">{company.name}</span>
-									</a>
-								))}
-							</div>
-						</div>
-					)}
-
-					{/* Achievements */}
-					{candidate.achievements && candidate.achievements.length > 0 && (
-						<div>
-							<h3 className="text-lg font-semibold mb-3">Achievements</h3>
-							<ul className="space-y-2">
-								{candidate.achievements.map((achievement, i) => (
-									<li key={i} className="flex items-start gap-2">
-										<span className="text-amber-500">★</span>
-										<div>
-											{achievement.url ? (
-												<a
-													href={achievement.url}
-													target="_blank"
-													rel="noopener noreferrer"
-													className="font-medium hover:underline"
-												>
-													{achievement.title}
-												</a>
-											) : (
-												<span className="font-medium">{achievement.title}</span>
-											)}
-											{achievement.description && (
-												<p className="text-sm text-neutral-500">
-													{achievement.description}
-												</p>
-											)}
-										</div>
-									</li>
-								))}
-							</ul>
-						</div>
-					)}
-
-					{/* Contact Section */}
-					<div className="pt-6 border-t border-neutral-200 dark:border-neutral-700">
-						<h3 className="text-lg font-semibold mb-4">Get in Touch</h3>
-						{isAnonymous ? (
-							<a
-								href={DCBUILDER_TELEGRAM}
-								target="_blank"
-								rel="noopener noreferrer"
-								onClick={() => onContactClick?.("telegram")}
-								className="inline-flex items-center gap-2 px-6 py-3 text-base font-medium rounded-lg bg-neutral-900 text-white dark:bg-white dark:text-neutral-900 hover:opacity-90 transition-opacity"
-							>
-								<svg
-									className="w-5 h-5"
-									viewBox="0 0 24 24"
-									fill="currentColor"
-								>
-									<path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
-								</svg>
-								Request Introduction via Telegram
-							</a>
-						) : (
-							<div className="flex flex-wrap justify-center gap-3">
-								{candidate.socials?.x && (
-									<a
-										href={candidate.socials.x}
-										target="_blank"
-										rel="noopener noreferrer"
-										onClick={() => onSocialClick?.("x", candidate.socials!.x!)}
-										className="p-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-										title="X"
-									>
-										<svg
-											className="w-5 h-5"
-											viewBox="0 0 24 24"
-											fill="currentColor"
-										>
-											<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-										</svg>
-									</a>
-								)}
-								{candidate.socials?.github && (
-									<a
-										href={candidate.socials.github}
-										target="_blank"
-										rel="noopener noreferrer"
-										onClick={() => onSocialClick?.("github", candidate.socials!.github!)}
-										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-									>
-										<svg
-											className="w-5 h-5"
-											viewBox="0 0 24 24"
-											fill="currentColor"
-										>
-											<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-										</svg>
-										<span>GitHub</span>
-									</a>
-								)}
-								{candidate.socials?.linkedin && (
-									<a
-										href={candidate.socials.linkedin}
-										target="_blank"
-										rel="noopener noreferrer"
-										onClick={() => onSocialClick?.("linkedin", candidate.socials!.linkedin!)}
-										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-									>
-										<svg
-											className="w-5 h-5"
-											viewBox="0 0 24 24"
-											fill="currentColor"
-										>
-											<path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-										</svg>
-										<span>LinkedIn</span>
-									</a>
-								)}
-								{candidate.socials?.email && (
-									<a
-										href={`mailto:${candidate.socials.email}`}
-										onClick={() => onContactClick?.("email")}
-										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-									>
-										<svg
-											className="w-5 h-5"
-											viewBox="0 0 24 24"
-											fill="none"
-											stroke="currentColor"
-											strokeWidth="2"
-											strokeLinecap="round"
-											strokeLinejoin="round"
-										>
-											<rect x="2" y="4" width="20" height="16" rx="2" />
-											<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
-										</svg>
-										<span>Email</span>
-									</a>
-								)}
-								{candidate.socials?.website && (
-									<a
-										href={candidate.socials.website}
-										target="_blank"
-										rel="noopener noreferrer"
-										onClick={() => onSocialClick?.("website", candidate.socials!.website!)}
-										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-									>
-										<svg
-											className="w-5 h-5"
-											viewBox="0 0 24 24"
-											fill="none"
-											stroke="currentColor"
-											strokeWidth="2"
-											strokeLinecap="round"
-											strokeLinejoin="round"
-										>
-											<circle cx="12" cy="12" r="10" />
-											<line x1="2" y1="12" x2="22" y2="12" />
-											<path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
-										</svg>
-										<span>Website</span>
-									</a>
-								)}
-								{candidate.socials?.telegram && (
-									<a
-										href={candidate.socials.telegram}
-										target="_blank"
-										rel="noopener noreferrer"
-										onClick={() => onSocialClick?.("telegram", candidate.socials!.telegram!)}
-										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-									>
-										<svg
-											className="w-5 h-5"
-											viewBox="0 0 24 24"
-											fill="currentColor"
-										>
-											<path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
-										</svg>
-										<span>Telegram</span>
-									</a>
-								)}
-								{candidate.socials?.cv && (
-									<a
-										href={candidate.socials.cv}
-										target="_blank"
-										rel="noopener noreferrer"
-										onClick={onCVClick}
-										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors"
-									>
-										<svg
-											className="w-5 h-5"
-											viewBox="0 0 24 24"
-											fill="none"
-											stroke="currentColor"
-											strokeWidth="2"
-											strokeLinecap="round"
-											strokeLinejoin="round"
-										>
-											<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-											<polyline points="14 2 14 8 20 8" />
-											<line x1="16" y1="13" x2="8" y2="13" />
-											<line x1="16" y1="17" x2="8" y2="17" />
-											<polyline points="10 9 9 9 8 9" />
-										</svg>
-										<span>View CV / Resume</span>
-									</a>
-								)}
-							</div>
-						)}
-					</div>
-				</div>
-			</div>
-		</div>
-	);
-}

--- a/src/components/CandidatesGrid.tsx
+++ b/src/components/CandidatesGrid.tsx
@@ -395,14 +395,15 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 
 				{/* Row 2: Search */}
 				<div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
-					<div className="flex-1 relative">
-						<input
-							type="text"
-							placeholder="Search candidates..."
-							value={searchQuery}
-							onChange={(e) => setSearchQuery(e.target.value)}
-							className="w-full px-3 py-2 pr-9 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
-						/>
+						<div className="flex-1 relative">
+							<input
+								type="text"
+								aria-label="Search candidates"
+								placeholder="Search candidates..."
+								value={searchQuery}
+								onChange={(e) => setSearchQuery(e.target.value)}
+								className="w-full px-3 py-2 pr-9 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
+							/>
 						{searchQuery && (
 							<button
 								type="button"
@@ -475,7 +476,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 								<button
 									key={tag}
 									onClick={() => toggleTag(tag)}
-									className={`px-3 py-1.5 text-sm font-medium rounded-full transition-all ${
+									className={`px-3 py-1.5 text-sm font-medium rounded-full transition-colors ${
 										tag === "hot"
 											? selectedTags.includes(tag)
 												? "bg-gradient-to-r from-orange-500 to-amber-500 text-white font-semibold shadow-[0_0_15px_rgba(251,146,60,0.6)]"
@@ -608,7 +609,7 @@ const CandidateCard = memo(function CandidateCard({
 
 	return (
 		<div
-			className={cn("p-4 rounded-xl border transition-all overflow-hidden", cardStyle)}
+			className={cn("p-4 rounded-xl border transition-[border-color,box-shadow,background-color] overflow-hidden", cardStyle)}
 		>
 			{/* Header */}
 			<div className="flex flex-col items-center gap-3 text-center">
@@ -717,7 +718,7 @@ const CandidateCard = memo(function CandidateCard({
 						event.stopPropagation();
 						onExpand();
 					}}
-					className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-700 dark:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-700 hover:border-neutral-400 dark:hover:border-neutral-500 transition-all"
+					className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-700 dark:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-700 hover:border-neutral-400 dark:hover:border-neutral-500 transition-colors"
 				>
 					<span>View Details</span>
 					<ChevronRightIcon />
@@ -842,7 +843,7 @@ function ExpandedCandidateView({
 
 	return (
 		<div
-			className={`fixed inset-0 z-50 min-h-screen flex sm:items-center sm:justify-center backdrop-blur-sm transition-all duration-300 ${
+			className={`fixed inset-0 z-50 min-h-screen flex sm:items-center sm:justify-center backdrop-blur-sm transition-colors duration-300 ${
 				isClosing ? "bg-black/0" : isOpen ? "bg-black/50" : "bg-black/0"
 			}`}
 			onClick={handleClose}
@@ -855,7 +856,7 @@ function ExpandedCandidateView({
 				aria-describedby={descriptionId}
 				tabIndex={-1}
 				onKeyDown={handleDialogKeyDown}
-				className={`fixed inset-0 sm:relative sm:inset-auto w-full h-[100dvh] sm:h-auto sm:max-w-4xl sm:max-h-[90vh] overflow-y-auto sm:rounded-2xl bg-white dark:bg-neutral-900 shadow-2xl transition-all duration-300 ${
+				className={`fixed inset-0 sm:relative sm:inset-auto w-full h-[100dvh] sm:h-auto sm:max-w-4xl sm:max-h-[90vh] overflow-y-auto sm:rounded-2xl bg-white dark:bg-neutral-900 shadow-2xl transition-[transform,opacity] duration-300 ${
 					isClosing
 						? "translate-y-full sm:translate-y-0 sm:scale-95 sm:opacity-0 ease-out"
 						: isOpen
@@ -875,7 +876,7 @@ function ExpandedCandidateView({
 					{/* Copy Link Button */}
 					<button
 						onClick={handleCopyLink}
-						className={`p-2 rounded-full transition-all active:scale-90 ${
+						className={`p-2 rounded-full transition-colors active:scale-90 ${
 							copySuccess
 								? "bg-green-100 dark:bg-green-900/50 text-green-600 dark:text-green-400"
 								: "bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400"
@@ -914,7 +915,7 @@ function ExpandedCandidateView({
 					{/* Close Button */}
 					<button
 						onClick={handleClose}
-						className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-all active:scale-90"
+						className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
 						aria-label="Close profile"
 					>
 						<svg
@@ -946,7 +947,7 @@ function ExpandedCandidateView({
 					<div className="sm:hidden flex items-center justify-end gap-2 mb-4 -mt-2">
 						<button
 							onClick={handleCopyLink}
-							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-all active:scale-90"
+							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
 							aria-label={copySuccess ? "Link copied!" : "Copy link"}
 						>
 							{copySuccess ? (
@@ -963,7 +964,7 @@ function ExpandedCandidateView({
 						<button
 							ref={closeButtonRef}
 							onClick={handleClose}
-							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-all active:scale-90"
+							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
 							aria-label="Close"
 						>
 							<svg

--- a/src/components/CandidatesGrid.tsx
+++ b/src/components/CandidatesGrid.tsx
@@ -3,7 +3,7 @@
 import dynamic from "next/dynamic";
 import { useState, useMemo, useEffect, useRef, useCallback, memo, useDeferredValue } from "react";
 import Image from "next/image";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import {
 	Candidate,
 	AvailabilityStatus,
@@ -46,8 +46,6 @@ interface CandidatesGridProps {
 }
 
 export function CandidatesGrid({ candidates }: CandidatesGridProps) {
-	const router = useRouter();
-	const pathname = usePathname();
 	const searchParams = useSearchParams();
 	const [availabilityFilter, setAvailabilityFilter] = useState<
 		"all" | AvailabilityStatus
@@ -73,13 +71,14 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 	const { isHotCandidate, hasTopTag, showTopCardStyle } = useHotCandidates();
 
 	const replaceSearchParams = useCallback((nextParams: URLSearchParams) => {
+		const currentUrl = new URL(window.location.href);
 		const queryString = nextParams.toString();
-		if (queryString === searchParams.toString()) return;
-		router.replace(queryString ? `${pathname}?${queryString}` : pathname, { scroll: false });
-	}, [pathname, router, searchParams]);
+		if (queryString === currentUrl.searchParams.toString()) return;
+		window.history.replaceState(null, "", queryString ? `${currentUrl.pathname}?${queryString}` : currentUrl.pathname);
+	}, []);
 
 	const updateUrlParams = useCallback((updates: Record<string, string | null>) => {
-		const nextParams = new URLSearchParams(searchParams.toString());
+		const nextParams = new URLSearchParams(window.location.search);
 		Object.entries(updates).forEach(([key, value]) => {
 			if (value === null || value === "") {
 				nextParams.delete(key);
@@ -88,7 +87,7 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 			}
 		});
 		replaceSearchParams(nextParams);
-	}, [replaceSearchParams, searchParams]);
+	}, [replaceSearchParams]);
 
 	// Helper to build candidate event properties for analytics
 	const getCandidateEventProps = useCallback((candidate: Candidate) => ({

--- a/src/components/CustomMultiSelect.tsx
+++ b/src/components/CustomMultiSelect.tsx
@@ -165,43 +165,30 @@ export function CustomMultiSelect({
 				aria-haspopup="listbox"
 				aria-expanded={isOpen}
 				aria-controls={id ? `${id}-listbox` : undefined}
-				className="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
+				className="w-full flex items-center justify-between gap-2 px-3 py-2 pr-9 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
 			>
 				<span className="truncate">{displayText}</span>
-				<div className="flex items-center gap-1.5">
-					{values.length > 0 && (
-						<span
-							role="button"
-							tabIndex={0}
-							onClick={(e) => {
-								e.stopPropagation();
-								onChange([]);
-							}}
-							onKeyDown={(e) => {
-								if (e.key === "Enter" || e.key === " ") {
-									e.preventDefault();
-									e.stopPropagation();
-									onChange([]);
-								}
-							}}
-							className="p-0.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 cursor-pointer"
-							aria-label="Clear selection"
-						>
-							<svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-								<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-							</svg>
-						</span>
-					)}
-					<svg
-						className={`w-4 h-4 flex-shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`}
-						fill="none"
-						viewBox="0 0 24 24"
-						stroke="currentColor"
-					>
-						<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-					</svg>
-				</div>
+				<svg
+					className={`w-4 h-4 flex-shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`}
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+				</svg>
 			</button>
+			{values.length > 0 && (
+				<button
+					type="button"
+					onClick={() => onChange([])}
+					className="absolute right-7 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 cursor-pointer"
+					aria-label="Clear selection"
+				>
+					<svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+					</svg>
+				</button>
+			)}
 
 			{/* Dropdown */}
 			{isOpen && (

--- a/src/components/ExpandedCandidateView.tsx
+++ b/src/components/ExpandedCandidateView.tsx
@@ -1,0 +1,620 @@
+"use client";
+
+import { useRef, useState, useEffect, useCallback } from "react";
+import Image from "next/image";
+import {
+  Candidate,
+  tagLabels,
+  availabilityLabels,
+  experienceLabels,
+  DCBUILDER_TELEGRAM,
+} from "@/data/candidates";
+import { isNew } from "@/lib/shuffle";
+
+export function ExpandedCandidateView({
+	candidate,
+	isHot,
+	isTop,
+	isTopStyle,
+	onClose,
+	onCVClick,
+	onSocialClick,
+	onContactClick,
+}: {
+	candidate: Candidate;
+	isHot: boolean;
+	isTop: boolean;
+	isTopStyle: boolean;
+	onClose: () => void;
+	onCVClick?: () => void;
+	onSocialClick?: (platform: string, url: string) => void;
+	onContactClick?: (contactType: "email" | "telegram" | "calendly") => void;
+}) {
+	const isAnonymous = candidate.visibility === "anonymous";
+	const displayName = isAnonymous
+		? candidate.anonymousAlias || "Anonymous"
+		: candidate.name;
+	const profileImage = isAnonymous
+		? "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg"
+		: candidate.profileImage || "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg";
+	const dialogRef = useRef<HTMLDivElement>(null);
+	const closeButtonRef = useRef<HTMLButtonElement>(null);
+	const titleId = `candidate-${candidate.id}-title`;
+	const descriptionId = `candidate-${candidate.id}-bio`;
+	const [copySuccess, setCopySuccess] = useState(false);
+	const [isClosing, setIsClosing] = useState(false);
+	const [isOpen, setIsOpen] = useState(false);
+
+	useEffect(() => {
+		// Trigger open animation after mount
+		requestAnimationFrame(() => setIsOpen(true));
+	}, []);
+
+	const handleClose = useCallback(() => {
+		setIsClosing(true);
+		setTimeout(() => {
+			onClose();
+		}, 300);
+	}, [onClose]);
+
+	const availabilityColor = {
+		looking:
+			"bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+		open: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+		"not-looking":
+			"bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400",
+	};
+
+	const handleCopyLink = useCallback(async () => {
+		const url = new URL(window.location.href);
+		url.searchParams.set("candidate", candidate.id);
+		try {
+			await navigator.clipboard.writeText(url.toString());
+			setCopySuccess(true);
+			setTimeout(() => setCopySuccess(false), 2000);
+		} catch (err) {
+			console.error("Failed to copy link:", err);
+		}
+	}, [candidate.id]);
+
+	useEffect(() => {
+		closeButtonRef.current?.focus();
+	}, []);
+
+	const handleDialogKeyDown = useCallback((e: React.KeyboardEvent) => {
+		if (e.key !== "Tab") return;
+
+		const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+			'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+		);
+		if (!focusable || focusable.length === 0) return;
+
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+		if (e.shiftKey && document.activeElement === first) {
+			e.preventDefault();
+			last.focus();
+		} else if (!e.shiftKey && document.activeElement === last) {
+			e.preventDefault();
+			first.focus();
+		}
+	}, []);
+
+	return (
+		<div
+			className={`fixed inset-0 z-50 min-h-screen flex sm:items-center sm:justify-center backdrop-blur-sm transition-colors duration-300 ${
+				isClosing ? "bg-black/0" : isOpen ? "bg-black/50" : "bg-black/0"
+			}`}
+			onClick={handleClose}
+		>
+			<div
+				ref={dialogRef}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby={titleId}
+				aria-describedby={descriptionId}
+				tabIndex={-1}
+				onKeyDown={handleDialogKeyDown}
+				className={`fixed inset-0 sm:relative sm:inset-auto w-full h-[100dvh] sm:h-auto sm:max-w-4xl sm:max-h-[90vh] overflow-y-auto sm:rounded-2xl bg-white dark:bg-neutral-900 shadow-2xl transition-[transform,opacity] duration-300 ${
+					isClosing
+						? "translate-y-full sm:translate-y-0 sm:scale-95 sm:opacity-0 ease-out"
+						: isOpen
+							? "translate-y-0 sm:scale-100 sm:opacity-100 ease-out"
+							: "translate-y-full sm:translate-y-0 sm:scale-95 sm:opacity-0 ease-in"
+				} ${
+					isHot
+						? "sm:ring-2 sm:ring-orange-500 sm:dark:ring-orange-400"
+						: isTopStyle
+							? "sm:ring-2 sm:ring-violet-500 sm:dark:ring-violet-400"
+							: "sm:ring-1 sm:ring-neutral-200 sm:dark:ring-neutral-700"
+				}`}
+				onClick={(e) => e.stopPropagation()}
+			>
+					{/* Desktop action buttons - Copy Link and Close */}
+				<div className="hidden sm:flex absolute top-4 right-4 z-10 items-center gap-2">
+					{/* Copy Link Button */}
+					<button
+						onClick={handleCopyLink}
+						className={`p-2 rounded-full transition-colors active:scale-90 ${
+							copySuccess
+								? "bg-green-100 dark:bg-green-900/50 text-green-600 dark:text-green-400"
+								: "bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400"
+						}`}
+						aria-label={copySuccess ? "Link copied!" : "Copy link to profile"}
+						title={copySuccess ? "Link copied!" : "Copy link to profile"}
+					>
+						{copySuccess ? (
+							<svg
+								className="w-6 h-6"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							>
+								<polyline points="20 6 9 17 4 12" />
+							</svg>
+						) : (
+							<svg
+								className="w-6 h-6"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							>
+								<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+								<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+							</svg>
+						)}
+					</button>
+
+					{/* Close Button */}
+					<button
+						onClick={handleClose}
+						className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
+						aria-label="Close profile"
+					>
+						<svg
+							className="w-6 h-6"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+						>
+							<line x1="18" y1="6" x2="6" y2="18" />
+							<line x1="6" y1="6" x2="18" y2="18" />
+						</svg>
+					</button>
+				</div>
+
+				{/* Header Section */}
+				<div
+					className={`p-6 sm:p-8 ${
+						isHot
+							? "bg-gradient-to-r from-orange-100 to-amber-100 dark:from-orange-900/40 dark:to-amber-900/40"
+							: isTopStyle
+								? "bg-gradient-to-r from-violet-100 to-purple-100 dark:from-violet-900/40 dark:to-purple-900/40"
+								: "bg-neutral-50 dark:bg-neutral-800/50"
+					}`}
+				>
+					{/* Mobile: Copy link and close buttons */}
+					<div className="sm:hidden flex items-center justify-end gap-2 mb-4 -mt-2">
+						<button
+							onClick={handleCopyLink}
+							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
+							aria-label={copySuccess ? "Link copied!" : "Copy link"}
+						>
+							{copySuccess ? (
+								<svg className="w-6 h-6 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+									<polyline points="20 6 9 17 4 12" />
+								</svg>
+							) : (
+								<svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+									<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+									<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+								</svg>
+							)}
+						</button>
+						<button
+							ref={closeButtonRef}
+							onClick={handleClose}
+							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
+							aria-label="Close"
+						>
+							<svg
+								className="w-6 h-6"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2.5"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							>
+								<line x1="18" y1="6" x2="6" y2="18" />
+								<line x1="6" y1="6" x2="18" y2="18" />
+							</svg>
+						</button>
+					</div>
+
+					<div className="flex flex-col items-center sm:flex-row sm:items-start gap-4 sm:gap-6 text-center sm:text-left">
+						{/* Profile Image */}
+						<div className="w-20 h-20 sm:w-32 sm:h-32 flex-shrink-0 rounded-full overflow-hidden bg-neutral-100 dark:bg-neutral-800 ring-4 ring-white dark:ring-neutral-900 hover:scale-[1.08] transition-transform duration-150">
+							<Image
+								src={profileImage}
+								alt={displayName}
+								width={128}
+								height={128}
+								className="object-cover w-full h-full"
+								onError={(e) => {
+									e.currentTarget.onerror = null;
+									e.currentTarget.src = "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg";
+								}}
+							/>
+						</div>
+
+						<div className="flex-1">
+							<div className="flex flex-wrap items-center justify-center sm:justify-start gap-2 mb-2">
+								<h2 id={titleId} className="text-xl sm:text-3xl font-bold">
+									{displayName}
+								</h2>
+								{candidate.featured && (
+									<span className="text-lg text-amber-600 dark:text-amber-400">
+										★
+									</span>
+								)}
+								{candidate.vouched !== false ? (
+									<span
+										className="text-lg text-green-600 dark:text-green-400"
+										title="Personally vouched"
+									>
+										✓
+									</span>
+								) : (
+									<span
+										className="text-lg text-amber-600 dark:text-amber-400"
+										title="Referred (not personally known)"
+									>
+										◇
+									</span>
+								)}
+							</div>
+							<div className="flex flex-wrap items-center justify-center sm:justify-start gap-2 mb-3">
+								<p className="text-base sm:text-lg text-neutral-600 dark:text-neutral-400">
+									{candidate.title}
+								</p>
+								{isHot && (
+									<span className="px-2 py-1 text-xs font-semibold rounded-full bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-[0_0_10px_rgba(251,146,60,0.5)]">
+										🔥 HOT
+									</span>
+								)}
+								{isTop && (
+									<span className="px-2 py-1 text-xs font-semibold rounded-full bg-gradient-to-r from-violet-500 to-purple-500 text-white shadow-[0_0_10px_rgba(139,92,246,0.5)]">
+										✨ TOP
+									</span>
+								)}
+								{isNew(candidate.createdAt) && (
+									<span className="px-2 py-1 text-xs font-semibold rounded-full bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400 animate-pulse-new">
+										NEW
+									</span>
+								)}
+							</div>
+							<div className="flex flex-wrap justify-center sm:justify-start gap-2">
+								<span
+									className={`px-3 py-1 text-sm rounded-full ${availabilityColor[candidate.availability]}`}
+								>
+									{availabilityLabels[candidate.availability]}
+								</span>
+								{candidate.experience && (
+									<span className="px-3 py-1 text-sm rounded-full bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400">
+										{experienceLabels[candidate.experience]}
+									</span>
+								)}
+								{candidate.location && (
+									<span className="px-3 py-1 text-sm rounded-full bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400">
+										{candidate.location}
+									</span>
+								)}
+								{candidate.remote && (
+									<span className="px-3 py-1 text-sm rounded-full bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400">
+										Remote OK
+									</span>
+								)}
+							</div>
+						</div>
+					</div>
+				</div>
+
+				{/* Content Section */}
+				<div className="p-6 sm:p-8 space-y-6 sm:space-y-8 text-center">
+					{/* Bio */}
+					<div>
+						<h3 className="text-lg font-semibold mb-3">About</h3>
+						<p
+							id={descriptionId}
+							className="text-neutral-600 dark:text-neutral-400 leading-relaxed"
+						>
+							{candidate.bio}
+						</p>
+					</div>
+
+					{/* Skills */}
+					{candidate.skills && candidate.skills.length > 0 && (() => {
+						const displaySkills = candidate.skills.filter((tag) => tag !== "hot" && tag !== "top");
+						return displaySkills.length > 0 && (
+							<div>
+								<h3 className="text-lg font-semibold mb-3">Skills</h3>
+								<div className="flex flex-wrap justify-center gap-2">
+									{displaySkills.map((tag) => (
+										<span
+											key={tag}
+											className="px-3 py-1.5 text-sm rounded-full bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+										>
+											{tagLabels[tag] ?? tag}
+										</span>
+									))}
+								</div>
+							</div>
+						);
+					})()}
+
+					{/* Preferred Roles */}
+					{candidate.preferredRoles && candidate.preferredRoles.length > 0 && (
+						<div>
+							<h3 className="text-lg font-semibold mb-3">Looking For</h3>
+							<div className="flex flex-wrap justify-center gap-2">
+								{candidate.preferredRoles.map((role) => (
+									<span
+										key={role}
+										className="px-3 py-1.5 text-sm rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+									>
+										{role}
+									</span>
+								))}
+							</div>
+						</div>
+					)}
+
+					{/* Previous Companies */}
+					{candidate.companies && candidate.companies.length > 0 && (
+						<div>
+							<h3 className="text-lg font-semibold mb-3">Experience</h3>
+							<div className="flex flex-wrap justify-center gap-3">
+								{candidate.companies.map((company) => (
+									<a
+										key={company.name}
+										href={company.url}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-50 dark:bg-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
+									>
+										{company.logo && (
+											<Image
+												src={company.logo || "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg"}
+												alt={company.name}
+												width={24}
+												height={24}
+												className="rounded"
+												onError={(e) => {
+													e.currentTarget.onerror = null;
+													e.currentTarget.style.display = "none";
+												}}
+											/>
+										)}
+										<span className="font-medium">{company.name}</span>
+									</a>
+								))}
+							</div>
+						</div>
+					)}
+
+					{/* Achievements */}
+					{candidate.achievements && candidate.achievements.length > 0 && (
+						<div>
+							<h3 className="text-lg font-semibold mb-3">Achievements</h3>
+							<ul className="space-y-2">
+								{candidate.achievements.map((achievement, i) => (
+									<li key={i} className="flex items-start gap-2">
+										<span className="text-amber-500">★</span>
+										<div>
+											{achievement.url ? (
+												<a
+													href={achievement.url}
+													target="_blank"
+													rel="noopener noreferrer"
+													className="font-medium hover:underline"
+												>
+													{achievement.title}
+												</a>
+											) : (
+												<span className="font-medium">{achievement.title}</span>
+											)}
+											{achievement.description && (
+												<p className="text-sm text-neutral-500">
+													{achievement.description}
+												</p>
+											)}
+										</div>
+									</li>
+								))}
+							</ul>
+						</div>
+					)}
+
+					{/* Contact Section */}
+					<div className="pt-6 border-t border-neutral-200 dark:border-neutral-700">
+						<h3 className="text-lg font-semibold mb-4">Get in Touch</h3>
+						{isAnonymous ? (
+							<a
+								href={DCBUILDER_TELEGRAM}
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={() => onContactClick?.("telegram")}
+								className="inline-flex items-center gap-2 px-6 py-3 text-base font-medium rounded-lg bg-neutral-900 text-white dark:bg-white dark:text-neutral-900 hover:opacity-90 transition-opacity"
+							>
+								<svg
+									className="w-5 h-5"
+									viewBox="0 0 24 24"
+									fill="currentColor"
+								>
+									<path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
+								</svg>
+								Request Introduction via Telegram
+							</a>
+						) : (
+							<div className="flex flex-wrap justify-center gap-3">
+								{candidate.socials?.x && (
+									<a
+										href={candidate.socials.x}
+										target="_blank"
+										rel="noopener noreferrer"
+										onClick={() => onSocialClick?.("x", candidate.socials!.x!)}
+										className="p-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+										title="X"
+									>
+										<svg
+											className="w-5 h-5"
+											viewBox="0 0 24 24"
+											fill="currentColor"
+										>
+											<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+										</svg>
+									</a>
+								)}
+								{candidate.socials?.github && (
+									<a
+										href={candidate.socials.github}
+										target="_blank"
+										rel="noopener noreferrer"
+										onClick={() => onSocialClick?.("github", candidate.socials!.github!)}
+										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+									>
+										<svg
+											className="w-5 h-5"
+											viewBox="0 0 24 24"
+											fill="currentColor"
+										>
+											<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+										</svg>
+										<span>GitHub</span>
+									</a>
+								)}
+								{candidate.socials?.linkedin && (
+									<a
+										href={candidate.socials.linkedin}
+										target="_blank"
+										rel="noopener noreferrer"
+										onClick={() => onSocialClick?.("linkedin", candidate.socials!.linkedin!)}
+										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+									>
+										<svg
+											className="w-5 h-5"
+											viewBox="0 0 24 24"
+											fill="currentColor"
+										>
+											<path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+										</svg>
+										<span>LinkedIn</span>
+									</a>
+								)}
+								{candidate.socials?.email && (
+									<a
+										href={`mailto:${candidate.socials.email}`}
+										onClick={() => onContactClick?.("email")}
+										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+									>
+										<svg
+											className="w-5 h-5"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="currentColor"
+											strokeWidth="2"
+											strokeLinecap="round"
+											strokeLinejoin="round"
+										>
+											<rect x="2" y="4" width="20" height="16" rx="2" />
+											<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+										</svg>
+										<span>Email</span>
+									</a>
+								)}
+								{candidate.socials?.website && (
+									<a
+										href={candidate.socials.website}
+										target="_blank"
+										rel="noopener noreferrer"
+										onClick={() => onSocialClick?.("website", candidate.socials!.website!)}
+										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+									>
+										<svg
+											className="w-5 h-5"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="currentColor"
+											strokeWidth="2"
+											strokeLinecap="round"
+											strokeLinejoin="round"
+										>
+											<circle cx="12" cy="12" r="10" />
+											<line x1="2" y1="12" x2="22" y2="12" />
+											<path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+										</svg>
+										<span>Website</span>
+									</a>
+								)}
+								{candidate.socials?.telegram && (
+									<a
+										href={candidate.socials.telegram}
+										target="_blank"
+										rel="noopener noreferrer"
+										onClick={() => onSocialClick?.("telegram", candidate.socials!.telegram!)}
+										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+									>
+										<svg
+											className="w-5 h-5"
+											viewBox="0 0 24 24"
+											fill="currentColor"
+										>
+											<path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
+										</svg>
+										<span>Telegram</span>
+									</a>
+								)}
+								{candidate.socials?.cv && (
+									<a
+										href={candidate.socials.cv}
+										target="_blank"
+										rel="noopener noreferrer"
+										onClick={onCVClick}
+										className="flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+									>
+										<svg
+											className="w-5 h-5"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="currentColor"
+											strokeWidth="2"
+											strokeLinecap="round"
+											strokeLinejoin="round"
+										>
+											<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+											<polyline points="14 2 14 8 20 8" />
+											<line x1="16" y1="13" x2="8" y2="13" />
+											<line x1="16" y1="17" x2="8" y2="17" />
+											<polyline points="10 9 9 9 8 9" />
+										</svg>
+										<span>View CV / Resume</span>
+									</a>
+								)}
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/ExpandedJobView.tsx
+++ b/src/components/ExpandedJobView.tsx
@@ -1,0 +1,502 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef, useId } from "react";
+import Image from "next/image";
+import Markdown from "react-markdown";
+import { Job } from "@/data/jobs";
+import { isNew } from "@/lib/shuffle";
+
+// Job type labels for display
+const jobTypeLabels: Record<string, string> = {
+	"full-time": "Full-time",
+	"part-time": "Part-time",
+	contract: "Contract",
+	internship: "Internship",
+};
+
+type JobDescriptionContent = {
+	description?: string;
+};
+
+const jobDescriptionCache = new Map<string, JobDescriptionContent>();
+
+// Expanded Job View Component
+export function ExpandedJobView({
+	job,
+	onClose,
+	jobUrl,
+	onViewOtherJobs,
+	otherJobsCount,
+	onApplyClick,
+	tagLabels,
+}: {
+	job: Job;
+	onClose: () => void;
+	jobUrl: string;
+	onViewOtherJobs: () => void;
+	otherJobsCount: number;
+	onApplyClick?: () => void;
+	tagLabels: Record<string, string>;
+}) {
+	const isHot = job.tags?.includes("hot");
+	const dialogRef = useRef<HTMLDivElement>(null);
+	const [copiedLink, setCopiedLink] = useState<"job" | "apply" | null>(null);
+	const [enrichedContent, setEnrichedContent] =
+		useState<JobDescriptionContent | null>(null);
+	const [isEnriching, setIsEnriching] = useState(false);
+	const [isClosing, setIsClosing] = useState(false);
+	const [isOpen, setIsOpen] = useState(false);
+	const titleId = useId();
+	const descriptionId = useId();
+
+	useEffect(() => {
+		// Trigger open animation after mount
+		requestAnimationFrame(() => setIsOpen(true));
+	}, []);
+
+	useEffect(() => {
+		if (isOpen) {
+			dialogRef.current?.focus();
+		}
+	}, [isOpen]);
+
+	const handleClose = useCallback(() => {
+		setIsClosing(true);
+		setTimeout(() => {
+			onClose();
+		}, 300);
+	}, [onClose]);
+	// Only enrich if we have no description at all
+	const missingSections = !job.description;
+
+	useEffect(() => {
+		setEnrichedContent(null);
+		if (!missingSections) return;
+
+		const cached = jobDescriptionCache.get(job.id);
+		if (cached) {
+			setEnrichedContent(cached);
+			return;
+		}
+
+		let cancelled = false;
+		const enrich = async () => {
+			setIsEnriching(true);
+			try {
+				const response = await fetch(
+					`/api/job-description?url=${encodeURIComponent(job.link)}`,
+				);
+				if (!response.ok) return;
+				const data = (await response.json()) as JobDescriptionContent;
+				if (!cancelled) {
+					jobDescriptionCache.set(job.id, data);
+					setEnrichedContent(data);
+				}
+			} catch {
+				// Failed to enrich - will show default description
+			} finally {
+				if (!cancelled) setIsEnriching(false);
+			}
+		};
+
+		void enrich();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [job.id, job.link, missingSections]);
+
+	const loadingLabel = "Fetching details from job link...";
+	const defaultBullet = "Details will be shared during the process.";
+	const description =
+		job.description?.trim() ||
+		enrichedContent?.description?.trim() ||
+		(isEnriching ? loadingLabel : defaultBullet);
+
+	const copyToClipboard = async (text: string, type: "job" | "apply") => {
+		try {
+			await navigator.clipboard.writeText(text);
+			setCopiedLink(type);
+			setTimeout(() => setCopiedLink(null), 2000);
+		} catch (err) {
+			console.error("Failed to copy:", err);
+		}
+	};
+
+	const handleDialogKeyDown = useCallback((e: React.KeyboardEvent) => {
+		if (e.key === "Escape") {
+			handleClose();
+			return;
+		}
+		if (e.key !== "Tab") return;
+
+		const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+			'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+		);
+		if (!focusable || focusable.length === 0) return;
+
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+		if (e.shiftKey && document.activeElement === first) {
+			e.preventDefault();
+			last.focus();
+		} else if (!e.shiftKey && document.activeElement === last) {
+			e.preventDefault();
+			first.focus();
+		}
+	}, [handleClose]);
+
+	return (
+		<div
+			className={`fixed inset-0 z-50 min-h-screen flex sm:items-center sm:justify-center backdrop-blur-sm transition-colors duration-300 ${
+				isClosing ? "bg-black/0" : isOpen ? "bg-black/50" : "bg-black/0"
+			}`}
+			onClick={handleClose}
+		>
+			<div
+				ref={dialogRef}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby={titleId}
+				aria-describedby={descriptionId}
+				tabIndex={-1}
+				onKeyDown={handleDialogKeyDown}
+				className={`fixed inset-0 sm:relative sm:inset-auto w-full h-[100dvh] sm:h-auto sm:max-w-4xl sm:max-h-[90vh] overflow-y-auto sm:rounded-2xl bg-white dark:bg-neutral-900 shadow-2xl transition-[transform,opacity] duration-300 ${
+					isClosing
+						? "translate-y-full sm:translate-y-0 sm:scale-95 sm:opacity-0 ease-out"
+						: isOpen
+							? "translate-y-0 sm:scale-100 sm:opacity-100 ease-out"
+							: "translate-y-full sm:translate-y-0 sm:scale-95 sm:opacity-0 ease-in"
+				} ${
+					isHot
+						? "sm:ring-2 sm:ring-orange-400 sm:dark:ring-orange-500"
+						: "sm:ring-1 sm:ring-neutral-200 sm:dark:ring-neutral-700"
+				}`}
+				onClick={(e) => e.stopPropagation()}
+			>
+				{/* Header Section - with drag handle inside */}
+				<div
+					className={`p-6 sm:p-8 ${
+						isHot
+							? "bg-gradient-to-r from-orange-50 to-amber-50 dark:from-orange-950/30 dark:to-amber-950/30"
+							: "bg-neutral-50 dark:bg-neutral-800/50"
+					}`}
+				>
+					{/* Mobile: Copy link and close buttons */}
+					<div className="sm:hidden flex items-center justify-end gap-2 mb-4 -mt-2">
+						<button
+							onClick={() => copyToClipboard(jobUrl, "job")}
+							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
+							aria-label="Copy link"
+						>
+							{copiedLink === "job" ? (
+								<svg className="w-6 h-6 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+									<polyline points="20 6 9 17 4 12" />
+								</svg>
+							) : (
+								<svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+									<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+									<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+								</svg>
+							)}
+						</button>
+						<button
+							onClick={handleClose}
+							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
+							aria-label="Close"
+						>
+							<svg
+								className="w-6 h-6"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2.5"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							>
+								<line x1="18" y1="6" x2="6" y2="18" />
+								<line x1="6" y1="6" x2="18" y2="18" />
+							</svg>
+						</button>
+					</div>
+
+					{/* Desktop: Copy link and close buttons */}
+					<div className="hidden sm:flex absolute top-4 right-4 z-10 gap-2">
+						<button
+							onClick={() => copyToClipboard(jobUrl, "job")}
+							className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
+							aria-label="Copy link"
+						>
+							{copiedLink === "job" ? (
+								<svg className="w-6 h-6 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+									<polyline points="20 6 9 17 4 12" />
+								</svg>
+							) : (
+								<svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+									<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+									<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+								</svg>
+							)}
+						</button>
+						<button
+							onClick={handleClose}
+							className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
+							aria-label="Close"
+						>
+							<svg
+								className="w-6 h-6"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							>
+								<line x1="18" y1="6" x2="6" y2="18" />
+								<line x1="6" y1="6" x2="18" y2="18" />
+							</svg>
+						</button>
+					</div>
+
+					<div className="flex flex-col items-center sm:flex-row sm:items-start gap-4 sm:gap-6 text-center sm:text-left">
+						{/* Company Logo */}
+						<div className="w-20 h-20 sm:w-24 sm:h-24 flex-shrink-0 rounded-xl overflow-hidden bg-white p-2 ring-2 ring-neutral-200 dark:ring-neutral-700 hover:scale-[1.08] transition-transform duration-150">
+							<Image
+								src={job.company.logo || "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg"}
+								alt={job.company.name}
+								width={96}
+								height={96}
+								className="object-contain w-full h-full"
+								onError={(e) => {
+									e.currentTarget.onerror = null;
+									e.currentTarget.src = "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg";
+								}}
+							/>
+						</div>
+
+						<div className="flex-1">
+							{/* 1. Title */}
+							<h2 id={titleId} className="text-xl sm:text-3xl font-bold mb-1">
+								{job.title}
+								{job.featured && (
+									<span className="ml-2 text-lg text-amber-600 dark:text-amber-400">★</span>
+								)}
+							</h2>
+							{/* 2. Company */}
+							<p className="text-base sm:text-lg text-neutral-600 dark:text-neutral-400 mb-2">
+								{job.company.name}
+							</p>
+							{/* 3. Location + 4. Type, Team, Comp (as text, not tag-like) */}
+							<p className="text-sm text-neutral-500 dark:text-neutral-400 mb-3">
+								{job.location}
+								{job.remote && " · Remote OK"}
+								{job.type && ` · ${jobTypeLabels[job.type] ?? job.type}`}
+								{job.department && ` · ${job.department}`}
+								{job.salary && ` · ${job.salary}`}
+							</p>
+							{/* 5. HOT/NEW/TOP badges + 6. Network/Portfolio */}
+							<div className="flex flex-wrap justify-center sm:justify-start gap-2">
+								{isHot && (
+									<span className="px-2.5 py-1 text-xs font-semibold rounded-full bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-[0_0_10px_rgba(251,146,60,0.5)]">
+										🔥 HOT
+									</span>
+								)}
+								{job.tags?.includes("top") && (
+									<span className="px-2.5 py-1 text-xs font-semibold rounded-full bg-gradient-to-r from-violet-500 to-purple-500 text-white">
+										TOP
+									</span>
+								)}
+								{isNew(job.createdAt) && (
+									<span className="px-2.5 py-1 text-xs font-semibold rounded-full bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400 animate-pulse-new">
+										NEW
+									</span>
+								)}
+								<span
+									className={`px-3 py-1 text-sm rounded-full ${
+										job.company.category === "portfolio"
+											? "bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400"
+											: "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400"
+									}`}
+								>
+									{job.company.category === "portfolio" ? "Portfolio" : "Network"}
+								</span>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				{/* Content Section */}
+				<div className="p-6 sm:p-8 space-y-6 sm:space-y-8">
+					{/* Tags - exclude hot, top, new as they're shown in header */}
+					{job.tags && job.tags.filter(t => !["hot", "top", "new"].includes(t)).length > 0 && (
+						<div>
+							<h3 className="text-lg font-semibold mb-3">Tags</h3>
+							<div className="flex flex-wrap gap-2">
+								{job.tags.filter(t => !["hot", "top", "new"].includes(t)).map((tag) => (
+									<span
+										key={tag}
+										className="px-3 py-1.5 text-sm rounded-full bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
+									>
+										{tagLabels[tag] ?? tag}
+									</span>
+								))}
+							</div>
+						</div>
+					)}
+
+					{/* Description */}
+					<div>
+						<h3 className="text-lg font-semibold mb-3">About the Role</h3>
+						<div id={descriptionId} className="prose-jd">
+							<Markdown>{description}</Markdown>
+						</div>
+					</div>
+
+					{/* Actions Section - scrollable with content */}
+					<div className="pt-6 border-t border-neutral-200 dark:border-neutral-700 space-y-4">
+						{/* Apply Button */}
+						<a
+							href={job.link}
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={onApplyClick}
+							className="block w-full px-6 py-3 bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 font-semibold rounded-lg hover:bg-neutral-700 dark:hover:bg-neutral-200 transition-colors text-center"
+						>
+							Apply Now →
+						</a>
+
+						{/* Copy Buttons - with labels */}
+						<div className="flex flex-wrap justify-center gap-2">
+							<button
+								onClick={() => copyToClipboard(jobUrl, "job")}
+								className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+							>
+								{copiedLink === "job" ? (
+									<>
+										<svg className="w-4 h-4 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+											<polyline points="20 6 9 17 4 12" />
+										</svg>
+										<span className="text-green-600 dark:text-green-400">Copied!</span>
+									</>
+								) : (
+									<>
+										<svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+											<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+											<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+										</svg>
+										<span>Copy link</span>
+									</>
+								)}
+							</button>
+							<button
+								onClick={() => copyToClipboard(job.link, "apply")}
+								className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+							>
+								{copiedLink === "apply" ? (
+									<>
+										<svg className="w-4 h-4 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+											<polyline points="20 6 9 17 4 12" />
+										</svg>
+										<span className="text-green-600 dark:text-green-400">Copied!</span>
+									</>
+								) : (
+									<>
+										<svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+											<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+											<polyline points="15 3 21 3 21 9" />
+											<line x1="10" y1="14" x2="21" y2="3" />
+										</svg>
+										<span>Copy apply link</span>
+									</>
+								)}
+							</button>
+						</div>
+
+						{/* Other Jobs & Careers - with labels */}
+						<div className="flex flex-wrap justify-center gap-2">
+							{otherJobsCount > 0 && (
+								<button
+									onClick={onViewOtherJobs}
+									className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+								>
+									<svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+										<rect x="3" y="3" width="7" height="7" />
+										<rect x="14" y="3" width="7" height="7" />
+										<rect x="14" y="14" width="7" height="7" />
+										<rect x="3" y="14" width="7" height="7" />
+									</svg>
+									<span>{otherJobsCount} more {otherJobsCount === 1 ? "job" : "jobs"}</span>
+								</button>
+							)}
+							{job.company.careers && (
+								<a
+									href={job.company.careers}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+								>
+									<svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+										<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+										<circle cx="12" cy="7" r="4" />
+									</svg>
+									<span>Careers page</span>
+								</a>
+							)}
+						</div>
+
+						{/* Company Links - with labels */}
+						<div className="flex flex-wrap justify-center gap-2">
+							<a
+								href={job.company.website}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+							>
+								<svg
+									className="w-4 h-4"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+								>
+									<circle cx="12" cy="12" r="10" />
+									<line x1="2" y1="12" x2="22" y2="12" />
+									<path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+								</svg>
+								<span>Website</span>
+							</a>
+							{job.company.x && (
+								<a
+									href={job.company.x}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+								>
+									<svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+										<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+									</svg>
+									<span>X</span>
+								</a>
+							)}
+							{job.company.github && (
+								<a
+									href={job.company.github}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+								>
+									<svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+										<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+									</svg>
+									<span>GitHub</span>
+								</a>
+							)}
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/InvestmentCard.tsx
+++ b/src/components/InvestmentCard.tsx
@@ -18,25 +18,9 @@ export function InvestmentCard({
   const isDefunct = investment.status === "defunct";
 
   return (
-    <div
-      onClick={(e) => {
-        // Don't navigate if clicking on nested links
-        if ((e.target as HTMLElement).closest("a")) return;
-        if (investment.website)
-          window.open(investment.website, "_blank", "noopener,noreferrer");
-      }}
-      role="link"
-      tabIndex={0}
-      aria-label={`View ${investment.title} website`}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          if (investment.website)
-            window.open(investment.website, "_blank", "noopener,noreferrer");
-        }
-      }}
+    <article
       data-testid="investment-card"
-      className={`group relative p-6 pb-8 rounded-xl border transition-colors flex flex-col items-center text-center cursor-pointer ${
+      className={`group relative p-6 pb-8 rounded-xl border transition-colors flex flex-col items-center text-center ${
         isDefunct
           ? "border-neutral-200 dark:border-neutral-800 hover:border-neutral-400 dark:hover:border-neutral-600"
           : investment.tier === 1
@@ -64,7 +48,18 @@ export function InvestmentCard({
         )}
       </div>
       <h3 className="font-semibold mb-2">
-        {investment.title}
+        {investment.website ? (
+          <a
+            href={investment.website}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+          >
+            {investment.title}
+          </a>
+        ) : (
+          investment.title
+        )}
         {investment.featured && (
           <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">
             ★
@@ -154,7 +149,7 @@ export function InvestmentCard({
       {jobCount > 0 && jobsUrl && (
         <a
           href={jobsUrl}
-          className="absolute bottom-3 right-3 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-full bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 shadow-sm hover:bg-black dark:hover:bg-neutral-100 hover:shadow-md hover:scale-105 active:scale-100 transition-all duration-150"
+          className="absolute bottom-3 right-3 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-full bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 shadow-sm hover:bg-black dark:hover:bg-neutral-100 hover:shadow-md hover:scale-105 active:scale-100 transition-[transform,box-shadow,background-color] duration-150"
           aria-label={`View ${jobCount} job openings at ${investment.title}`}
         >
           <span className="relative flex h-2 w-2">
@@ -167,6 +162,6 @@ export function InvestmentCard({
           </span>
         </a>
       )}
-    </div>
+    </article>
   );
 }

--- a/src/components/JobsGrid.tsx
+++ b/src/components/JobsGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback, useRef, useId } from "react";
 import { useSearchParams } from "next/navigation";
 import Image from "next/image";
 import Markdown from "react-markdown";
@@ -47,17 +47,26 @@ function ExpandedJobView({
 	tagLabels: Record<string, string>;
 }) {
 	const isHot = job.tags?.includes("hot");
+	const dialogRef = useRef<HTMLDivElement>(null);
 	const [copiedLink, setCopiedLink] = useState<"job" | "apply" | null>(null);
 	const [enrichedContent, setEnrichedContent] =
 		useState<JobDescriptionContent | null>(null);
 	const [isEnriching, setIsEnriching] = useState(false);
 	const [isClosing, setIsClosing] = useState(false);
 	const [isOpen, setIsOpen] = useState(false);
+	const titleId = useId();
+	const descriptionId = useId();
 
 	useEffect(() => {
 		// Trigger open animation after mount
 		requestAnimationFrame(() => setIsOpen(true));
 	}, []);
+
+	useEffect(() => {
+		if (isOpen) {
+			dialogRef.current?.focus();
+		}
+	}, [isOpen]);
 
 	const handleClose = useCallback(() => {
 		setIsClosing(true);
@@ -122,15 +131,45 @@ function ExpandedJobView({
 		}
 	};
 
+	const handleDialogKeyDown = useCallback((e: React.KeyboardEvent) => {
+		if (e.key === "Escape") {
+			handleClose();
+			return;
+		}
+		if (e.key !== "Tab") return;
+
+		const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+			'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+		);
+		if (!focusable || focusable.length === 0) return;
+
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+		if (e.shiftKey && document.activeElement === first) {
+			e.preventDefault();
+			last.focus();
+		} else if (!e.shiftKey && document.activeElement === last) {
+			e.preventDefault();
+			first.focus();
+		}
+	}, [handleClose]);
+
 	return (
 		<div
-			className={`fixed inset-0 z-50 min-h-screen flex sm:items-center sm:justify-center backdrop-blur-sm transition-all duration-300 ${
+			className={`fixed inset-0 z-50 min-h-screen flex sm:items-center sm:justify-center backdrop-blur-sm transition-colors duration-300 ${
 				isClosing ? "bg-black/0" : isOpen ? "bg-black/50" : "bg-black/0"
 			}`}
 			onClick={handleClose}
 		>
 			<div
-				className={`fixed inset-0 sm:relative sm:inset-auto w-full h-[100dvh] sm:h-auto sm:max-w-4xl sm:max-h-[90vh] overflow-y-auto sm:rounded-2xl bg-white dark:bg-neutral-900 shadow-2xl transition-all duration-300 ${
+				ref={dialogRef}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby={titleId}
+				aria-describedby={descriptionId}
+				tabIndex={-1}
+				onKeyDown={handleDialogKeyDown}
+				className={`fixed inset-0 sm:relative sm:inset-auto w-full h-[100dvh] sm:h-auto sm:max-w-4xl sm:max-h-[90vh] overflow-y-auto sm:rounded-2xl bg-white dark:bg-neutral-900 shadow-2xl transition-[transform,opacity] duration-300 ${
 					isClosing
 						? "translate-y-full sm:translate-y-0 sm:scale-95 sm:opacity-0 ease-out"
 						: isOpen
@@ -155,7 +194,7 @@ function ExpandedJobView({
 					<div className="sm:hidden flex items-center justify-end gap-2 mb-4 -mt-2">
 						<button
 							onClick={() => copyToClipboard(jobUrl, "job")}
-							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-all active:scale-90"
+							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
 							aria-label="Copy link"
 						>
 							{copiedLink === "job" ? (
@@ -171,7 +210,7 @@ function ExpandedJobView({
 						</button>
 						<button
 							onClick={handleClose}
-							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-all active:scale-90"
+							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
 							aria-label="Close"
 						>
 							<svg
@@ -193,7 +232,7 @@ function ExpandedJobView({
 					<div className="hidden sm:flex absolute top-4 right-4 z-10 gap-2">
 						<button
 							onClick={() => copyToClipboard(jobUrl, "job")}
-							className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-all active:scale-90"
+							className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
 							aria-label="Copy link"
 						>
 							{copiedLink === "job" ? (
@@ -209,7 +248,7 @@ function ExpandedJobView({
 						</button>
 						<button
 							onClick={handleClose}
-							className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-all active:scale-90"
+							className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
 							aria-label="Close"
 						>
 							<svg
@@ -245,7 +284,7 @@ function ExpandedJobView({
 
 						<div className="flex-1">
 							{/* 1. Title */}
-							<h2 className="text-xl sm:text-3xl font-bold mb-1">
+							<h2 id={titleId} className="text-xl sm:text-3xl font-bold mb-1">
 								{job.title}
 								{job.featured && (
 									<span className="ml-2 text-lg text-amber-600 dark:text-amber-400">★</span>
@@ -316,7 +355,7 @@ function ExpandedJobView({
 					{/* Description */}
 					<div>
 						<h3 className="text-lg font-semibold mb-3">About the Role</h3>
-						<div className="prose-jd">
+						<div id={descriptionId} className="prose-jd">
 							<Markdown>{description}</Markdown>
 						</div>
 					</div>
@@ -541,6 +580,8 @@ interface JobsGridProps {
   roleDefinitions?: RoleDefinition[];
 }
 
+const JOBS_PAGE_SIZE = 60;
+
 export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: JobsGridProps) {
   // Build tag labels from definitions (with fallback to hardcoded)
   const tagLabels = useMemo(() => {
@@ -589,6 +630,7 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
   const [selectedTags, setSelectedTags] = useState<JobTag[]>(initialParams.selectedTags);
   const [tagsExpanded, setTagsExpanded] = useState(false);
   const [showFeaturedOnly, setShowFeaturedOnly] = useState(initialParams.showFeaturedOnly);
+  const [displayCount, setDisplayCount] = useState(JOBS_PAGE_SIZE);
   const [expandedJob, setExpandedJob] = useState<Job | null>(() => {
     if (!initialParams.jobId) return null;
     return jobs.find((job) => job.id === initialParams.jobId) ?? null;
@@ -968,6 +1010,14 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
     return [...shuffledHot, ...shuffledFeatured, ...shuffledNonFeatured];
   }, [filteredJobs, getTier, filterKey, isHotJob]);
 
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setDisplayCount(JOBS_PAGE_SIZE);
+  }, [filterKey]);
+
+  const visibleJobs = displayJobs.slice(0, displayCount);
+  const hasMoreJobs = displayJobs.length > displayCount;
+
   return (
     <div className="space-y-6" data-testid="jobs-grid">
       {/* Filters */}
@@ -1059,14 +1109,15 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
           </div>
 
           {/* Search - full width on mobile */}
-          <div className="flex-1 relative">
-            <input
-              type="text"
-              placeholder="Search jobs..."
-              value={searchQuery}
-              onChange={(e) => handleSearchChange(e.target.value)}
-              className="w-full px-3 py-2 pr-9 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
-            />
+	          <div className="flex-1 relative">
+	            <input
+	              type="text"
+	              aria-label="Search jobs"
+	              placeholder="Search jobs..."
+	              value={searchQuery}
+	              onChange={(e) => handleSearchChange(e.target.value)}
+	              className="w-full px-3 py-2 pr-9 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
+	            />
             {searchQuery && (
               <button
                 type="button"
@@ -1184,7 +1235,7 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
                 <button
                   key={tag}
                   onClick={() => handleTagToggle(tag)}
-                  className={`px-3 py-1.5 text-sm font-medium rounded-full transition-all ${
+                  className={`px-3 py-1.5 text-sm font-medium rounded-full transition-colors ${
                     tag === "hot"
                       ? selectedTags.includes(tag)
                         ? "bg-gradient-to-r from-orange-500 to-amber-500 text-white font-semibold shadow-[0_0_15px_rgba(251,146,60,0.6)]"
@@ -1228,7 +1279,7 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
             No jobs found matching your criteria.
           </p>
         ) : (
-          displayJobs.map((job) => (
+          visibleJobs.map((job) => (
             <div
               key={job.id}
               onClick={(e) => {
@@ -1245,7 +1296,7 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
                   openJob(job);
                 }
               }}
-              className={`group block p-4 rounded-xl border transition-all cursor-pointer ${
+              className={`group block p-4 rounded-xl border transition-[border-color,box-shadow,background-color] cursor-pointer ${
                 isHotJob(job)
                   ? "border-orange-400 dark:border-orange-500 bg-gradient-to-r from-orange-50 to-amber-50 dark:from-orange-950/20 dark:to-amber-950/20 shadow-[0_0_15px_rgba(251,146,60,0.3)] dark:shadow-[0_0_20px_rgba(251,146,60,0.2)] hover:shadow-[0_0_25px_rgba(251,146,60,0.5)] dark:hover:shadow-[0_0_30px_rgba(251,146,60,0.4)]"
                   : "border-neutral-200 dark:border-neutral-800 hover:border-neutral-400 dark:hover:border-neutral-600"
@@ -1418,6 +1469,14 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
               </div>
             </div>
           ))
+        )}
+        {hasMoreJobs && (
+          <button
+            onClick={() => setDisplayCount((count) => count + JOBS_PAGE_SIZE)}
+            className="w-full py-2 text-sm text-neutral-600 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200 transition-colors"
+          >
+            Load more jobs ({displayJobs.length - visibleJobs.length} remaining)
+          </button>
         )}
       </div>
 

--- a/src/components/JobsGrid.tsx
+++ b/src/components/JobsGrid.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useMemo, useEffect, useCallback, useRef, useId } from "react";
-import { useSearchParams } from "next/navigation";
+import dynamic from "next/dynamic";
+import { useState, useMemo, useEffect, useCallback, useDeferredValue } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
-import Markdown from "react-markdown";
 import { Job, JobTag, RelationshipCategory, tagLabels as defaultTagLabels } from "@/data/jobs";
 import { CustomSelect } from "./CustomSelect";
 import { CustomMultiSelect } from "./CustomMultiSelect";
@@ -14,500 +14,10 @@ import {
 } from "@/lib/posthog";
 import { hashString, seededRandom, shuffleArray, isNew } from "@/lib/shuffle";
 
-// Job type labels for display
-const jobTypeLabels: Record<string, string> = {
-	"full-time": "Full-time",
-	"part-time": "Part-time",
-	contract: "Contract",
-	internship: "Internship",
-};
-
-type JobDescriptionContent = {
-	description?: string;
-};
-
-const jobDescriptionCache = new Map<string, JobDescriptionContent>();
-
-// Expanded Job View Component
-function ExpandedJobView({
-	job,
-	onClose,
-	jobUrl,
-	onViewOtherJobs,
-	otherJobsCount,
-	onApplyClick,
-	tagLabels,
-}: {
-	job: Job;
-	onClose: () => void;
-	jobUrl: string;
-	onViewOtherJobs: () => void;
-	otherJobsCount: number;
-	onApplyClick?: () => void;
-	tagLabels: Record<string, string>;
-}) {
-	const isHot = job.tags?.includes("hot");
-	const dialogRef = useRef<HTMLDivElement>(null);
-	const [copiedLink, setCopiedLink] = useState<"job" | "apply" | null>(null);
-	const [enrichedContent, setEnrichedContent] =
-		useState<JobDescriptionContent | null>(null);
-	const [isEnriching, setIsEnriching] = useState(false);
-	const [isClosing, setIsClosing] = useState(false);
-	const [isOpen, setIsOpen] = useState(false);
-	const titleId = useId();
-	const descriptionId = useId();
-
-	useEffect(() => {
-		// Trigger open animation after mount
-		requestAnimationFrame(() => setIsOpen(true));
-	}, []);
-
-	useEffect(() => {
-		if (isOpen) {
-			dialogRef.current?.focus();
-		}
-	}, [isOpen]);
-
-	const handleClose = useCallback(() => {
-		setIsClosing(true);
-		setTimeout(() => {
-			onClose();
-		}, 300);
-	}, [onClose]);
-	// Only enrich if we have no description at all
-	const missingSections = !job.description;
-
-	useEffect(() => {
-		setEnrichedContent(null);
-		if (!missingSections) return;
-
-		const cached = jobDescriptionCache.get(job.id);
-		if (cached) {
-			setEnrichedContent(cached);
-			return;
-		}
-
-		let cancelled = false;
-		const enrich = async () => {
-			setIsEnriching(true);
-			try {
-				const response = await fetch(
-					`/api/job-description?url=${encodeURIComponent(job.link)}`,
-				);
-				if (!response.ok) return;
-				const data = (await response.json()) as JobDescriptionContent;
-				if (!cancelled) {
-					jobDescriptionCache.set(job.id, data);
-					setEnrichedContent(data);
-				}
-			} catch {
-				// Failed to enrich - will show default description
-			} finally {
-				if (!cancelled) setIsEnriching(false);
-			}
-		};
-
-		void enrich();
-
-		return () => {
-			cancelled = true;
-		};
-	}, [job.id, job.link, missingSections]);
-
-	const loadingLabel = "Fetching details from job link...";
-	const defaultBullet = "Details will be shared during the process.";
-	const description =
-		job.description?.trim() ||
-		enrichedContent?.description?.trim() ||
-		(isEnriching ? loadingLabel : defaultBullet);
-
-	const copyToClipboard = async (text: string, type: "job" | "apply") => {
-		try {
-			await navigator.clipboard.writeText(text);
-			setCopiedLink(type);
-			setTimeout(() => setCopiedLink(null), 2000);
-		} catch (err) {
-			console.error("Failed to copy:", err);
-		}
-	};
-
-	const handleDialogKeyDown = useCallback((e: React.KeyboardEvent) => {
-		if (e.key === "Escape") {
-			handleClose();
-			return;
-		}
-		if (e.key !== "Tab") return;
-
-		const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
-			'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
-		);
-		if (!focusable || focusable.length === 0) return;
-
-		const first = focusable[0];
-		const last = focusable[focusable.length - 1];
-		if (e.shiftKey && document.activeElement === first) {
-			e.preventDefault();
-			last.focus();
-		} else if (!e.shiftKey && document.activeElement === last) {
-			e.preventDefault();
-			first.focus();
-		}
-	}, [handleClose]);
-
-	return (
-		<div
-			className={`fixed inset-0 z-50 min-h-screen flex sm:items-center sm:justify-center backdrop-blur-sm transition-colors duration-300 ${
-				isClosing ? "bg-black/0" : isOpen ? "bg-black/50" : "bg-black/0"
-			}`}
-			onClick={handleClose}
-		>
-			<div
-				ref={dialogRef}
-				role="dialog"
-				aria-modal="true"
-				aria-labelledby={titleId}
-				aria-describedby={descriptionId}
-				tabIndex={-1}
-				onKeyDown={handleDialogKeyDown}
-				className={`fixed inset-0 sm:relative sm:inset-auto w-full h-[100dvh] sm:h-auto sm:max-w-4xl sm:max-h-[90vh] overflow-y-auto sm:rounded-2xl bg-white dark:bg-neutral-900 shadow-2xl transition-[transform,opacity] duration-300 ${
-					isClosing
-						? "translate-y-full sm:translate-y-0 sm:scale-95 sm:opacity-0 ease-out"
-						: isOpen
-							? "translate-y-0 sm:scale-100 sm:opacity-100 ease-out"
-							: "translate-y-full sm:translate-y-0 sm:scale-95 sm:opacity-0 ease-in"
-				} ${
-					isHot
-						? "sm:ring-2 sm:ring-orange-400 sm:dark:ring-orange-500"
-						: "sm:ring-1 sm:ring-neutral-200 sm:dark:ring-neutral-700"
-				}`}
-				onClick={(e) => e.stopPropagation()}
-			>
-				{/* Header Section - with drag handle inside */}
-				<div
-					className={`p-6 sm:p-8 ${
-						isHot
-							? "bg-gradient-to-r from-orange-50 to-amber-50 dark:from-orange-950/30 dark:to-amber-950/30"
-							: "bg-neutral-50 dark:bg-neutral-800/50"
-					}`}
-				>
-					{/* Mobile: Copy link and close buttons */}
-					<div className="sm:hidden flex items-center justify-end gap-2 mb-4 -mt-2">
-						<button
-							onClick={() => copyToClipboard(jobUrl, "job")}
-							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
-							aria-label="Copy link"
-						>
-							{copiedLink === "job" ? (
-								<svg className="w-6 h-6 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
-									<polyline points="20 6 9 17 4 12" />
-								</svg>
-							) : (
-								<svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-									<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-									<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-								</svg>
-							)}
-						</button>
-						<button
-							onClick={handleClose}
-							className="p-2.5 rounded-full bg-white/80 dark:bg-neutral-800/80 hover:bg-white dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
-							aria-label="Close"
-						>
-							<svg
-								className="w-6 h-6"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2.5"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-							>
-								<line x1="18" y1="6" x2="6" y2="18" />
-								<line x1="6" y1="6" x2="18" y2="18" />
-							</svg>
-						</button>
-					</div>
-
-					{/* Desktop: Copy link and close buttons */}
-					<div className="hidden sm:flex absolute top-4 right-4 z-10 gap-2">
-						<button
-							onClick={() => copyToClipboard(jobUrl, "job")}
-							className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
-							aria-label="Copy link"
-						>
-							{copiedLink === "job" ? (
-								<svg className="w-6 h-6 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-									<polyline points="20 6 9 17 4 12" />
-								</svg>
-							) : (
-								<svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-									<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-									<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-								</svg>
-							)}
-						</button>
-						<button
-							onClick={handleClose}
-							className="p-2 rounded-full bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-400 transition-colors active:scale-90"
-							aria-label="Close"
-						>
-							<svg
-								className="w-6 h-6"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								strokeWidth="2"
-								strokeLinecap="round"
-								strokeLinejoin="round"
-							>
-								<line x1="18" y1="6" x2="6" y2="18" />
-								<line x1="6" y1="6" x2="18" y2="18" />
-							</svg>
-						</button>
-					</div>
-
-					<div className="flex flex-col items-center sm:flex-row sm:items-start gap-4 sm:gap-6 text-center sm:text-left">
-						{/* Company Logo */}
-						<div className="w-20 h-20 sm:w-24 sm:h-24 flex-shrink-0 rounded-xl overflow-hidden bg-white p-2 ring-2 ring-neutral-200 dark:ring-neutral-700 hover:scale-[1.08] transition-transform duration-150">
-							<Image
-								src={job.company.logo || "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg"}
-								alt={job.company.name}
-								width={96}
-								height={96}
-								className="object-contain w-full h-full"
-								onError={(e) => {
-									e.currentTarget.onerror = null;
-									e.currentTarget.src = "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/candidates/anonymous-placeholder.svg";
-								}}
-							/>
-						</div>
-
-						<div className="flex-1">
-							{/* 1. Title */}
-							<h2 id={titleId} className="text-xl sm:text-3xl font-bold mb-1">
-								{job.title}
-								{job.featured && (
-									<span className="ml-2 text-lg text-amber-600 dark:text-amber-400">★</span>
-								)}
-							</h2>
-							{/* 2. Company */}
-							<p className="text-base sm:text-lg text-neutral-600 dark:text-neutral-400 mb-2">
-								{job.company.name}
-							</p>
-							{/* 3. Location + 4. Type, Team, Comp (as text, not tag-like) */}
-							<p className="text-sm text-neutral-500 dark:text-neutral-400 mb-3">
-								{job.location}
-								{job.remote && " · Remote OK"}
-								{job.type && ` · ${jobTypeLabels[job.type] ?? job.type}`}
-								{job.department && ` · ${job.department}`}
-								{job.salary && ` · ${job.salary}`}
-							</p>
-							{/* 5. HOT/NEW/TOP badges + 6. Network/Portfolio */}
-							<div className="flex flex-wrap justify-center sm:justify-start gap-2">
-								{isHot && (
-									<span className="px-2.5 py-1 text-xs font-semibold rounded-full bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-[0_0_10px_rgba(251,146,60,0.5)]">
-										🔥 HOT
-									</span>
-								)}
-								{job.tags?.includes("top") && (
-									<span className="px-2.5 py-1 text-xs font-semibold rounded-full bg-gradient-to-r from-violet-500 to-purple-500 text-white">
-										TOP
-									</span>
-								)}
-								{isNew(job.createdAt) && (
-									<span className="px-2.5 py-1 text-xs font-semibold rounded-full bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400 animate-pulse-new">
-										NEW
-									</span>
-								)}
-								<span
-									className={`px-3 py-1 text-sm rounded-full ${
-										job.company.category === "portfolio"
-											? "bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400"
-											: "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400"
-									}`}
-								>
-									{job.company.category === "portfolio" ? "Portfolio" : "Network"}
-								</span>
-							</div>
-						</div>
-					</div>
-				</div>
-
-				{/* Content Section */}
-				<div className="p-6 sm:p-8 space-y-6 sm:space-y-8">
-					{/* Tags - exclude hot, top, new as they're shown in header */}
-					{job.tags && job.tags.filter(t => !["hot", "top", "new"].includes(t)).length > 0 && (
-						<div>
-							<h3 className="text-lg font-semibold mb-3">Tags</h3>
-							<div className="flex flex-wrap gap-2">
-								{job.tags.filter(t => !["hot", "top", "new"].includes(t)).map((tag) => (
-									<span
-										key={tag}
-										className="px-3 py-1.5 text-sm rounded-full bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"
-									>
-										{tagLabels[tag] ?? tag}
-									</span>
-								))}
-							</div>
-						</div>
-					)}
-
-					{/* Description */}
-					<div>
-						<h3 className="text-lg font-semibold mb-3">About the Role</h3>
-						<div id={descriptionId} className="prose-jd">
-							<Markdown>{description}</Markdown>
-						</div>
-					</div>
-
-					{/* Actions Section - scrollable with content */}
-					<div className="pt-6 border-t border-neutral-200 dark:border-neutral-700 space-y-4">
-						{/* Apply Button */}
-						<a
-							href={job.link}
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={onApplyClick}
-							className="block w-full px-6 py-3 bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 font-semibold rounded-lg hover:bg-neutral-700 dark:hover:bg-neutral-200 transition-colors text-center"
-						>
-							Apply Now →
-						</a>
-
-						{/* Copy Buttons - with labels */}
-						<div className="flex flex-wrap justify-center gap-2">
-							<button
-								onClick={() => copyToClipboard(jobUrl, "job")}
-								className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-							>
-								{copiedLink === "job" ? (
-									<>
-										<svg className="w-4 h-4 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-											<polyline points="20 6 9 17 4 12" />
-										</svg>
-										<span className="text-green-600 dark:text-green-400">Copied!</span>
-									</>
-								) : (
-									<>
-										<svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-											<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-											<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-										</svg>
-										<span>Copy link</span>
-									</>
-								)}
-							</button>
-							<button
-								onClick={() => copyToClipboard(job.link, "apply")}
-								className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-							>
-								{copiedLink === "apply" ? (
-									<>
-										<svg className="w-4 h-4 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-											<polyline points="20 6 9 17 4 12" />
-										</svg>
-										<span className="text-green-600 dark:text-green-400">Copied!</span>
-									</>
-								) : (
-									<>
-										<svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-											<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-											<polyline points="15 3 21 3 21 9" />
-											<line x1="10" y1="14" x2="21" y2="3" />
-										</svg>
-										<span>Copy apply link</span>
-									</>
-								)}
-							</button>
-						</div>
-
-						{/* Other Jobs & Careers - with labels */}
-						<div className="flex flex-wrap justify-center gap-2">
-							{otherJobsCount > 0 && (
-								<button
-									onClick={onViewOtherJobs}
-									className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-								>
-									<svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-										<rect x="3" y="3" width="7" height="7" />
-										<rect x="14" y="3" width="7" height="7" />
-										<rect x="14" y="14" width="7" height="7" />
-										<rect x="3" y="14" width="7" height="7" />
-									</svg>
-									<span>{otherJobsCount} more {otherJobsCount === 1 ? "job" : "jobs"}</span>
-								</button>
-							)}
-							{job.company.careers && (
-								<a
-									href={job.company.careers}
-									target="_blank"
-									rel="noopener noreferrer"
-									className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-								>
-									<svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-										<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-										<circle cx="12" cy="7" r="4" />
-									</svg>
-									<span>Careers page</span>
-								</a>
-							)}
-						</div>
-
-						{/* Company Links - with labels */}
-						<div className="flex flex-wrap justify-center gap-2">
-							<a
-								href={job.company.website}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-							>
-								<svg
-									className="w-4 h-4"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-								>
-									<circle cx="12" cy="12" r="10" />
-									<line x1="2" y1="12" x2="22" y2="12" />
-									<path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
-								</svg>
-								<span>Website</span>
-							</a>
-							{job.company.x && (
-								<a
-									href={job.company.x}
-									target="_blank"
-									rel="noopener noreferrer"
-									className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-								>
-									<svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-										<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-									</svg>
-									<span>X</span>
-								</a>
-							)}
-							{job.company.github && (
-								<a
-									href={job.company.github}
-									target="_blank"
-									rel="noopener noreferrer"
-									className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-								>
-									<svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-										<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-									</svg>
-									<span>GitHub</span>
-								</a>
-							)}
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	);
-}
+const ExpandedJobView = dynamic(
+  () => import("./ExpandedJobView").then((mod) => mod.ExpandedJobView),
+  { ssr: false }
+);
 
 type FilterCategory = "all" | RelationshipCategory;
 
@@ -583,6 +93,8 @@ interface JobsGridProps {
 const JOBS_PAGE_SIZE = 60;
 
 export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: JobsGridProps) {
+  const router = useRouter();
+  const pathname = usePathname();
   // Build tag labels from definitions (with fallback to hardcoded)
   const tagLabels = useMemo(() => {
     const labels: Record<string, string> = { ...defaultTagLabels };
@@ -636,6 +148,7 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
     return jobs.find((job) => job.id === initialParams.jobId) ?? null;
   });
   const [dataHotJobIds, setDataHotJobIds] = useState<Set<string>>(new Set());
+  const deferredSearchQuery = useDeferredValue(searchQuery);
 
   // Fetch data-driven hot jobs from analytics
   useEffect(() => {
@@ -662,18 +175,23 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
     is_hot: job.tags?.includes("hot") ?? false,
   }), []);
 
-  // Helper to update URL params without React re-render
+  const replaceSearchParams = useCallback((nextParams: URLSearchParams) => {
+    const queryString = nextParams.toString();
+    if (queryString === searchParams.toString()) return;
+    router.replace(queryString ? `${pathname}?${queryString}` : pathname, { scroll: false });
+  }, [pathname, router, searchParams]);
+
   const updateUrlParams = useCallback((updates: Record<string, string | null>) => {
-    const url = new URL(window.location.href);
+    const nextParams = new URLSearchParams(searchParams.toString());
     Object.entries(updates).forEach(([key, value]) => {
       if (value === null || value === "" || value === "all") {
-        url.searchParams.delete(key);
+        nextParams.delete(key);
       } else {
-        url.searchParams.set(key, value);
+        nextParams.set(key, value);
       }
     });
-    window.history.replaceState(null, "", url.pathname + url.search);
-  }, []);
+    replaceSearchParams(nextParams);
+  }, [replaceSearchParams, searchParams]);
 
   // Sync URL with modal state
   const openJob = useCallback((job: Job) => {
@@ -695,14 +213,13 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
 
   const handleCompanyChange = useCallback((values: string[]) => {
     setSelectedCompanies(values.length === 0 ? ["all"] : values);
-    // Update URL with multiple company params
-    const url = new URL(window.location.href);
-    url.searchParams.delete("company");
+    const nextParams = new URLSearchParams(searchParams.toString());
+    nextParams.delete("company");
     if (values.length > 0) {
-      values.forEach((v) => url.searchParams.append("company", v));
+      values.forEach((v) => nextParams.append("company", v));
     }
-    window.history.replaceState(null, "", url.pathname + url.search);
-  }, []);
+    replaceSearchParams(nextParams);
+  }, [replaceSearchParams, searchParams]);
 
   const handleLocationChange = useCallback((value: string) => {
     setSelectedLocation(value);
@@ -716,8 +233,7 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
 
   const handleSearchChange = useCallback((value: string) => {
     setSearchQuery(value);
-    updateUrlParams({ q: value || null });
-  }, [updateUrlParams]);
+  }, []);
 
   const handleFeaturedToggle = useCallback(() => {
     const newValue = !showFeaturedOnly;
@@ -726,17 +242,12 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
   }, [showFeaturedOnly, updateUrlParams]);
 
   const handleTagToggle = useCallback((tag: JobTag) => {
-    setSelectedTags((prev) => {
-      const newTags = prev.includes(tag)
-        ? prev.filter((t) => t !== tag)
-        : [...prev, tag];
-      // Use setTimeout to avoid updating URL during render
-      setTimeout(() => {
-        updateUrlParams({ tags: newTags.length > 0 ? newTags.join(",") : null });
-      }, 0);
-      return newTags;
-    });
-  }, [updateUrlParams]);
+    const newTags = selectedTags.includes(tag)
+      ? selectedTags.filter((t) => t !== tag)
+      : [...selectedTags, tag];
+    setSelectedTags(newTags);
+    updateUrlParams({ tags: newTags.length > 0 ? newTags.join(",") : null });
+  }, [selectedTags, updateUrlParams]);
 
   const handleClearTags = useCallback(() => {
     setSelectedTags([]);
@@ -751,17 +262,23 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
     setSearchQuery("");
     setSelectedTags([]);
     setShowFeaturedOnly(false);
-    // Clear all filter params from URL
-    const url = new URL(window.location.href);
-    url.searchParams.delete("type");
-    url.searchParams.delete("company");
-    url.searchParams.delete("role");
-    url.searchParams.delete("location");
-    url.searchParams.delete("q");
-    url.searchParams.delete("tags");
-    url.searchParams.delete("featured");
-    window.history.replaceState(null, "", url.pathname + url.search);
-  }, []);
+    const nextParams = new URLSearchParams(searchParams.toString());
+    nextParams.delete("type");
+    nextParams.delete("company");
+    nextParams.delete("role");
+    nextParams.delete("location");
+    nextParams.delete("q");
+    nextParams.delete("tags");
+    nextParams.delete("featured");
+    replaceSearchParams(nextParams);
+  }, [replaceSearchParams, searchParams]);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      updateUrlParams({ q: searchQuery || null });
+    }, 180);
+    return () => clearTimeout(timeoutId);
+  }, [searchQuery, updateUrlParams]);
 
   // Check if any filter is active
   const hasActiveFilters =
@@ -855,6 +372,21 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
     return Array.from(locations).sort();
   }, [jobs]);
 
+  const jobSearchIndex = useMemo(() => {
+    const index = new Map<string, string>();
+    jobs.forEach((job) => {
+      const tagText = job.tags?.map((t) => tagLabels[t]).join(" ") || "";
+      index.set(
+        job.id,
+        [job.title, job.company.name, job.location, job.department, tagText]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase(),
+      );
+    });
+    return index;
+  }, [jobs, tagLabels]);
+
   const filteredJobs = useMemo(() => {
     return jobs.filter((job) => {
       // Category filter
@@ -911,19 +443,9 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
       }
 
       // Search filter (title, company name, location, tags)
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase();
-        const tagText = job.tags?.map((t) => tagLabels[t]).join(" ") || "";
-        const searchableText = [
-          job.title,
-          job.company.name,
-          job.location,
-          job.department,
-          tagText,
-        ]
-          .filter(Boolean)
-          .join(" ")
-          .toLowerCase();
+      if (deferredSearchQuery) {
+        const query = deferredSearchQuery.toLowerCase();
+        const searchableText = jobSearchIndex.get(job.id) || "";
         if (!searchableText.includes(query)) {
           return false;
         }
@@ -937,10 +459,10 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
     selectedCompanies,
     selectedRole,
     selectedLocation,
-    searchQuery,
+    deferredSearchQuery,
     selectedTags,
     showFeaturedOnly,
-    tagLabels,
+    jobSearchIndex,
   ]);
 
 
@@ -955,12 +477,12 @@ export function JobsGrid({ jobs, tagDefinitions = [], roleDefinitions = [] }: Jo
         selectedCompanies.join(","),
         selectedRole,
         selectedLocation,
-        searchQuery,
+        deferredSearchQuery,
         selectedTags.join(","),
         showFeaturedOnly,
         shuffleSeed,
       ].join("|"),
-    [filterCategory, selectedCompanies, selectedRole, selectedLocation, searchQuery, selectedTags, showFeaturedOnly, shuffleSeed],
+    [filterCategory, selectedCompanies, selectedRole, selectedLocation, deferredSearchQuery, selectedTags, showFeaturedOnly, shuffleSeed],
   );
 
   // Helper to check if job is hot (manual tag OR data-driven)

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -70,7 +70,7 @@ export function Navbar() {
 				{/* Logo */}
 				<Link
 					href="/"
-					className="text-xl font-bold hover:opacity-70 transition-opacity cursor-pointer"
+					className="text-xl font-bold hover:opacity-70 transition-opacity cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
 				>
 					dcbuilder.eth
 				</Link>
@@ -81,7 +81,7 @@ export function Navbar() {
 						href="https://x.com/dcbuilder"
 						target="_blank"
 						rel="noopener noreferrer"
-						className="p-2 hover:scale-110 transition-transform cursor-pointer"
+						className="p-2 hover:scale-110 transition-transform cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
 						aria-label="X (Twitter)"
 					>
 						<svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
@@ -92,7 +92,7 @@ export function Navbar() {
 						href="https://github.com/dcbuild3r"
 						target="_blank"
 						rel="noopener noreferrer"
-						className="p-2 hover:scale-110 transition-transform cursor-pointer"
+						className="p-2 hover:scale-110 transition-transform cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
 						aria-label="GitHub"
 					>
 						<svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
@@ -102,17 +102,18 @@ export function Navbar() {
 				</div>
 
 				{/* Desktop: Right - Navigation & Theme */}
-				<div className="hidden md:flex items-center gap-6">
-					{navLinks.map((link) => (
-						<Link
-							key={link.href}
-							href={link.href}
-							className={`hover:opacity-70 transition-opacity cursor-pointer ${
-								pathname === link.href
-									? "font-medium"
-									: "text-neutral-600 dark:text-neutral-400"
-							}`}
-						>
+					<div className="hidden md:flex items-center gap-6">
+						{navLinks.map((link) => (
+							<Link
+								key={link.href}
+								href={link.href}
+								aria-current={pathname === link.href ? "page" : undefined}
+								className={`hover:opacity-70 transition-opacity cursor-pointer ${
+									pathname === link.href
+										? "font-medium"
+										: "text-neutral-600 dark:text-neutral-400"
+								} rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900`}
+							>
 							{link.label}
 						</Link>
 					))}
@@ -131,7 +132,7 @@ export function Navbar() {
 								openMenu();
 							}
 						}}
-						className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+						className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
 						aria-label={isMenuOpen ? "Close menu" : "Open menu"}
 						aria-expanded={isMenuOpen}
 						aria-controls="mobile-menu"
@@ -165,17 +166,18 @@ export function Navbar() {
 					<div className="flex flex-col items-center p-6 space-y-6">
 						{/* Nav Links - centered for easy thumb reach */}
 						<div className="flex flex-col items-center space-y-4">
-							{navLinks.map((link, index) => (
-								<Link
-									key={link.href}
-									ref={index === 0 ? firstFocusableRef : undefined}
-									href={link.href}
+								{navLinks.map((link, index) => (
+									<Link
+										key={link.href}
+										ref={index === 0 ? firstFocusableRef : undefined}
+										href={link.href}
+										aria-current={pathname === link.href ? "page" : undefined}
 									onClick={closeMenu}
 									className={`text-xl py-2 ${
 										pathname === link.href
 											? "font-semibold"
 											: "text-neutral-600 dark:text-neutral-400"
-									}`}
+									} rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900`}
 								>
 									{link.label}
 								</Link>
@@ -191,7 +193,7 @@ export function Navbar() {
 								href="https://x.com/dcbuilder"
 								target="_blank"
 								rel="noopener noreferrer"
-								className="p-3 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+								className="p-3 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
 								aria-label="X (Twitter)"
 							>
 								<svg className="w-6 h-6" viewBox="0 0 24 24" fill="currentColor">
@@ -202,7 +204,7 @@ export function Navbar() {
 								href="https://github.com/dcbuild3r"
 								target="_blank"
 								rel="noopener noreferrer"
-								className="p-3 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+								className="p-3 rounded-lg bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
 								aria-label="GitHub"
 								ref={lastFocusableRef}
 							>

--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -202,6 +202,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 							height={NEWS_THUMBNAIL_SIZE}
 							sizes={NEWS_THUMBNAIL_REQUEST_SIZE}
 							quality={NEWS_THUMBNAIL_QUALITY}
+							unoptimized
 							className="rounded w-14 h-14 object-cover group-hover:scale-[1.08] transition-transform duration-150"
 							onError={() => markImageFailed(imageKey)}
 						/>

--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -138,9 +138,10 @@ export function NewsGrid({ news }: NewsGridProps) {
 						<Image
 							src={`https://unavatar.io/twitter/${handle}`}
 							alt={handle}
-							width={48}
-							height={48}
-							className="rounded-full"
+							width={56}
+							height={56}
+							sizes="56px"
+							className="rounded-full w-14 h-14 object-cover"
 							onError={() => markImageFailed(imageKey)}
 						/>
 						<XLogo />
@@ -160,9 +161,10 @@ export function NewsGrid({ news }: NewsGridProps) {
 						<Image
 							src={item.image.trim()}
 							alt={item.title}
-							width={48}
-							height={48}
-							className="rounded object-cover w-12 h-12 group-hover:scale-[1.08] transition-transform duration-150"
+							width={56}
+							height={56}
+							sizes="56px"
+							className="rounded object-cover w-14 h-14 group-hover:scale-[1.08] transition-transform duration-150"
 							onError={() => markImageFailed(imageKey)}
 						/>
 					);
@@ -180,9 +182,10 @@ export function NewsGrid({ news }: NewsGridProps) {
 						<Image
 							src={item.companyLogo.trim()}
 							alt={item.company || "Company"}
-							width={48}
-							height={48}
-							className="rounded group-hover:scale-[1.08] transition-transform duration-150"
+							width={56}
+							height={56}
+							sizes="56px"
+							className="rounded w-14 h-14 object-cover group-hover:scale-[1.08] transition-transform duration-150"
 							onError={() => markImageFailed(imageKey)}
 						/>
 					);
@@ -319,7 +322,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 						>
 							<div className="flex items-center gap-4">
 								{/* Icon */}
-								<div className="flex-shrink-0 w-12 h-12 flex items-center justify-center">
+								<div className="flex-shrink-0 w-14 h-14 flex items-center justify-center">
 									{getTypeIcon(item)}
 								</div>
 

--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -16,6 +16,11 @@ const typeLabels: Record<NewsType, string> = {
 	announcement: "Announcements",
 };
 
+const NEWS_THUMBNAIL_SIZE = 56;
+const NEWS_THUMBNAIL_REQUEST_SIZE = "112px";
+const NEWS_THUMBNAIL_QUALITY = 90;
+const BLOG_IMAGE_CACHE_VERSION = "20260206";
+
 // Check if item is fresh based on platform
 // X posts: 5 days, everything else: 2 weeks
 const isFreshItem = (dateString: string | Date | undefined, platform?: string): boolean => {
@@ -114,6 +119,15 @@ export function NewsGrid({ news }: NewsGridProps) {
 		setFailedImageKeys((prev) => (prev[key] ? prev : { ...prev, [key]: true }));
 	}, []);
 
+	const getBlogImageUrl = useCallback((rawUrl: string) => {
+		const url = rawUrl.trim();
+		if (!url.includes(".r2.dev/blog/images/")) {
+			return url;
+		}
+		const separator = url.includes("?") ? "&" : "?";
+		return `${url}${separator}v=${BLOG_IMAGE_CACHE_VERSION}`;
+	}, []);
+
 	// X logo SVG for overlay
 	const XLogo = () => (
 		<div className="absolute -bottom-1 -right-1 w-5 h-5 bg-black rounded-full flex items-center justify-center border-2 border-white dark:border-neutral-900">
@@ -138,9 +152,10 @@ export function NewsGrid({ news }: NewsGridProps) {
 						<Image
 							src={`https://unavatar.io/twitter/${handle}`}
 							alt={handle}
-							width={56}
-							height={56}
-							sizes="56px"
+							width={NEWS_THUMBNAIL_SIZE}
+							height={NEWS_THUMBNAIL_SIZE}
+							sizes={NEWS_THUMBNAIL_REQUEST_SIZE}
+							quality={NEWS_THUMBNAIL_QUALITY}
 							className="rounded-full w-14 h-14 object-cover"
 							onError={() => markImageFailed(imageKey)}
 						/>
@@ -159,11 +174,12 @@ export function NewsGrid({ news }: NewsGridProps) {
 					}
 					return (
 						<Image
-							src={item.image.trim()}
+							src={getBlogImageUrl(item.image)}
 							alt={item.title}
-							width={56}
-							height={56}
-							sizes="56px"
+							width={NEWS_THUMBNAIL_SIZE}
+							height={NEWS_THUMBNAIL_SIZE}
+							sizes={NEWS_THUMBNAIL_REQUEST_SIZE}
+							quality={NEWS_THUMBNAIL_QUALITY}
 							className="rounded object-cover w-14 h-14 group-hover:scale-[1.08] transition-transform duration-150"
 							onError={() => markImageFailed(imageKey)}
 						/>
@@ -182,9 +198,10 @@ export function NewsGrid({ news }: NewsGridProps) {
 						<Image
 							src={item.companyLogo.trim()}
 							alt={item.company || "Company"}
-							width={56}
-							height={56}
-							sizes="56px"
+							width={NEWS_THUMBNAIL_SIZE}
+							height={NEWS_THUMBNAIL_SIZE}
+							sizes={NEWS_THUMBNAIL_REQUEST_SIZE}
+							quality={NEWS_THUMBNAIL_QUALITY}
 							className="rounded w-14 h-14 object-cover group-hover:scale-[1.08] transition-transform duration-150"
 							onError={() => markImageFailed(imageKey)}
 						/>

--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -39,6 +39,16 @@ export function NewsGrid({ news }: NewsGridProps) {
 	const [typeFilter, setTypeFilter] = useState<NewsType>("all");
 	const [categoryFilter, setCategoryFilter] = useState<"all" | NewsCategory>("all");
 	const [searchQuery, setSearchQuery] = useState("");
+	const dateFormatter = useMemo(
+		() =>
+			new Intl.DateTimeFormat("en-US", {
+				year: "numeric",
+				month: "short",
+				day: "numeric",
+				timeZone: "UTC",
+			}),
+		[],
+	);
 
 	// Get all unique categories from news items
 	const allCategories = useMemo(() => {
@@ -83,11 +93,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 	// Format date for display
 	const formatDate = (dateString: string) => {
 		const date = new Date(dateString);
-		return date.toLocaleDateString("en-US", {
-			year: "numeric",
-			month: "short",
-			day: "numeric",
-		});
+		return dateFormatter.format(date);
 	};
 
 	// Extract X/Twitter handle from URL
@@ -119,7 +125,6 @@ export function NewsGrid({ news }: NewsGridProps) {
 							width={48}
 							height={48}
 							className="rounded-full"
-							unoptimized
 						/>
 						<XLogo />
 					</div>
@@ -137,7 +142,6 @@ export function NewsGrid({ news }: NewsGridProps) {
 							width={48}
 							height={48}
 							className="rounded object-cover w-12 h-12 group-hover:scale-[1.08] transition-transform duration-150"
-							unoptimized
 						/>
 					);
 				}
@@ -232,14 +236,15 @@ export function NewsGrid({ news }: NewsGridProps) {
 
 				{/* Row 2: Search */}
 				<div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
-					<div className="flex-1 relative">
-						<input
-							type="text"
-							placeholder="Search news..."
-							value={searchQuery}
-							onChange={(e) => setSearchQuery(e.target.value)}
-							className="w-full px-3 py-2 pr-9 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
-						/>
+						<div className="flex-1 relative">
+							<input
+								type="text"
+								aria-label="Search news"
+								placeholder="Search news..."
+								value={searchQuery}
+								onChange={(e) => setSearchQuery(e.target.value)}
+								className="w-full px-3 py-2 pr-9 text-sm rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
+							/>
 						{searchQuery && (
 							<button
 								type="button"
@@ -283,7 +288,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 							target={isExternalLink(item) ? "_blank" : undefined}
 							rel={isExternalLink(item) ? "noopener noreferrer" : undefined}
 							onClick={() => handleNewsClick(item)}
-							className="group block p-4 rounded-xl border border-neutral-200 dark:border-neutral-800 hover:border-neutral-400 dark:hover:border-neutral-600 transition-all"
+							className="group block p-4 rounded-xl border border-neutral-200 dark:border-neutral-800 hover:border-neutral-400 dark:hover:border-neutral-600 transition-colors"
 						>
 							<div className="flex items-center gap-4">
 								{/* Icon */}

--- a/src/components/PortfolioGrid.tsx
+++ b/src/components/PortfolioGrid.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import Image from "next/image";
 import { InvestmentCard } from "./InvestmentCard";
+import { R2_PUBLIC_URL } from "@/services/r2";
 import {
   Investment,
   InvestmentCategory,
@@ -287,13 +288,12 @@ export function PortfolioGrid({
       {defunctInvestments.length > 0 && (
         <div className="flex justify-center py-4">
           <Image
-            src="https://i.pinimg.com/originals/bc/c7/ab/bcc7abc844aa8be1abc46a9f5d3c22c5.gif"
+            src={`${R2_PUBLIC_URL}/site/portfolio-separator.gif`}
             alt="Separator"
             width={512}
             height={512}
             sizes="(min-width: 640px) 512px, 320px"
             unoptimized
-            loader={({ src }) => src}
             className="w-[512px] h-[512px] object-contain"
           />
         </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -22,7 +22,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? "light" : "dark")}
-      className="p-2 rounded-lg hover:bg-neutral-200 dark:hover:bg-neutral-800 transition-colors cursor-pointer"
+      className="p-2 rounded-lg hover:bg-neutral-200 dark:hover:bg-neutral-800 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
       aria-label="Toggle theme"
       aria-pressed={isDark}
     >

--- a/src/components/skeletons/GridSkeleton.tsx
+++ b/src/components/skeletons/GridSkeleton.tsx
@@ -260,7 +260,7 @@ export function PortfolioFiltersStatic() {
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-2">
           <label className="text-sm text-neutral-600 dark:text-neutral-400">
-            Sort by:
+            Sorting:
           </label>
           <select
             disabled

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -3,7 +3,6 @@
  * Seeds test data before all tests run
  */
 
-import { db } from "../src/db";
 import {
   jobs,
   jobTags,
@@ -14,8 +13,173 @@ import {
   investmentCategories,
 } from "../src/db/schema";
 import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import postgres from "postgres";
+import { resolve } from "node:path";
+import { loadEnvConfig } from "@next/env";
+import * as dbSchema from "../src/db/schema";
 
 const TEST_PREFIX = "test-";
+
+loadEnvConfig(process.cwd());
+
+function getConnectionString() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required for E2E tests");
+  }
+  return connectionString;
+}
+
+async function ensureDatabaseSchema(connectionString: string) {
+  const migrationClient = postgres(connectionString, { max: 1, onnotice: () => {} });
+  try {
+    const migrationDb = drizzle(migrationClient);
+    try {
+      await migrate(migrationDb, {
+        migrationsFolder: resolve(process.cwd(), "drizzle"),
+      });
+    } catch (error) {
+      const code = (error as { cause?: { code?: string } })?.cause?.code;
+      if (code !== "42P07") {
+        throw error;
+      }
+      // If migration history drift exists (some tables already created but journal is incomplete),
+      // bootstrap the tables required by E2E to keep local setup reliable.
+      console.log("⚠️  Migration journal drift detected, applying E2E schema bootstrap...");
+      await ensureE2ESchema(migrationDb);
+    }
+  } finally {
+    await migrationClient.end();
+  }
+}
+
+async function ensureE2ESchema(db: PostgresJsDatabase<Record<string, never>>) {
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "jobs" (
+      "id" text PRIMARY KEY NOT NULL,
+      "title" text NOT NULL,
+      "company" text NOT NULL,
+      "company_logo" text,
+      "link" text NOT NULL,
+      "location" text,
+      "remote" text,
+      "type" text,
+      "salary" text,
+      "department" text,
+      "tags" text[],
+      "category" text NOT NULL,
+      "featured" boolean DEFAULT false,
+      "description" text,
+      "responsibilities" text[],
+      "qualifications" text[],
+      "benefits" text[],
+      "company_website" text,
+      "company_x" text,
+      "company_github" text,
+      "created_at" timestamp DEFAULT now() NOT NULL,
+      "updated_at" timestamp DEFAULT now() NOT NULL
+    )
+  `);
+
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "candidates" (
+      "id" text PRIMARY KEY NOT NULL,
+      "name" text NOT NULL,
+      "title" text,
+      "location" text,
+      "summary" text,
+      "skills" text[],
+      "experience" text,
+      "education" text,
+      "image" text,
+      "cv" text,
+      "featured" boolean DEFAULT false,
+      "available" boolean DEFAULT true,
+      "availability" text DEFAULT 'looking',
+      "email" text,
+      "telegram" text,
+      "calendly" text,
+      "x" text,
+      "github" text,
+      "linkedin" text,
+      "website" text,
+      "created_at" timestamp DEFAULT now() NOT NULL,
+      "updated_at" timestamp DEFAULT now() NOT NULL
+    )
+  `);
+
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "curated_links" (
+      "id" text PRIMARY KEY NOT NULL,
+      "title" text NOT NULL,
+      "url" text NOT NULL,
+      "source" text NOT NULL,
+      "source_image" text,
+      "date" timestamp NOT NULL,
+      "description" text,
+      "category" text NOT NULL,
+      "featured" boolean DEFAULT false,
+      "created_at" timestamp DEFAULT now() NOT NULL,
+      "updated_at" timestamp DEFAULT now() NOT NULL
+    )
+  `);
+
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "investments" (
+      "id" text PRIMARY KEY NOT NULL,
+      "title" text NOT NULL,
+      "description" text,
+      "image_url" text,
+      "logo" text,
+      "tier" text,
+      "featured" boolean DEFAULT false,
+      "status" text DEFAULT 'active',
+      "categories" text[],
+      "website" text,
+      "x" text,
+      "github" text,
+      "created_at" timestamp DEFAULT now() NOT NULL,
+      "updated_at" timestamp DEFAULT now() NOT NULL
+    )
+  `);
+
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "investment_categories" (
+      "id" text PRIMARY KEY NOT NULL,
+      "slug" text NOT NULL UNIQUE,
+      "label" text NOT NULL,
+      "color" text,
+      "created_at" timestamp DEFAULT now() NOT NULL
+    )
+  `);
+
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "job_tags" (
+      "id" text PRIMARY KEY NOT NULL,
+      "slug" text NOT NULL UNIQUE,
+      "label" text NOT NULL,
+      "color" text,
+      "created_at" timestamp DEFAULT now() NOT NULL
+    )
+  `);
+
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS "job_roles" (
+      "id" text PRIMARY KEY NOT NULL,
+      "slug" text NOT NULL UNIQUE,
+      "label" text NOT NULL,
+      "created_at" timestamp DEFAULT now() NOT NULL
+    )
+  `);
+
+  await db.execute(sql`ALTER TABLE "candidates" ADD COLUMN IF NOT EXISTS "available" boolean DEFAULT true`);
+  await db.execute(sql`ALTER TABLE "candidates" ADD COLUMN IF NOT EXISTS "availability" text DEFAULT 'looking'`);
+  await db.execute(sql`ALTER TABLE "curated_links" ADD COLUMN IF NOT EXISTS "source_image" text`);
+  await db.execute(sql`ALTER TABLE "investments" ADD COLUMN IF NOT EXISTS "categories" text[]`);
+}
 
 // Test data definitions (keep in sync with scripts/seed-test-data.ts)
 const testJobTags = [
@@ -98,7 +262,7 @@ const testInvestments = [
   },
 ];
 
-async function cleanTestData() {
+async function cleanTestData(db: PostgresJsDatabase<typeof dbSchema>) {
   await db.delete(jobs).where(sql`id LIKE ${TEST_PREFIX + "%"}`);
   await db.delete(candidates).where(sql`id LIKE ${TEST_PREFIX + "%"}`);
   await db.delete(curatedLinks).where(sql`id LIKE ${TEST_PREFIX + "%"}`);
@@ -108,7 +272,7 @@ async function cleanTestData() {
   await db.delete(jobRoles).where(sql`id LIKE ${TEST_PREFIX + "%"}`);
 }
 
-async function seedTestData() {
+async function seedTestData(db: PostgresJsDatabase<typeof dbSchema>) {
   for (const tag of testJobTags) {
     await db.insert(jobTags).values(tag).onConflictDoNothing();
   }
@@ -137,12 +301,19 @@ async function seedTestData() {
 export default async function globalSetup() {
   console.log("\n🌱 Setting up E2E test data...");
 
+  const connectionString = getConnectionString();
+  const queryClient = postgres(connectionString, { onnotice: () => {} });
+  const testDb = drizzle(queryClient, { schema: dbSchema });
+
   try {
-    await cleanTestData();
-    await seedTestData();
+    await ensureDatabaseSchema(connectionString);
+    await cleanTestData(testDb);
+    await seedTestData(testDb);
     console.log("✅ Test data seeded successfully\n");
   } catch (error) {
     console.error("❌ Failed to seed test data:", error);
     throw error;
+  } finally {
+    await queryClient.end();
   }
 }


### PR DESCRIPTION
## Summary
This PR improves public-page UX/accessibility, reduces client-side interaction cost, restores and sharpens media rendering on `/news` and `/portfolio`, fixes review regressions, and hardens local E2E setup.

## Changes Included
- Improved public-page accessibility and consistency across home/about/blog/news/jobs/candidates/portfolio pages and shared layout/components.
- Refined modal/dialog behavior and extracted heavy detail views into dynamic components:
  - `src/components/ExpandedJobView.tsx`
  - `src/components/ExpandedCandidateView.tsx`
- Reduced unnecessary client work in large grids by optimizing filtering/search paths (including deferred search behavior and precomputed indexes where applicable).
- Replaced broad `transition-all` usage with targeted transition properties in key UI surfaces.
- Restored portfolio separator GIF and hosted it on Cloudflare R2 (`src/components/PortfolioGrid.tsx`).
- Fixed broken blog/news thumbnail behavior with resilient image fallback handling in `src/components/NewsGrid.tsx`.
- Increased perceived image quality on news thumbnails and added cache busting for refreshed R2 blog images.
- Fixed strict-mode E2E selector collisions in loading states:
  - `src/app/jobs/loading.tsx`
  - `src/app/portfolio/loading.tsx`
  - `src/components/skeletons/GridSkeleton.tsx`
- Addressed review regressions:
  - Restored history-only URL syncing (no App Router navigation) for Jobs/Candidates filters and modal params.
  - Preserved cross-domain announcement logos in News by keeping announcement images `unoptimized`.
- Hardened local E2E setup in `tests/global-setup.ts`:
  - load env via Next config before DB access
  - run migrations pre-seed
  - handle migration-journal drift with idempotent schema bootstrap for required E2E tables
  - cleanup and seed test data reliably

## Validation
- `bun run lint`
- `bun run test:unit`
- `bun run test:e2e tests/home.spec.ts tests/jobs.spec.ts`

## Notes
- Branch diff vs `master`: 32 files changed, 1692 insertions, 1327 deletions.
- Main commits included:
  - `1b3337e`, `821d867`, `2d8e56e`, `4d66f8c`, `02bc2b3`, `3d50b87`, `8ba8466`, `12dae89`, `5719200`
