### PR TITLE
CON-17: Job-board ingestion automation and termination detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,10 @@ POSTHOG_PROJECT_ID="12345"
 
 # External API keys for AI features (if using)
 ANTHROPIC_API_KEY="sk-ant-..."
+
+# Cron auth secret (for /api/cron/job-board-sync)
+CRON_SECRET="replace-with-long-random-secret"
+
+# Optional JSON config for job-board sync sources
+# Example: [{"name":"board","url":"https://example.com/jobs","jobLinkPattern":"/jobs/"}]
+JOB_BOARD_SOURCES_JSON="[]"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Personal site built with Next.js (App Router) for dcbuilder.eth. Features a home
 - **Blog**: MDX posts with syntax highlighting and dynamic OG images
 - **Portfolio**: Investment cards with tiers, status, and category filtering
 - **Jobs**: Filterable job board with HOT/TOP/NEW badges, modal details, and shareable URLs
+- **Job Board Automation**: Config-driven ingestion from external boards with automatic termination detection
 - **Candidates**: Candidate directory with modal profiles, skill tags, and availability status
 - **News**: Curated links and portfolio announcements
 
@@ -160,6 +161,9 @@ bunx drizzle-kit studio
 # Run Playwright tests
 bunx playwright install  # first time only
 bun run test
+
+# Sync jobs from configured job boards
+bun run jobs:sync --dry-run
 ```
 
 ## Environment Variables

--- a/drizzle/0004_previous_arclight.sql
+++ b/drizzle/0004_previous_arclight.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "jobs" ADD COLUMN "source_board" text;--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "source_url" text;--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "source_external_id" text;--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "last_checked_at" timestamp;--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "terminated" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "terminated_at" timestamp;--> statement-breakpoint
+ALTER TABLE "jobs" ADD COLUMN "termination_reason" text;--> statement-breakpoint
+ALTER TABLE "curated_links" ADD COLUMN "source_image" text;--> statement-breakpoint
+CREATE INDEX "jobs_source_board_idx" ON "jobs" USING btree ("source_board");--> statement-breakpoint
+CREATE INDEX "jobs_terminated_idx" ON "jobs" USING btree ("terminated");

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1361 @@
+{
+  "id": "a4170256-68cb-458a-a9df-68e4e1c67ef9",
+  "prevId": "fa0a7a65-90bd-4d83-ba2b-1aad9713c87f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blog_posts": {
+      "name": "blog_posts",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blog_posts_date_idx": {
+          "name": "blog_posts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_posts_published_idx": {
+          "name": "blog_posts_published_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidates": {
+      "name": "candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience": {
+          "name": "experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education": {
+          "name": "education",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cv": {
+          "name": "cv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'looking'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendly": {
+          "name": "calendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidates_featured_idx": {
+          "name": "candidates_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidates_available_idx": {
+          "name": "candidates_available_idx",
+          "columns": [
+            {
+              "expression": "available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_roles": {
+      "name": "job_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_roles_slug_idx": {
+          "name": "job_roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_roles_slug_unique": {
+          "name": "job_roles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_tags": {
+      "name": "job_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_tags_slug_idx": {
+          "name": "job_tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_tags_slug_unique": {
+          "name": "job_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote": {
+          "name": "remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary": {
+          "name": "salary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_x": {
+          "name": "company_x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_github": {
+          "name": "company_github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_board": {
+          "name": "source_board",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_external_id": {
+          "name": "source_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminated": {
+          "name": "terminated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_reason": {
+          "name": "termination_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_company_idx": {
+          "name": "jobs_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_category_idx": {
+          "name": "jobs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_featured_idx": {
+          "name": "jobs_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_source_board_idx": {
+          "name": "jobs_source_board_idx",
+          "columns": [
+            {
+              "expression": "source_board",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_terminated_idx": {
+          "name": "jobs_terminated_idx",
+          "columns": [
+            {
+              "expression": "terminated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_company_idx": {
+          "name": "announcements_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_date_idx": {
+          "name": "announcements_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_links": {
+      "name": "curated_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_image": {
+          "name": "source_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curated_links_category_idx": {
+          "name": "curated_links_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "curated_links_date_idx": {
+          "name": "curated_links_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investment_categories": {
+      "name": "investment_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investment_categories_slug_idx": {
+          "name": "investment_categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "investment_categories_slug_unique": {
+          "name": "investment_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investments_tier_idx": {
+          "name": "investments_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investments_featured_idx": {
+          "name": "investments_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_begin": {
+          "name": "date_begin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_title_idx": {
+          "name": "affiliations_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate_redirects": {
+      "name": "candidate_redirects",
+      "schema": "",
+      "columns": {
+        "old_id": {
+          "name": "old_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_id": {
+          "name": "new_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_redirects_new_id_idx": {
+          "name": "candidate_redirects_new_id_idx",
+          "columns": [
+            {
+              "expression": "new_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1770201446093,
       "tag": "0003_breezy_silverclaw",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1770378995162,
+      "tag": "0004_previous_arclight",
+      "breakpoints": true
     }
   ]
 }

--- a/job-board-sources.example.json
+++ b/job-board-sources.example.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "example-board",
+    "url": "https://example.com/careers",
+    "company": "Example Company",
+    "category": "network",
+    "listSelector": "a[href*='/jobs/']",
+    "jobLinkPattern": "/jobs/",
+    "closedMarkers": [
+      "position has been filled",
+      "job is no longer available"
+    ]
+  }
+]

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "playwright test",
     "test:unit": "bun test tests/*.test.ts",
     "test:e2e": "playwright test",
-    "test:all": "bun run test:unit && bun run test:e2e"
+    "test:all": "bun run test:unit && bun run test:e2e",
+    "jobs:sync": "bun run scripts/sync-job-boards.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",

--- a/scripts/sync-job-boards.ts
+++ b/scripts/sync-job-boards.ts
@@ -1,0 +1,17 @@
+import { syncJobBoards } from "../src/services/job-board-sync";
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes("--dry-run");
+
+  const sourceIndex = args.findIndex((arg) => arg === "--source");
+  const sourceName = sourceIndex >= 0 ? args[sourceIndex + 1] : undefined;
+
+  const summary = await syncJobBoards({ dryRun, sourceName });
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main().catch((error) => {
+  console.error("[sync-job-boards] Failed:", error);
+  process.exit(1);
+});

--- a/src/app/api/cron/job-board-sync/route.ts
+++ b/src/app/api/cron/job-board-sync/route.ts
@@ -1,0 +1,31 @@
+import { syncJobBoards } from "@/services/job-board-sync";
+
+export const runtime = "nodejs";
+
+function isAuthorized(request: Request): boolean {
+  const configuredSecret = process.env.CRON_SECRET;
+  if (!configuredSecret) return false;
+
+  const bearerToken = request.headers.get("authorization")?.replace(/^Bearer\s+/i, "");
+  const headerToken = request.headers.get("x-cron-secret");
+  const token = bearerToken || headerToken;
+
+  return token === configuredSecret;
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(request.url);
+  const dryRun = url.searchParams.get("dryRun") === "true";
+  const sourceName = url.searchParams.get("source") || undefined;
+
+  const summary = await syncJobBoards({ dryRun, sourceName });
+  return Response.json(summary);
+}
+
+export async function GET(request: Request) {
+  return POST(request);
+}

--- a/src/app/api/v1/jobs/[id]/route.ts
+++ b/src/app/api/v1/jobs/[id]/route.ts
@@ -29,6 +29,13 @@ export async function GET(_request: NextRequest, { params }: Params) {
         companyWebsite: jobs.companyWebsite,
         companyX: jobs.companyX,
         companyGithub: jobs.companyGithub,
+        sourceBoard: jobs.sourceBoard,
+        sourceUrl: jobs.sourceUrl,
+        sourceExternalId: jobs.sourceExternalId,
+        lastCheckedAt: jobs.lastCheckedAt,
+        terminated: jobs.terminated,
+        terminatedAt: jobs.terminatedAt,
+        terminationReason: jobs.terminationReason,
         createdAt: jobs.createdAt,
         updatedAt: jobs.updatedAt,
       })

--- a/src/app/api/v1/jobs/route.ts
+++ b/src/app/api/v1/jobs/route.ts
@@ -9,6 +9,7 @@ export async function GET(request: NextRequest) {
   const company = searchParams.get("company");
   const category = searchParams.get("category");
   const featured = searchParams.get("featured");
+  const includeTerminated = searchParams.get("includeTerminated");
   const { limit, offset } = parsePaginationParams(searchParams);
 
   try {
@@ -22,6 +23,9 @@ export async function GET(request: NextRequest) {
     }
     if (featured === "true") {
       conditions.push(eq(jobs.featured, true));
+    }
+    if (includeTerminated !== "true") {
+      conditions.push(eq(jobs.terminated, false));
     }
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
@@ -46,6 +50,13 @@ export async function GET(request: NextRequest) {
           companyWebsite: jobs.companyWebsite,
           companyX: jobs.companyX,
           companyGithub: jobs.companyGithub,
+          sourceBoard: jobs.sourceBoard,
+          sourceUrl: jobs.sourceUrl,
+          sourceExternalId: jobs.sourceExternalId,
+          lastCheckedAt: jobs.lastCheckedAt,
+          terminated: jobs.terminated,
+          terminatedAt: jobs.terminatedAt,
+          terminationReason: jobs.terminationReason,
           createdAt: jobs.createdAt,
           updatedAt: jobs.updatedAt,
         })

--- a/src/app/api/v1/jobs/sync/route.ts
+++ b/src/app/api/v1/jobs/sync/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/services/auth";
+import { syncJobBoards } from "@/services/job-board-sync";
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request, "jobs:write");
+  if (auth instanceof Response) return auth;
+
+  let body: { dryRun?: boolean; sourceName?: string };
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const summary = await syncJobBoards({
+    dryRun: Boolean(body.dryRun),
+    sourceName: body.sourceName,
+  });
+
+  return Response.json(summary);
+}

--- a/src/db/schema/jobs.ts
+++ b/src/db/schema/jobs.ts
@@ -27,6 +27,13 @@ export const jobs = pgTable(
     companyWebsite: text("company_website"),
     companyX: text("company_x"),
     companyGithub: text("company_github"),
+    sourceBoard: text("source_board"),
+    sourceUrl: text("source_url"),
+    sourceExternalId: text("source_external_id"),
+    lastCheckedAt: timestamp("last_checked_at"),
+    terminated: boolean("terminated").default(false).notNull(),
+    terminatedAt: timestamp("terminated_at"),
+    terminationReason: text("termination_reason"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
@@ -34,6 +41,8 @@ export const jobs = pgTable(
     index("jobs_company_idx").on(table.company),
     index("jobs_category_idx").on(table.category),
     index("jobs_featured_idx").on(table.featured),
+    index("jobs_source_board_idx").on(table.sourceBoard),
+    index("jobs_terminated_idx").on(table.terminated),
   ]
 );
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -15,7 +15,11 @@ import type { CuratedLink } from "@/data/news";
 
 // Fetch all jobs from database and transform to component format
 export async function getJobsFromDB(): Promise<Job[]> {
-  const dbJobs = await db.select().from(jobsTable).orderBy(desc(jobsTable.createdAt));
+  const dbJobs = await db
+    .select()
+    .from(jobsTable)
+    .where(eq(jobsTable.terminated, false))
+    .orderBy(desc(jobsTable.createdAt));
 
   return dbJobs.map((job) => {
     const company: Company = {

--- a/src/lib/job-board-sync.ts
+++ b/src/lib/job-board-sync.ts
@@ -1,0 +1,116 @@
+import * as cheerio from "cheerio";
+
+export interface JobBoardSource {
+  name: string;
+  url: string;
+  category?: "portfolio" | "network";
+  company?: string;
+  listSelector?: string;
+  jobLinkPattern?: string;
+  closedMarkers?: string[];
+}
+
+export interface ParsedJobLink {
+  link: string;
+  title: string;
+}
+
+const DEFAULT_CLOSED_MARKERS = [
+  "position has been filled",
+  "position is no longer available",
+  "job is no longer available",
+  "this job has expired",
+  "role has been filled",
+  "no openings at this time",
+];
+
+export function canonicalizeJobUrl(url: string): string {
+  const parsed = new URL(url);
+
+  // Remove tracking and pagination params
+  const keepParams = new URLSearchParams();
+  parsed.searchParams.forEach((value, key) => {
+    if (!key.toLowerCase().startsWith("utm_") && key !== "ref" && key !== "source") {
+      keepParams.append(key, value);
+    }
+  });
+
+  parsed.search = keepParams.toString();
+  parsed.hash = "";
+
+  if (parsed.pathname.length > 1 && parsed.pathname.endsWith("/")) {
+    parsed.pathname = parsed.pathname.slice(0, -1);
+  }
+
+  return parsed.toString();
+}
+
+function deriveTitleFromUrl(url: string): string {
+  const parsed = new URL(url);
+  const slug = parsed.pathname.split("/").filter(Boolean).pop() || "Job";
+  return slug
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function extractJobLinksFromHtml(source: JobBoardSource, html: string): ParsedJobLink[] {
+  const $ = cheerio.load(html);
+  const selector = source.listSelector || "a[href]";
+  const pattern = source.jobLinkPattern ? new RegExp(source.jobLinkPattern, "i") : null;
+
+  const linksByUrl = new Map<string, ParsedJobLink>();
+  $(selector).each((_, element) => {
+    const href = $(element).attr("href");
+    if (!href) return;
+
+    try {
+      const absolute = new URL(href, source.url).toString();
+      if (pattern && !pattern.test(absolute)) return;
+      if (!absolute.startsWith("http://") && !absolute.startsWith("https://")) return;
+
+      const canonical = canonicalizeJobUrl(absolute);
+      const rawTitle = $(element).text().trim();
+      const title = rawTitle || deriveTitleFromUrl(canonical);
+
+      if (!linksByUrl.has(canonical)) {
+        linksByUrl.set(canonical, { link: canonical, title });
+      }
+    } catch {
+      // Ignore malformed URLs
+    }
+  });
+
+  return Array.from(linksByUrl.values());
+}
+
+export function detectTermination(params: {
+  status: number;
+  bodyText?: string;
+  finalUrl?: string;
+  jobUrl: string;
+  sourceUrl: string;
+  closedMarkers?: string[];
+}): { terminated: boolean; reason: string } {
+  const markerList = (params.closedMarkers || DEFAULT_CLOSED_MARKERS).map((marker) => marker.toLowerCase());
+  const status = params.status;
+
+  if (status === 404 || status === 410) {
+    return { terminated: true, reason: `http_${status}` };
+  }
+
+  const finalUrl = params.finalUrl ? canonicalizeJobUrl(params.finalUrl) : canonicalizeJobUrl(params.jobUrl);
+  const sourceUrl = canonicalizeJobUrl(params.sourceUrl);
+  const jobUrl = canonicalizeJobUrl(params.jobUrl);
+
+  if (finalUrl !== jobUrl && finalUrl === sourceUrl) {
+    return { terminated: true, reason: "redirected_to_board_home" };
+  }
+
+  const body = (params.bodyText || "").toLowerCase();
+  const marker = markerList.find((entry) => body.includes(entry));
+  if (marker) {
+    return { terminated: true, reason: `content_marker:${marker}` };
+  }
+
+  return { terminated: false, reason: "active" };
+}

--- a/src/services/job-board-sync.ts
+++ b/src/services/job-board-sync.ts
@@ -1,0 +1,268 @@
+import { readFile } from "fs/promises";
+import { resolve } from "path";
+import { and, eq } from "drizzle-orm";
+import { db, jobs } from "@/db";
+import { JobBoardSource, detectTermination, extractJobLinksFromHtml } from "@/lib/job-board-sync";
+
+type SourceRunSummary = {
+  source: string;
+  discovered: number;
+  inserted: number;
+  updated: number;
+  reactivated: number;
+  terminated: number;
+  checked: number;
+  errors: string[];
+};
+
+export type JobBoardSyncSummary = {
+  dryRun: boolean;
+  startedAt: string;
+  finishedAt: string;
+  sourcesProcessed: number;
+  totals: {
+    discovered: number;
+    inserted: number;
+    updated: number;
+    reactivated: number;
+    terminated: number;
+    checked: number;
+  };
+  bySource: SourceRunSummary[];
+};
+
+function safeJsonParse<T>(value: string): T | null {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+}
+
+function validateSource(source: Partial<JobBoardSource>): source is JobBoardSource {
+  return Boolean(source.name && source.url);
+}
+
+async function loadSourcesFromConfigFile(): Promise<JobBoardSource[]> {
+  const configPath = resolve(process.cwd(), "job-board-sources.json");
+  try {
+    const raw = await readFile(configPath, "utf-8");
+    const parsed = safeJsonParse<Partial<JobBoardSource>[]>(raw);
+    if (!parsed) return [];
+    return parsed.filter(validateSource);
+  } catch {
+    return [];
+  }
+}
+
+export async function loadJobBoardSources(): Promise<JobBoardSource[]> {
+  const envConfig = process.env.JOB_BOARD_SOURCES_JSON;
+  if (envConfig) {
+    const parsed = safeJsonParse<Partial<JobBoardSource>[]>(envConfig);
+    if (!parsed) {
+      throw new Error("JOB_BOARD_SOURCES_JSON is not valid JSON");
+    }
+
+    const valid = parsed.filter(validateSource);
+    if (valid.length === 0) {
+      throw new Error("JOB_BOARD_SOURCES_JSON contains no valid sources");
+    }
+    return valid;
+  }
+
+  return loadSourcesFromConfigFile();
+}
+
+async function fetchWithRetry(url: string, maxAttempts: number = 3): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await fetch(url, {
+        redirect: "follow",
+        headers: { "User-Agent": "dcbuilder-job-sync/1.0" },
+      });
+    } catch (error) {
+      lastError = error;
+      const waitMs = 300 * attempt;
+      await new Promise((resolveWait) => setTimeout(resolveWait, waitMs));
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Failed to fetch URL");
+}
+
+function toIso(value: Date): string {
+  return value.toISOString();
+}
+
+async function processSource(source: JobBoardSource, dryRun: boolean): Promise<SourceRunSummary> {
+  const now = new Date();
+  const summary: SourceRunSummary = {
+    source: source.name,
+    discovered: 0,
+    inserted: 0,
+    updated: 0,
+    reactivated: 0,
+    terminated: 0,
+    checked: 0,
+    errors: [],
+  };
+
+  try {
+    const listResponse = await fetchWithRetry(source.url);
+    if (!listResponse.ok) {
+      summary.errors.push(`Failed to fetch board URL (${listResponse.status})`);
+      return summary;
+    }
+
+    const html = await listResponse.text();
+    const parsedLinks = extractJobLinksFromHtml(source, html);
+    summary.discovered = parsedLinks.length;
+
+    const existingJobs = await db
+      .select({
+        id: jobs.id,
+        link: jobs.link,
+        terminated: jobs.terminated,
+      })
+      .from(jobs)
+      .where(eq(jobs.sourceBoard, source.name));
+
+    const existingByLink = new Map(existingJobs.map((job) => [job.link, job]));
+    const seenLinks = new Set<string>();
+
+    for (const parsedJob of parsedLinks) {
+      seenLinks.add(parsedJob.link);
+      const existing = existingByLink.get(parsedJob.link);
+      const company = source.company || new URL(source.url).hostname.replace(/^www\./, "");
+      const category = source.category || "network";
+
+      if (!existing) {
+        summary.inserted += 1;
+        if (!dryRun) {
+          await db.insert(jobs).values({
+            title: parsedJob.title,
+            company,
+            link: parsedJob.link,
+            category,
+            sourceBoard: source.name,
+            sourceUrl: source.url,
+            sourceExternalId: parsedJob.link,
+            terminated: false,
+            terminatedAt: null,
+            terminationReason: null,
+            lastCheckedAt: now,
+            createdAt: now,
+            updatedAt: now,
+          });
+        }
+        continue;
+      }
+
+      summary.updated += 1;
+      if (existing.terminated) {
+        summary.reactivated += 1;
+      }
+      if (!dryRun) {
+        await db
+          .update(jobs)
+          .set({
+            title: parsedJob.title,
+            company,
+            category,
+            sourceBoard: source.name,
+            sourceUrl: source.url,
+            sourceExternalId: parsedJob.link,
+            terminated: false,
+            terminatedAt: null,
+            terminationReason: null,
+            lastCheckedAt: now,
+            updatedAt: now,
+          })
+          .where(eq(jobs.id, existing.id));
+      }
+    }
+
+    const activeExisting = existingJobs.filter((job) => !job.terminated);
+    for (const job of activeExisting) {
+      if (seenLinks.has(job.link)) continue;
+      summary.checked += 1;
+
+      let terminated = false;
+      let reason = "active";
+      try {
+        const detailResponse = await fetchWithRetry(job.link);
+        const body = await detailResponse.text();
+        const detection = detectTermination({
+          status: detailResponse.status,
+          bodyText: body,
+          finalUrl: detailResponse.url,
+          jobUrl: job.link,
+          sourceUrl: source.url,
+          closedMarkers: source.closedMarkers,
+        });
+        terminated = detection.terminated;
+        reason = detection.reason;
+      } catch (error) {
+        summary.errors.push(`Termination check failed for ${job.link}: ${error instanceof Error ? error.message : "Unknown error"}`);
+      }
+
+      if (terminated) {
+        summary.terminated += 1;
+      }
+
+      if (!dryRun) {
+        await db
+          .update(jobs)
+          .set({
+            terminated,
+            terminatedAt: terminated ? now : null,
+            terminationReason: terminated ? reason : null,
+            lastCheckedAt: now,
+            updatedAt: now,
+          })
+          .where(and(eq(jobs.id, job.id), eq(jobs.sourceBoard, source.name)));
+      }
+    }
+  } catch (error) {
+    summary.errors.push(error instanceof Error ? error.message : "Unknown source processing error");
+  }
+
+  return summary;
+}
+
+export async function syncJobBoards(options?: { dryRun?: boolean; sourceName?: string }): Promise<JobBoardSyncSummary> {
+  const startedAt = new Date();
+  const dryRun = Boolean(options?.dryRun);
+  const allSources = await loadJobBoardSources();
+  const sources = options?.sourceName
+    ? allSources.filter((source) => source.name === options.sourceName)
+    : allSources;
+
+  const bySource: SourceRunSummary[] = [];
+  for (const source of sources) {
+    const summary = await processSource(source, dryRun);
+    bySource.push(summary);
+  }
+
+  const totals = bySource.reduce(
+    (acc, current) => ({
+      discovered: acc.discovered + current.discovered,
+      inserted: acc.inserted + current.inserted,
+      updated: acc.updated + current.updated,
+      reactivated: acc.reactivated + current.reactivated,
+      terminated: acc.terminated + current.terminated,
+      checked: acc.checked + current.checked,
+    }),
+    { discovered: 0, inserted: 0, updated: 0, reactivated: 0, terminated: 0, checked: 0 }
+  );
+
+  return {
+    dryRun,
+    startedAt: toIso(startedAt),
+    finishedAt: toIso(new Date()),
+    sourcesProcessed: bySource.length,
+    totals,
+    bySource,
+  };
+}

--- a/tests/job-board-sync.test.ts
+++ b/tests/job-board-sync.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import {
+  canonicalizeJobUrl,
+  detectTermination,
+  extractJobLinksFromHtml,
+  type JobBoardSource,
+} from "../src/lib/job-board-sync";
+
+describe("job board sync helpers", () => {
+  test("canonicalizes URLs by removing tracking params and hashes", () => {
+    const canonical = canonicalizeJobUrl(
+      "https://example.com/jobs/senior-engineer/?utm_source=twitter&ref=abc&lang=en#section"
+    );
+
+    expect(canonical).toBe("https://example.com/jobs/senior-engineer?lang=en");
+  });
+
+  test("extracts deduplicated job links from board HTML", () => {
+    const source: JobBoardSource = {
+      name: "board",
+      url: "https://jobs.example.com",
+      jobLinkPattern: "/positions/",
+    };
+
+    const html = `
+      <main>
+        <a href="/positions/backend-engineer">Backend Engineer</a>
+        <a href="/positions/backend-engineer?utm_source=x">Backend Engineer duplicate</a>
+        <a href="/positions/design-lead">Design Lead</a>
+        <a href="/blog/company-update">Blog post</a>
+      </main>
+    `;
+
+    const links = extractJobLinksFromHtml(source, html);
+    expect(links).toHaveLength(2);
+    expect(links.map((link) => link.link)).toEqual([
+      "https://jobs.example.com/positions/backend-engineer",
+      "https://jobs.example.com/positions/design-lead",
+    ]);
+  });
+
+  test("detects terminated job on HTTP status codes and content markers", () => {
+    expect(
+      detectTermination({
+        status: 404,
+        jobUrl: "https://jobs.example.com/positions/backend",
+        sourceUrl: "https://jobs.example.com/careers",
+      })
+    ).toEqual({ terminated: true, reason: "http_404" });
+
+    expect(
+      detectTermination({
+        status: 200,
+        bodyText: "Sorry, this position has been filled.",
+        jobUrl: "https://jobs.example.com/positions/backend",
+        sourceUrl: "https://jobs.example.com/careers",
+      })
+    ).toEqual({ terminated: true, reason: "content_marker:position has been filled" });
+
+    expect(
+      detectTermination({
+        status: 200,
+        bodyText: "Apply now",
+        finalUrl: "https://jobs.example.com/positions/backend",
+        jobUrl: "https://jobs.example.com/positions/backend",
+        sourceUrl: "https://jobs.example.com/careers",
+      })
+    ).toEqual({ terminated: false, reason: "active" });
+  });
+});


### PR DESCRIPTION
  ## Summary
  - add job provenance/termination fields + migration (`source_board`, `source_url`, `source_external_id`, `last_checked_at`, `terminated`, `terminated_at`, `termination_reason`)
  - implement config-driven job-board sync service with discovery, dedupe, and upsert
  - add helper tests for URL canonicalization, extraction, and termination detection
  - hide terminated jobs from public jobs listing by default

  ## Validation
  - bunx tsc --noEmit
  Closes CON-17.
