### PR TITLE
CON-16: Backend 7-day freshness lifecycle for /news

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,6 @@ POSTHOG_PROJECT_ID="12345"
 
 # External API keys for AI features (if using)
 ANTHROPIC_API_KEY="sk-ant-..."
+
+# Shared secret used by cron endpoints (e.g. /api/cron/news-freshness)
+CRON_SECRET="replace-with-long-random-secret"

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ bunx drizzle-kit studio
 # Run Playwright tests
 bunx playwright install  # first time only
 bun run test
+
+# Reconcile /news FRESH tags (<7 days fresh, >=7 days stale)
+bun run news:freshness:reconcile
 ```
 
 ## Environment Variables
@@ -181,6 +184,9 @@ R2_PUBLIC_URL="https://pub-xxx.r2.dev"
 NEXT_PUBLIC_POSTHOG_KEY="phc_..."
 POSTHOG_PERSONAL_API_KEY="phx_..."
 POSTHOG_PROJECT_ID="..."
+
+# Cron authorization (used by /api/cron/news-freshness)
+CRON_SECRET="..."
 ```
 
 ## Content Management

--- a/drizzle/0004_groovy_owl.sql
+++ b/drizzle/0004_groovy_owl.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "blog_posts" ADD COLUMN "is_fresh" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "announcements" ADD COLUMN "is_fresh" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "curated_links" ADD COLUMN "source_image" text;--> statement-breakpoint
+ALTER TABLE "curated_links" ADD COLUMN "is_fresh" boolean DEFAULT false NOT NULL;

--- a/drizzle/0004_groovy_owl.sql
+++ b/drizzle/0004_groovy_owl.sql
@@ -1,4 +1,10 @@
 ALTER TABLE "blog_posts" ADD COLUMN "is_fresh" boolean DEFAULT false NOT NULL;--> statement-breakpoint
 ALTER TABLE "announcements" ADD COLUMN "is_fresh" boolean DEFAULT false NOT NULL;--> statement-breakpoint
 ALTER TABLE "curated_links" ADD COLUMN "source_image" text;--> statement-breakpoint
-ALTER TABLE "curated_links" ADD COLUMN "is_fresh" boolean DEFAULT false NOT NULL;
+ALTER TABLE "curated_links" ADD COLUMN "is_fresh" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+UPDATE "blog_posts"
+SET "is_fresh" = ("date" > (timezone('UTC', now()) - interval '7 day'));--> statement-breakpoint
+UPDATE "announcements"
+SET "is_fresh" = ("date" > (timezone('UTC', now()) - interval '7 day'));--> statement-breakpoint
+UPDATE "curated_links"
+SET "is_fresh" = ("date" > (timezone('UTC', now()) - interval '7 day'));

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1309 @@
+{
+  "id": "1c842f0a-b212-462e-8c62-a5e891757ab6",
+  "prevId": "fa0a7a65-90bd-4d83-ba2b-1aad9713c87f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blog_posts": {
+      "name": "blog_posts",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_fresh": {
+          "name": "is_fresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blog_posts_date_idx": {
+          "name": "blog_posts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_posts_published_idx": {
+          "name": "blog_posts_published_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidates": {
+      "name": "candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience": {
+          "name": "experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education": {
+          "name": "education",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cv": {
+          "name": "cv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'looking'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendly": {
+          "name": "calendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidates_featured_idx": {
+          "name": "candidates_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidates_available_idx": {
+          "name": "candidates_available_idx",
+          "columns": [
+            {
+              "expression": "available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_roles": {
+      "name": "job_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_roles_slug_idx": {
+          "name": "job_roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_roles_slug_unique": {
+          "name": "job_roles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_tags": {
+      "name": "job_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_tags_slug_idx": {
+          "name": "job_tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_tags_slug_unique": {
+          "name": "job_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote": {
+          "name": "remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary": {
+          "name": "salary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_x": {
+          "name": "company_x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_github": {
+          "name": "company_github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_company_idx": {
+          "name": "jobs_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_category_idx": {
+          "name": "jobs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_featured_idx": {
+          "name": "jobs_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_fresh": {
+          "name": "is_fresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_company_idx": {
+          "name": "announcements_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_date_idx": {
+          "name": "announcements_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_links": {
+      "name": "curated_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_image": {
+          "name": "source_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_fresh": {
+          "name": "is_fresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curated_links_category_idx": {
+          "name": "curated_links_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "curated_links_date_idx": {
+          "name": "curated_links_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investment_categories": {
+      "name": "investment_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investment_categories_slug_idx": {
+          "name": "investment_categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "investment_categories_slug_unique": {
+          "name": "investment_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investments_tier_idx": {
+          "name": "investments_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investments_featured_idx": {
+          "name": "investments_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_begin": {
+          "name": "date_begin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_title_idx": {
+          "name": "affiliations_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate_redirects": {
+      "name": "candidate_redirects",
+      "schema": "",
+      "columns": {
+        "old_id": {
+          "name": "old_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_id": {
+          "name": "new_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_redirects_new_id_idx": {
+          "name": "candidate_redirects_new_id_idx",
+          "columns": [
+            {
+              "expression": "new_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1770201446093,
       "tag": "0003_breezy_silverclaw",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1770378364144,
+      "tag": "0004_groovy_owl",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "playwright test",
     "test:unit": "bun test tests/*.test.ts",
     "test:e2e": "playwright test",
-    "test:all": "bun run test:unit && bun run test:e2e"
+    "test:all": "bun run test:unit && bun run test:e2e",
+    "news:freshness:reconcile": "bun run scripts/reconcile-news-freshness.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",

--- a/scripts/reconcile-news-freshness.ts
+++ b/scripts/reconcile-news-freshness.ts
@@ -1,0 +1,11 @@
+import { reconcileNewsFreshness } from "../src/services/news-freshness";
+
+async function main() {
+  const result = await reconcileNewsFreshness();
+  console.log(JSON.stringify({ ok: true, ...result }, null, 2));
+}
+
+main().catch((error) => {
+  console.error("[reconcile-news-freshness] Failed:", error);
+  process.exit(1);
+});

--- a/src/app/api/cron/news-freshness/route.ts
+++ b/src/app/api/cron/news-freshness/route.ts
@@ -1,0 +1,33 @@
+import { reconcileNewsFreshness } from "@/services/news-freshness";
+
+export const runtime = "nodejs";
+
+function isAuthorized(request: Request): boolean {
+  const configuredSecret = process.env.CRON_SECRET;
+  if (!configuredSecret) return false;
+
+  const bearerToken = request.headers.get("authorization")?.replace(/^Bearer\s+/i, "");
+  const headerToken = request.headers.get("x-cron-secret");
+  const token = bearerToken || headerToken;
+
+  return token === configuredSecret;
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await reconcileNewsFreshness();
+    console.info("[cron/news-freshness] Reconciled freshness", result);
+    return Response.json({ ok: true, ...result });
+  } catch (error) {
+    console.error("[cron/news-freshness] Reconcile failed", error);
+    return Response.json({ error: "Failed to reconcile news freshness" }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request) {
+  return POST(request);
+}

--- a/src/app/api/v1/news/announcements/[id]/route.ts
+++ b/src/app/api/v1/news/announcements/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { db, announcements } from "@/db";
 import { eq } from "drizzle-orm";
 import { requireAuth } from "@/services/auth";
+import { shouldBeFresh } from "@/services/news-freshness";
 
 // GET /api/v1/news/announcements/[id] - Get an announcement by ID
 export async function GET(
@@ -54,7 +55,11 @@ export async function PUT(
     if (body.company !== undefined) updateData.company = body.company;
     if (body.companyLogo !== undefined) updateData.companyLogo = body.companyLogo;
     if (body.platform !== undefined) updateData.platform = body.platform;
-    if (body.date !== undefined) updateData.date = new Date(body.date);
+    if (body.date !== undefined) {
+      const parsedDate = new Date(body.date);
+      updateData.date = parsedDate;
+      updateData.isFresh = shouldBeFresh(parsedDate);
+    }
     if (body.description !== undefined) updateData.description = body.description;
     if (body.category !== undefined) updateData.category = body.category;
     if (body.featured !== undefined) updateData.featured = body.featured;

--- a/src/app/api/v1/news/announcements/route.ts
+++ b/src/app/api/v1/news/announcements/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { db, announcements, NewAnnouncement } from "@/db";
 import { eq, desc, and, SQL } from "drizzle-orm";
 import { requireAuth, parsePaginationParams } from "@/services/auth";
+import { shouldBeFresh } from "@/services/news-freshness";
 
 // GET /api/v1/news/announcements - List announcements
 export async function GET(request: NextRequest) {
@@ -79,6 +80,7 @@ export async function POST(request: NextRequest) {
       .values({
         ...body,
         date: new Date(body.date),
+        isFresh: shouldBeFresh(new Date(body.date)),
       })
       .returning();
 

--- a/src/app/api/v1/news/curated/[id]/route.ts
+++ b/src/app/api/v1/news/curated/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { db, curatedLinks } from "@/db";
 import { eq } from "drizzle-orm";
 import { requireAuth } from "@/services/auth";
+import { shouldBeFresh } from "@/services/news-freshness";
 
 // GET /api/v1/news/curated/[id] - Get a curated link by ID
 export async function GET(
@@ -52,7 +53,11 @@ export async function PUT(
     if (body.title !== undefined) updateData.title = body.title;
     if (body.url !== undefined) updateData.url = body.url;
     if (body.source !== undefined) updateData.source = body.source;
-    if (body.date !== undefined) updateData.date = new Date(body.date);
+    if (body.date !== undefined) {
+      const parsedDate = new Date(body.date);
+      updateData.date = parsedDate;
+      updateData.isFresh = shouldBeFresh(parsedDate);
+    }
     if (body.description !== undefined) updateData.description = body.description;
     if (body.category !== undefined) updateData.category = body.category;
     if (body.featured !== undefined) updateData.featured = body.featured;

--- a/src/app/api/v1/news/curated/route.ts
+++ b/src/app/api/v1/news/curated/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { db, curatedLinks, NewCuratedLink } from "@/db";
 import { eq, desc, and, SQL } from "drizzle-orm";
 import { requireAuth, parsePaginationParams } from "@/services/auth";
+import { shouldBeFresh } from "@/services/news-freshness";
 
 // GET /api/v1/news/curated - List curated links
 export async function GET(request: NextRequest) {
@@ -64,6 +65,7 @@ export async function POST(request: NextRequest) {
       .values({
         ...body,
         date: new Date(body.date),
+        isFresh: shouldBeFresh(new Date(body.date)),
       })
       .returning();
 

--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -16,21 +16,6 @@ const typeLabels: Record<NewsType, string> = {
 	announcement: "Announcements",
 };
 
-// Check if item is fresh based on platform
-// X posts: 5 days, everything else: 2 weeks
-const isFreshItem = (dateString: string | Date | undefined, platform?: string): boolean => {
-	if (!dateString) return false;
-	const date = new Date(dateString);
-	const now = new Date();
-	const cutoff = new Date();
-
-	// X posts are fresh for 5 days, others for 2 weeks
-	const daysThreshold = platform === "x" ? 5 : 14;
-	cutoff.setDate(now.getDate() - daysThreshold);
-
-	return date > cutoff;
-};
-
 interface NewsGridProps {
 	news: AggregatedNewsItem[];
 }
@@ -296,7 +281,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 									{/* Title */}
 									<h3 className="font-semibold group-hover:text-neutral-600 dark:group-hover:text-neutral-300 transition-colors flex items-center gap-2">
 										<span className="truncate">{item.title}</span>
-										{isFreshItem(item.date, item.platform) && (
+										{item.isFresh && (
 											<span className="flex-shrink-0 px-2 py-0.5 text-xs font-semibold rounded-full bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400">
 												✨ FRESH
 											</span>

--- a/src/db/schema/blog.ts
+++ b/src/db/schema/blog.ts
@@ -13,6 +13,7 @@ export const blogPosts = pgTable(
     sourceUrl: text("source_url"), // Original URL if republished
     image: text("image"), // Featured image URL
     published: boolean("published").default(true),
+    isFresh: boolean("is_fresh").default(false).notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },

--- a/src/db/schema/news.ts
+++ b/src/db/schema/news.ts
@@ -13,6 +13,7 @@ export const curatedLinks = pgTable(
     source: text("source").notNull(), // e.g., "Vitalik Buterin", "Paradigm"
     sourceImage: text("source_image"), // Profile image URL for the source
     date: timestamp("date").notNull(),
+    isFresh: boolean("is_fresh").default(false).notNull(),
     description: text("description"),
     category: text("category").notNull(), // crypto, ai, infrastructure, etc.
     featured: boolean("featured").default(false),
@@ -38,6 +39,7 @@ export const announcements = pgTable(
     companyLogo: text("company_logo"),
     platform: text("platform").notNull(), // x, blog, discord, github, other
     date: timestamp("date").notNull(),
+    isFresh: boolean("is_fresh").default(false).notNull(),
     description: text("description"),
     category: text("category").notNull(),
     featured: boolean("featured").default(false),

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -10,6 +10,7 @@ export interface BlogPostView {
   date: string;
   description: string;
   content: string;
+  isFresh: boolean;
   source?: string;
   sourceUrl?: string;
   readingTime: number;
@@ -21,6 +22,7 @@ export interface BlogPostMeta {
   title: string;
   date: string;
   description: string;
+  isFresh: boolean;
   source?: string;
   sourceUrl?: string;
   readingTime: number;
@@ -73,6 +75,7 @@ export async function getAllPosts(): Promise<BlogPostMeta[]> {
       title: post.title,
       date: formatDateString(post.date, post.slug),
       description: post.description || "",
+      isFresh: post.isFresh,
       source: post.source || undefined,
       sourceUrl: post.sourceUrl || undefined,
       readingTime: calculateReadingTime(post.content),
@@ -100,6 +103,7 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
       date: formatDateString(post.date, post.slug),
       description: post.description || "",
       content: post.content,
+      isFresh: post.isFresh,
       source: post.source || undefined,
       sourceUrl: post.sourceUrl || undefined,
       readingTime: calculateReadingTime(post.content),

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -13,6 +13,7 @@ export interface AggregatedNewsItem {
   description?: string;
   category: NewsCategory;
   featured?: boolean;
+  isFresh: boolean;
   // Type-specific fields
   source?: string; // For curated links
   company?: string; // For announcements
@@ -39,6 +40,7 @@ export async function getAllNews(): Promise<AggregatedNewsItem[]> {
     date: post.date,
     description: post.description,
     category: "general" as NewsCategory,
+    isFresh: post.isFresh,
     readingTime: `${post.readingTime} min read`,
     image: post.image,
   }));
@@ -53,6 +55,7 @@ export async function getAllNews(): Promise<AggregatedNewsItem[]> {
     description: link.description || undefined,
     category: link.category as NewsCategory,
     featured: link.featured || false,
+    isFresh: link.isFresh,
     source: link.source,
   }));
 
@@ -66,6 +69,7 @@ export async function getAllNews(): Promise<AggregatedNewsItem[]> {
     description: ann.description || undefined,
     category: ann.category as NewsCategory,
     featured: ann.featured || false,
+    isFresh: ann.isFresh,
     company: ann.company,
     companyLogo: ann.companyLogo || undefined,
     platform: ann.platform,

--- a/src/services/news-freshness.ts
+++ b/src/services/news-freshness.ts
@@ -1,0 +1,82 @@
+import { and, eq, gt, lte } from "drizzle-orm";
+import { db, announcements, blogPosts, curatedLinks } from "@/db";
+
+export const FRESH_WINDOW_DAYS = 7;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function getFreshCutoff(now: Date = new Date()): Date {
+  return new Date(now.getTime() - FRESH_WINDOW_DAYS * DAY_MS);
+}
+
+export function shouldBeFresh(date: Date, now: Date = new Date()): boolean {
+  return now.getTime() - date.getTime() < FRESH_WINDOW_DAYS * DAY_MS;
+}
+
+type FreshnessReconcileStats = {
+  table: "curated_links" | "announcements" | "blog_posts";
+  markedFresh: number;
+  markedStale: number;
+};
+
+export interface NewsFreshnessReconcileResult {
+  cutoffUtc: string;
+  stats: FreshnessReconcileStats[];
+}
+
+export async function reconcileNewsFreshness(now: Date = new Date()): Promise<NewsFreshnessReconcileResult> {
+  const cutoff = getFreshCutoff(now);
+
+  const [curatedFresh, curatedStale, announcementsFresh, announcementsStale, blogFresh, blogStale] = await Promise.all([
+    db
+      .update(curatedLinks)
+      .set({ isFresh: true, updatedAt: now })
+      .where(and(gt(curatedLinks.date, cutoff), eq(curatedLinks.isFresh, false)))
+      .returning({ id: curatedLinks.id }),
+    db
+      .update(curatedLinks)
+      .set({ isFresh: false, updatedAt: now })
+      .where(and(lte(curatedLinks.date, cutoff), eq(curatedLinks.isFresh, true)))
+      .returning({ id: curatedLinks.id }),
+    db
+      .update(announcements)
+      .set({ isFresh: true, updatedAt: now })
+      .where(and(gt(announcements.date, cutoff), eq(announcements.isFresh, false)))
+      .returning({ id: announcements.id }),
+    db
+      .update(announcements)
+      .set({ isFresh: false, updatedAt: now })
+      .where(and(lte(announcements.date, cutoff), eq(announcements.isFresh, true)))
+      .returning({ id: announcements.id }),
+    db
+      .update(blogPosts)
+      .set({ isFresh: true, updatedAt: now })
+      .where(and(gt(blogPosts.date, cutoff), eq(blogPosts.isFresh, false)))
+      .returning({ slug: blogPosts.slug }),
+    db
+      .update(blogPosts)
+      .set({ isFresh: false, updatedAt: now })
+      .where(and(lte(blogPosts.date, cutoff), eq(blogPosts.isFresh, true)))
+      .returning({ slug: blogPosts.slug }),
+  ]);
+
+  return {
+    cutoffUtc: cutoff.toISOString(),
+    stats: [
+      {
+        table: "curated_links",
+        markedFresh: curatedFresh.length,
+        markedStale: curatedStale.length,
+      },
+      {
+        table: "announcements",
+        markedFresh: announcementsFresh.length,
+        markedStale: announcementsStale.length,
+      },
+      {
+        table: "blog_posts",
+        markedFresh: blogFresh.length,
+        markedStale: blogStale.length,
+      },
+    ],
+  };
+}

--- a/tests/news-freshness.test.ts
+++ b/tests/news-freshness.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { FRESH_WINDOW_DAYS, getFreshCutoff, shouldBeFresh } from "../src/services/news-freshness";
+
+describe("news freshness lifecycle", () => {
+  test("uses a strict 7-day freshness window", () => {
+    expect(FRESH_WINDOW_DAYS).toBe(7);
+  });
+
+  test("marks items newer than 7 days as fresh", () => {
+    const now = new Date("2026-02-06T12:00:00.000Z");
+    const justInsideWindow = new Date("2026-01-30T12:00:00.001Z");
+
+    expect(shouldBeFresh(justInsideWindow, now)).toBe(true);
+  });
+
+  test("marks items exactly 7 days old as stale", () => {
+    const now = new Date("2026-02-06T12:00:00.000Z");
+    const exactBoundary = new Date("2026-01-30T12:00:00.000Z");
+
+    expect(shouldBeFresh(exactBoundary, now)).toBe(false);
+  });
+
+  test("matches cutoff helper behavior", () => {
+    const now = new Date("2026-02-06T12:00:00.000Z");
+    const cutoff = getFreshCutoff(now);
+
+    expect(cutoff.toISOString()).toBe("2026-01-30T12:00:00.000Z");
+    expect(shouldBeFresh(new Date("2026-01-31T00:00:00.000Z"), now)).toBe(true);
+    expect(shouldBeFresh(new Date("2026-01-29T23:59:59.999Z"), now)).toBe(false);
+  });
+});


### PR DESCRIPTION
  ## Summary
  - add `news-freshness` reconciliation service with strict UTC 7-day cutoff logic
  - remove client-side freshness heuristics and render FRESH badge from backend state only
  - add unit tests for freshness boundary behavior

  - bun run lint
  - bun run test:unit
  - bunx tsc --noEmit

  Closes CON-16.
