### PR TITLE
CON-14: Newsletter backend, lifecycle APIs, and campaign pipeline

### DIFF
--- a/.claude/skills/post-news/SKILL.md
+++ b/.claude/skills/post-news/SKILL.md
@@ -82,6 +82,20 @@ Required fields:
 
 ### Step 2: Insert via Database
 
+Preferred (script):
+
+```bash
+# Example (loads env vars from .env.local)
+bunx dotenv -e .env.local -- bun run scripts/add-curated-link.ts \
+  --title "YOUR_TITLE" \
+  --url "YOUR_URL" \
+  --source "SOURCE_NAME" \
+  --category x_post \
+  --date YYYY-MM-DD
+```
+
+Alternate (inline):
+
 ```bash
 bun -e "
 import { db, curatedLinks } from './src/db';
@@ -212,7 +226,4 @@ process.exit(0);
 - **`references/schemas.md`** - Detailed field schemas and validation rules
 
 ### Scripts
-- **`scripts/add-announcement.ts`** - Add announcement via JSON
-- **`scripts/add-curated-link.ts`** - Add curated link via JSON
-- **`scripts/download-image.ts`** - Download image from URL
-- **`scripts/upload-to-r2.ts`** - Upload image to R2
+- **`scripts/add-curated-link.ts`** - Add curated link via CLI flags (`--dry-run` supported)

--- a/.claude/skills/post-news/scripts/add-announcement.ts
+++ b/.claude/skills/post-news/scripts/add-announcement.ts
@@ -15,7 +15,7 @@
  * - featured (optional): boolean
  */
 
-import { db, announcements } from "../../../src/db";
+import { db, announcements } from "../../../../src/db";
 
 const jsonData = process.argv[2];
 

--- a/.claude/skills/post-news/scripts/add-curated-link.ts
+++ b/.claude/skills/post-news/scripts/add-curated-link.ts
@@ -7,13 +7,14 @@
  * - title (required): Link title
  * - url (required): Link URL
  * - source (required): Source name (e.g., "Vitalik Buterin", "Paradigm")
+ * - sourceImage (optional): Source image URL (R2 or external)
  * - date (required): Date string (YYYY-MM-DD)
  * - category (required): x_post | crypto | ai | infrastructure | defi | research | product | funding | general
  * - description (optional): Description text
  * - featured (optional): boolean
  */
 
-import { db, curatedLinks } from "../../../src/db";
+import { db, curatedLinks } from "../../../../src/db";
 
 const jsonData = process.argv[2];
 
@@ -37,6 +38,7 @@ try {
     title: data.title,
     url: data.url,
     source: data.source,
+    sourceImage: data.sourceImage,
     date: new Date(data.date),
     description: data.description,
     category: data.category,

--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,16 @@
 # REQUIRED
 # ====================
 
-# Database - PostgreSQL connection string
-# For local: postgresql://localhost:5432/your_db_name
-# For hosted: Get from Neon, Supabase, Railway, etc.
+# Runtime DB URL (set this in the app runtime: local, Vercel staging, Vercel prod)
 DATABASE_URL="postgresql://user:password@host:5432/database"
+
+# Drizzle migration targets (explicit environment separation)
+# Local development DB (usually your Supabase dev project)
+DATABASE_URL_DEV="postgresql://user:password@host:5432/dev_db"
+# Staging DB (GitHub Actions + staging environment)
+DATABASE_URL_STAGING="postgresql://user:password@host:5432/staging_db"
+# Production DB (GitHub Actions + production environment)
+DATABASE_URL_PROD="postgresql://user:password@host:5432/prod_db"
 
 # ====================
 # IMAGE STORAGE (Cloudflare R2)

--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,8 @@ POSTHOG_PROJECT_ID="12345"
 
 # External API keys for AI features (if using)
 ANTHROPIC_API_KEY="sk-ant-..."
+
+# Newsletter delivery provider
+RESEND_API_KEY="re_xxx"
+NEWSLETTER_FROM_EMAIL="newsletter@yourdomain.com"
+NEWSLETTER_REPLY_TO="hello@yourdomain.com"

--- a/.env.example
+++ b/.env.example
@@ -51,5 +51,6 @@ ANTHROPIC_API_KEY="sk-ant-..."
 
 # Newsletter delivery provider
 RESEND_API_KEY="re_xxx"
+RESEND_WEBHOOK_SECRET="whsec_xxx"
 NEWSLETTER_FROM_EMAIL="newsletter@yourdomain.com"
 NEWSLETTER_REPLY_TO="hello@yourdomain.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
@@ -44,6 +46,18 @@ jobs:
 
       - name: Install dependencies
         run: bun install
+
+      - name: Check schema and migration sync
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+            if [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+              BASE_SHA="$(git rev-list --max-parents=0 HEAD)"
+            fi
+          fi
+          bun run db:check:migrations -- --base="$BASE_SHA" --head="${{ github.sha }}"
 
       - name: Type Check
         run: bun run tsc --noEmit
@@ -67,9 +81,9 @@ jobs:
         run: bunx playwright install-deps
 
       - name: Run Migrations
-        run: bunx drizzle-kit push
+        run: bun run db:migrate:dev
         env:
-          DATABASE_URL: "postgresql://postgres:password@localhost:5432/dcbuilder_dev"
+          DATABASE_URL_DEV: "postgresql://postgres:password@localhost:5432/dcbuilder_dev"
 
       - name: Build
         run: bun run build

--- a/.github/workflows/db-migrate-prod.yml
+++ b/.github/workflows/db-migrate-prod.yml
@@ -1,0 +1,61 @@
+name: Database Migration (Production)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to migrate"
+        required: true
+        default: "master"
+      confirm:
+        description: "Type migrate-prod to confirm"
+        required: true
+
+jobs:
+  migrate-prod:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Validate confirmation input
+        run: |
+          if [ "${{ inputs.confirm }}" != "migrate-prod" ]; then
+            echo "Invalid confirmation. Type 'migrate-prod' to run production migrations."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+
+      - name: Backup production database
+        run: |
+          BACKUP_FILE="prod-pre-migration-$(date -u +%Y%m%dT%H%M%SZ).sql.gz"
+          pg_dump --no-owner --no-acl "$DATABASE_URL_PROD" | gzip > "$BACKUP_FILE"
+          echo "BACKUP_FILE=$BACKUP_FILE" >> "$GITHUB_ENV"
+        env:
+          DATABASE_URL_PROD: ${{ secrets.DATABASE_URL_PROD }}
+
+      - name: Upload backup artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BACKUP_FILE }}
+          path: ${{ env.BACKUP_FILE }}
+          retention-days: 14
+
+      - name: Apply migrations to production
+        run: bun run db:migrate:prod
+        env:
+          DATABASE_URL_PROD: ${{ secrets.DATABASE_URL_PROD }}
+          ALLOW_PROD_MIGRATION: "true"

--- a/.github/workflows/db-migrate-staging.yml
+++ b/.github/workflows/db-migrate-staging.yml
@@ -1,0 +1,27 @@
+name: Database Migration (Staging)
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  migrate-staging:
+    runs-on: ubuntu-latest
+    environment: staging
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Apply migrations to staging
+        run: bun run db:migrate:staging
+        env:
+          DATABASE_URL_STAGING: ${{ secrets.DATABASE_URL_STAGING }}

--- a/.github/workflows/newsletter-issue-create.yml
+++ b/.github/workflows/newsletter-issue-create.yml
@@ -1,0 +1,49 @@
+name: Newsletter Issue Create (Weekly)
+
+on:
+  schedule:
+    # Monday 14:00 UTC
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+
+jobs:
+  create-weekly-newsletter-issue:
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    concurrency:
+      group: newsletter-issue-create
+      cancel-in-progress: false
+
+    steps:
+      - name: Trigger newsletter issue creation cron endpoint
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          CRON_BASE_URL: ${{ secrets.CRON_BASE_URL }}
+        run: |
+          if [ -z "${CRON_SECRET:-}" ]; then
+            echo "Missing required secret: CRON_SECRET"
+            exit 1
+          fi
+
+          BASE_URL="${CRON_BASE_URL:-https://dcbuilder.dev}"
+          ENDPOINT="${BASE_URL%/}/api/cron/newsletter-issue-create"
+          RESPONSE_FILE="$(mktemp)"
+
+          STATUS_CODE="$(curl -sS \
+            -X POST \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            -o "${RESPONSE_FILE}" \
+            -w "%{http_code}" \
+            "${ENDPOINT}")"
+
+          echo "Endpoint: ${ENDPOINT}"
+          echo "Status: ${STATUS_CODE}"
+          cat "${RESPONSE_FILE}"
+
+          if [ "${STATUS_CODE}" -lt 200 ] || [ "${STATUS_CODE}" -ge 300 ]; then
+            echo "Newsletter issue creation failed."
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,179 @@
+# AGENTS.md
+
+This file defines a practical multi-agent setup for `dcbuilder.dev` so concurrent work stays consistent.
+
+## Global Rules
+
+- Use `bun` for JavaScript/TypeScript runtime tasks.
+- Keep changes migration-first for database work (Drizzle schema + SQL migration).
+- Prefer backend source-of-truth over client-only logic for lifecycle/state features.
+- Any agent touching API routes must preserve auth/permission checks.
+
+## Shared Architecture Context
+
+All agents should assume this architecture unless explicitly told otherwise:
+
+- Framework: Next.js App Router (`src/app`)
+- Language/runtime: TypeScript + Bun
+- Data layer: PostgreSQL + Drizzle ORM (`src/db`, `src/db/schema`)
+- API style: route handlers in `src/app/api/**/route.ts`
+- Service layer: `src/services/*` for business logic and external integrations
+- UI:
+  - Public pages in `src/app/*`
+  - Admin pages in `src/app/admin/*`
+  - Shared components in `src/components/*`
+- External systems:
+  - PostHog for analytics (`src/services/posthog.ts`)
+  - Cloudflare R2 for media
+  - Resend (newsletter send provider)
+- Scheduled jobs via authenticated cron endpoints:
+  - `/api/cron/news-freshness`
+  - `/api/cron/newsletter-send`
+  - `/api/cron/job-board-sync`
+
+### Current Feature Boundaries
+
+- News freshness lifecycle:
+  - Backend-controlled `is_fresh` logic with strict 7-day UTC threshold.
+- Newsletter platform:
+  - Double opt-in subscribers, preferences, campaigns, recipients, send events, tokens.
+  - `news` / `jobs` / `candidates` audience segmentation.
+- Job-board automation:
+  - Config-driven ingestion, dedupe, terminated-position detection.
+- Admin dashboard:
+  - CRUD management + analytics-first workflows.
+
+## Agent Roster
+
+Use the smallest set of agents needed for a task. If multiple agents are used, they should share this document as baseline context.
+
+### 1) `architecture-steward`
+- Mission: preserve boundaries, data flow, and consistency across features.
+- Owns: cross-cutting refactors, invariants, integration decisions.
+- Skills:
+  - `vercel-react-best-practices`
+  - `typescript-advanced-types`
+  - `javascript-testing-patterns`
+  - `web-design-guidelines`
+
+### 2) `frontend-product-agent`
+- Mission: public UI/UX implementation for pages/components.
+- Owns: `src/app/*`, `src/components/*` (non-admin focus).
+- Skills:
+  - `frontend-design`
+  - `vercel-react-best-practices`
+  - `web-design-guidelines`
+  - `playwright`
+  - `e2e-testing-patterns`
+
+### 3) `admin-ui-agent`
+- Mission: admin workflows, table UX, editing flows, operational views.
+- Owns: `src/app/admin/*`, `src/components/admin/*`.
+- Skills:
+  - `frontend-design`
+  - `vercel-react-best-practices`
+  - `javascript-testing-patterns`
+  - `web-design-guidelines`
+
+### 4) `api-backend-agent`
+- Mission: route handlers, service orchestration, validation, idempotency.
+- Owns: `src/app/api/**`, `src/services/**`.
+- Skills:
+  - `api-security-best-practices`
+  - `security-review`
+  - `javascript-testing-patterns`
+  - `e2e-testing-patterns`
+
+### 5) `data-migrations-agent`
+- Mission: schema evolution, migrations, data correctness, rollout safety.
+- Owns: `src/db/schema/**`, `drizzle/**`.
+- Skills:
+  - `drizzle-orm`
+  - `drizzle-migrations`
+  - `supabase-postgres-best-practices`
+
+### 6) `newsletter-agent`
+- Mission: subscriber lifecycle, campaign rendering, send pipeline quality.
+- Owns:
+  - `src/services/newsletter.ts`
+  - `src/app/api/v1/newsletter/**`
+  - newsletter admin tooling.
+- Skills:
+  - `api-security-best-practices`
+  - `security-review`
+  - `javascript-testing-patterns`
+  - `linear`
+
+### 7) `news-lifecycle-agent`
+- Mission: freshness lifecycle, news aggregation quality, deterministic behavior.
+- Owns:
+  - `src/services/news-freshness.ts`
+  - `src/lib/news.ts`
+  - `/api/cron/news-freshness`.
+- Skills:
+  - `drizzle-orm`
+  - `drizzle-migrations`
+  - `javascript-testing-patterns`
+
+### 8) `job-automation-agent`
+- Mission: job-board ingestion, dedupe, termination detection.
+- Owns:
+  - `src/services/job-board-sync.ts`
+  - `src/lib/job-board-sync.ts`
+  - `/api/cron/job-board-sync`.
+- Skills:
+  - `api-security-best-practices`
+  - `javascript-testing-patterns`
+  - `supabase-postgres-best-practices`
+
+### 9) `qa-agent`
+- Mission: regression prevention, flaky test stabilization, CI confidence.
+- Owns: `tests/**`, Playwright config, test data seeding.
+- Skills:
+  - `e2e-testing-patterns`
+  - `javascript-testing-patterns`
+  - `playwright`
+  - `gh-fix-ci`
+
+### 10) `security-agent`
+- Mission: auth, secrets, abuse prevention, safe defaults.
+- Owns: security reviews of API/features before merge.
+- Skills:
+  - `security-review`
+  - `security-best-practices`
+  - `api-security-best-practices`
+  - `security-threat-model`
+
+### 11) `release-agent`
+- Mission: deployment, previews, runtime config, production checks.
+- Owns: deploy automation and environment verification.
+- Skills:
+  - `vercel-deploy`
+  - `cloudflare-deploy`
+  - `wrangler`
+  - `gh-address-comments`
+
+### 12) `project-ops-agent`
+- Mission: issue/PR hygiene, execution tracking, rollout communication.
+- Owns: Linear/GitHub coordination and status updates.
+- Skills:
+  - `linear`
+  - `gh-address-comments`
+  - `gh-fix-ci`
+
+## Collaboration Pattern (Recommended)
+
+1. `architecture-steward` defines scope and invariants.
+2. Domain agent implements (`frontend-product-agent`, `api-backend-agent`, `data-migrations-agent`, etc.).
+3. `qa-agent` verifies test and UX regressions.
+4. `security-agent` performs final security pass.
+5. `release-agent` handles deployment + environment checks.
+6. `project-ops-agent` updates Linear/PR status.
+
+## Done Criteria For Any Agent
+
+- Code compiles (`bunx tsc --noEmit`).
+- Lint passes (`bun run lint`).
+- Relevant tests pass (`bun run test:unit` and targeted e2e where needed).
+- Schema changes include migration files.
+- API behavior is documented or discoverable from code patterns.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,10 @@ Never use npm, npx, yarn, or pnpm.
 - `src/components/ui/` - Reusable UI primitives (Badge, Icons, SocialLinks)
 - `src/db/` - Database schema and client (Drizzle)
 - `src/hooks/` - Custom React hooks (useHotCandidates, etc.)
-- `src/lib/` - Utilities (utils, skill-colors, source-colors, r2, posthog-api)
+- `src/lib/` - Utilities (utils, skill-colors, source-colors, r2, posthog-api, recommendations, news-tools)
 - `content/blog/` - MDX blog posts
 - `scripts/` - Utility scripts for data management
-- `tests/` - E2E tests (Playwright)
+- `tests/` - Bun unit tests and Playwright end-to-end coverage
 
 ## Code Style
 

--- a/CLONE.md
+++ b/CLONE.md
@@ -26,8 +26,8 @@ bun install
 cp .env.example .env.local
 # Edit .env.local with your values
 
-# 4. Push database schema
-bunx drizzle-kit push
+# 4. Apply committed migrations to your dev database
+bun run db:migrate:dev
 
 # 5. Start development server
 bun dev
@@ -66,11 +66,11 @@ Get your connection string from your provider's dashboard.
 #### Initialize Schema
 
 ```bash
-# Push schema to database
-bunx drizzle-kit push
+# Apply committed migration files to your dev database
+bun run db:migrate:dev
 
 # (Optional) Open Drizzle Studio to view/edit data
-bunx drizzle-kit studio
+bun run db:studio
 ```
 
 ### 2. Cloudflare R2 Setup (Image Storage)
@@ -124,8 +124,13 @@ Create `.env.local` with all required variables:
 # REQUIRED
 # ===================
 
-# Database - PostgreSQL connection string
-DATABASE_URL="postgresql://user:password@host:5432/database"
+# Runtime database URL used by the local app.
+# If you use Supabase, prefer the transaction pooler / IPv4-safe URL here.
+DATABASE_URL="postgresql://user:password@host:6543/database?pgbouncer=true"
+
+# Explicit migration target for your development database.
+# If you use Supabase, keep this as the direct connection string.
+DATABASE_URL_DEV="postgresql://user:password@host:5432/database"
 
 # ===================
 # OPTIONAL (but recommended)
@@ -158,7 +163,7 @@ The admin dashboard uses API key authentication stored in the database.
 
 ```bash
 # Open Drizzle Studio
-bunx drizzle-kit studio
+bun run db:studio
 ```
 
 In Drizzle Studio:
@@ -195,7 +200,8 @@ The database schema supports:
 
 To add/modify fields, edit `src/db/schema/*.ts` and run:
 ```bash
-bunx drizzle-kit push
+bun run db:generate
+bun run db:migrate:dev
 ```
 
 ### Features to Enable/Disable
@@ -255,6 +261,7 @@ Works with any platform supporting Next.js:
 │   └── lib/                   # Utilities
 │       ├── r2.ts              # Cloudflare R2 helpers
 │       ├── posthog-api.ts     # PostHog server API
+│       ├── recommendations.ts # Shared recommendation data for /news + newsletters
 │       └── ...                # Other utilities
 ├── content/
 │   └── blog/                  # MDX blog posts
@@ -268,6 +275,7 @@ Works with any platform supporting Next.js:
 - Verify `DATABASE_URL` format: `postgresql://user:pass@host:port/dbname`
 - Check if database is accessible from your network
 - For SSL: append `?sslmode=require` to connection string
+- For Supabase local runtime, use the transaction pooler URL for `DATABASE_URL`; keep direct URLs for `DATABASE_URL_DEV` migrations
 
 ### R2 Upload Failures
 - Verify bucket exists and is public
@@ -282,6 +290,7 @@ Works with any platform supporting Next.js:
 ### Admin Login Issues
 - Verify API key exists in `api_keys` table
 - Check key has `admin:read` permission
+- Ensure the database behind `DATABASE_URL` is reachable; admin auth reads keys from the database, not from an env fallback
 - Clear browser localStorage and try again
 
 ## Commands Reference
@@ -293,12 +302,14 @@ bun run build               # Production build
 bun run start               # Start production server
 
 # Database
-bunx drizzle-kit push       # Push schema changes
-bunx drizzle-kit studio     # Open database GUI
-bunx drizzle-kit generate   # Generate migration files
+bun run db:generate         # Generate migration files
+bun run db:migrate:dev      # Apply migrations to dev database
+bun run db:studio           # Open database GUI
 
 # Testing
+bun run test:unit           # Run Bun unit tests
 bun run test                # Run Playwright tests
+bun run test:all            # Run unit + e2e coverage
 bunx playwright install     # Install browser binaries
 
 # Utilities

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Personal site built with Next.js (App Router) for dcbuilder.eth. Features a home
 - **Jobs**: Filterable job board with HOT/TOP/NEW badges, modal details, and shareable URLs
 - **Candidates**: Candidate directory with modal profiles, skill tags, and availability status
 - **News**: Curated links and portfolio announcements
+- **Newsletter**: Double opt-in subscriptions, segmented campaigns (`news`/`jobs`/`candidates`), and scheduled sends
 
 ### OpenGraph & Social Sharing
 
@@ -181,6 +182,14 @@ R2_PUBLIC_URL="https://pub-xxx.r2.dev"
 NEXT_PUBLIC_POSTHOG_KEY="phc_..."
 POSTHOG_PERSONAL_API_KEY="phx_..."
 POSTHOG_PROJECT_ID="..."
+
+# Newsletter delivery (Resend)
+RESEND_API_KEY="re_..."
+NEWSLETTER_FROM_EMAIL="newsletter@yourdomain.com"
+NEWSLETTER_REPLY_TO="hello@yourdomain.com"
+
+# Cron auth for /api/cron/* endpoints
+CRON_SECRET="..."
 ```
 
 ## Content Management

--- a/README.md
+++ b/README.md
@@ -152,11 +152,16 @@ bun run start
 # Lint
 bun run lint
 
-# Run database migrations
-bunx drizzle-kit push
+# Generate SQL migrations from schema changes
+bun run db:generate
+
+# Apply migration files (explicit target required)
+bun run db:migrate:dev
+bun run db:migrate:staging
+ALLOW_PROD_MIGRATION=true bun run db:migrate:prod
 
 # Open Drizzle Studio (DB GUI)
-bunx drizzle-kit studio
+bun run db:studio
 
 # Run Playwright tests
 bunx playwright install  # first time only
@@ -168,8 +173,13 @@ bun run test
 See [.env.example](./.env.example) for all configuration options.
 
 ```bash
-# Required
+# Runtime database URL (set per environment in your hosting platform)
 DATABASE_URL="postgresql://..."
+
+# Explicit migration targets (local + CI)
+DATABASE_URL_DEV="postgresql://..."
+DATABASE_URL_STAGING="postgresql://..."
+DATABASE_URL_PROD="postgresql://..."
 
 # Cloudflare R2 (image storage)
 R2_ENDPOINT="https://ACCOUNT_ID.r2.cloudflarestorage.com"
@@ -191,6 +201,34 @@ NEWSLETTER_REPLY_TO="hello@yourdomain.com"
 # Cron auth for /api/cron/* endpoints
 CRON_SECRET="..."
 ```
+
+### Weekly Newsletter Issue Automation
+
+The workflow `.github/workflows/newsletter-issue-create.yml` runs every Monday at `14:00 UTC` and calls:
+
+- `POST /api/cron/newsletter-issue-create`
+
+Required GitHub environment secrets (recommended in `production` environment):
+
+- `CRON_SECRET` (required)
+- `CRON_BASE_URL` (optional, defaults to `https://dcbuilder.dev`)
+
+## Database Environments (Supabase + Drizzle)
+
+This repo now uses explicit environment targets for migrations:
+
+1. `dev` (local development Supabase project)
+2. `staging` (staging Supabase project)
+3. `prod` (production Supabase project)
+
+Promotion flow:
+
+1. Generate and commit migration files in PRs (`bun run db:generate`)
+2. Merge to `master` and run staging migration workflow
+3. Verify staging
+4. Run production migration workflow (manual + backup artifact + explicit confirmation)
+
+Setup details are in `docs/database-environments.md`.
 
 ## Content Management
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ bun run start
 
 # Lint
 bun run lint
+# Note: Next.js v16 no longer ships a `next lint` command; use ESLint directly.
 
 # Generate SQL migrations from schema changes
 bun run db:generate

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Personal site built with Next.js (App Router) for dcbuilder.eth. Features a home
 - **Portfolio**: Investment cards with tiers, status, and category filtering
 - **Jobs**: Filterable job board with HOT/TOP/NEW badges, modal details, and shareable URLs
 - **Candidates**: Candidate directory with modal profiles, skill tags, and availability status
-- **News**: Curated links and portfolio announcements
+- **News**: Curated links, portfolio announcements, and a compact tools deck for the latest issue, subscriptions, and recommendations
 - **Newsletter**: Double opt-in subscriptions, segmented campaigns (`news`/`jobs`/`candidates`), and scheduled sends
 
 ### OpenGraph & Social Sharing
@@ -53,6 +53,7 @@ Personal site built with Next.js (App Router) for dcbuilder.eth. Features a home
 - **Candidates Management**: Profile editor with skills
 - **Investments Management**: Tier and status tracking
 - **News Management**: Curated links and announcements
+- **Newsletter Studio**: Compose, queue, and templates workflow with template, markdown, and manual content modes
 - **Affiliations Management**: About page affiliations
 
 #### Admin Features
@@ -68,6 +69,7 @@ Personal site built with Next.js (App Router) for dcbuilder.eth. Features a home
 - **Analytics**: Real-time PostHog data with skeleton loading
 - **Pulsing Tags**: Animated HOT/TOP badges for featured items
 - **Batch Operations**: Multi-select for bulk updates
+- **Template-Parity Preview**: Markdown newsletter previews render through the same shell and recommendation blocks as template mode
 
 ## Architecture
 
@@ -106,14 +108,17 @@ src/
 ├── services/            # Business logic & External clients (R2, PostHog, Auth)
 └── lib/                 # Shared utilities and helpers
     ├── data.ts          # Shared data fetching (getJobById, getCandidateById, getBaseUrl)
+    ├── recommendations.ts # Shared recommendation data for /news and newsletter content
     ├── shuffle.ts       # Deterministic shuffling and date utilities (isNew, isWithinDays)
     ├── utils.ts         # General utilities (cn for classnames)
     └── *-colors.ts      # Color mappings for skills, sources, tiers
 
-tests/                   # E2E tests (Playwright)
+tests/                   # Bun unit tests and Playwright end-to-end coverage
 
 docs/
 ├── API.md               # API documentation
+├── database-environments.md # Runtime vs migration DB environment guidance
+├── newsletter-studio-ui.md  # Newsletter Studio UX/spec notes
 └── openapi.yaml         # OpenAPI specification
 ```
 
@@ -164,9 +169,15 @@ ALLOW_PROD_MIGRATION=true bun run db:migrate:prod
 # Open Drizzle Studio (DB GUI)
 bun run db:studio
 
+# Run unit tests
+bun run test:unit
+
 # Run Playwright tests
 bunx playwright install  # first time only
 bun run test
+
+# Run all tests
+bun run test:all
 ```
 
 ## Environment Variables
@@ -175,9 +186,11 @@ See [.env.example](./.env.example) for all configuration options.
 
 ```bash
 # Runtime database URL (set per environment in your hosting platform)
+# For Supabase app runtime, prefer the transaction pooler / IPv4-safe URL.
 DATABASE_URL="postgresql://..."
 
 # Explicit migration targets (local + CI)
+# For Supabase migrations, use direct connection strings.
 DATABASE_URL_DEV="postgresql://..."
 DATABASE_URL_STAGING="postgresql://..."
 DATABASE_URL_PROD="postgresql://..."

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ POSTHOG_PROJECT_ID="..."
 
 # Newsletter delivery (Resend)
 RESEND_API_KEY="re_..."
+RESEND_WEBHOOK_SECRET="whsec_..."
 NEWSLETTER_FROM_EMAIL="newsletter@yourdomain.com"
 NEWSLETTER_REPLY_TO="hello@yourdomain.com"
 
@@ -226,6 +227,7 @@ Required GitHub environment secrets (recommended in `production` environment):
 
 - `CRON_SECRET` (required)
 - `CRON_BASE_URL` (optional, defaults to `https://dcbuilder.dev`)
+- `RESEND_WEBHOOK_SECRET` (required for `POST /api/v1/webhooks/resend`)
 
 ## Database Environments (Supabase + Drizzle)
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "drizzle-orm": "^0.45.1",
         "gray-matter": "^4.0.3",
         "next": "^16.1.6",
-        "next-mdx-remote": "^5.0.0",
+        "next-mdx-remote": "^6.0.0",
         "next-themes": "^0.4.6",
         "postgres": "^3.4.8",
         "posthog-js": "^1.336.1",
@@ -565,7 +565,7 @@
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
-    "@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.53.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.53.1", "@typescript-eslint/type-utils": "8.53.1", "@typescript-eslint/utils": "8.53.1", "@typescript-eslint/visitor-keys": "8.53.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.53.1", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-cFYYFZ+oQFi6hUnBTbLRXfTJiaQtYE3t4O692agbBl+2Zy+eqSKWtPjhPXJu1G7j4RLjKgeJPDdq3EqOwmX5Ag=="],
 
@@ -1219,7 +1219,7 @@
 
     "next": ["next@16.1.6", "", { "dependencies": { "@next/env": "16.1.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.6", "@next/swc-darwin-x64": "16.1.6", "@next/swc-linux-arm64-gnu": "16.1.6", "@next/swc-linux-arm64-musl": "16.1.6", "@next/swc-linux-x64-gnu": "16.1.6", "@next/swc-linux-x64-musl": "16.1.6", "@next/swc-win32-arm64-msvc": "16.1.6", "@next/swc-win32-x64-msvc": "16.1.6", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw=="],
 
-    "next-mdx-remote": ["next-mdx-remote@5.0.0", "", { "dependencies": { "@babel/code-frame": "^7.23.5", "@mdx-js/mdx": "^3.0.1", "@mdx-js/react": "^3.0.1", "unist-util-remove": "^3.1.0", "vfile": "^6.0.1", "vfile-matter": "^5.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-RNNbqRpK9/dcIFZs/esQhuLA8jANqlH694yqoDBK8hkVdJUndzzGmnPHa2nyi90N4Z9VmzuSWNRpr5ItT3M7xQ=="],
+    "next-mdx-remote": ["next-mdx-remote@6.0.0", "", { "dependencies": { "@babel/code-frame": "^7.23.5", "@mdx-js/mdx": "^3.0.1", "@mdx-js/react": "^3.0.1", "unist-util-remove": "^4.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.1", "vfile-matter": "^5.0.0" }, "peerDependencies": { "react": ">=16" } }, "sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
@@ -1463,19 +1463,19 @@
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
-    "unist-util-is": ["unist-util-is@5.2.1", "", { "dependencies": { "@types/unist": "^2.0.0" } }, "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw=="],
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 
     "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
 
     "unist-util-position-from-estree": ["unist-util-position-from-estree@2.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ=="],
 
-    "unist-util-remove": ["unist-util-remove@3.1.1", "", { "dependencies": { "@types/unist": "^2.0.0", "unist-util-is": "^5.0.0", "unist-util-visit-parents": "^5.0.0" } }, "sha512-kfCqZK5YVY5yEa89tvpl7KnBBHu2c6CzMkqHUrlOqaRgGOMp0sMvwWOVrbAtj03KhovQB7i96Gda72v/EFE0vw=="],
+    "unist-util-remove": ["unist-util-remove@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg=="],
 
     "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
 
     "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
 
-    "unist-util-visit-parents": ["unist-util-visit-parents@5.1.3", "", { "dependencies": { "@types/unist": "^2.0.0", "unist-util-is": "^5.0.0" } }, "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg=="],
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
@@ -1573,10 +1573,6 @@
 
     "@tybys/wasm-util/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@types/hast/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "@types/mdast/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
@@ -1593,53 +1589,23 @@
 
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
-    "estree-util-visit/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "hast-util-to-jsx-runtime/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "is-bun-module/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
-    "mdast-util-from-markdown/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "mdast-util-mdx-jsx/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "mdast-util-phrasing/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
-
-    "mdast-util-to-markdown/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "micromark-util-events-to-acorn/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
-    "unified/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "unist-util-position/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "unist-util-position-from-estree/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "unist-util-stringify-position/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "unist-util-visit/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "unist-util-visit/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
-
-    "unist-util-visit/unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
-
-    "vfile/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "vfile-message/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
@@ -1716,8 +1682,6 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "mdast-util-phrasing/unist-util-is/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 

--- a/docs/database-environments.md
+++ b/docs/database-environments.md
@@ -1,0 +1,96 @@
+# Database Environments: Supabase + Drizzle
+
+This project uses three separate Supabase Postgres databases:
+
+- `dev`: day-to-day local development
+- `staging`: pre-production validation
+- `prod`: production
+
+## 1. Supabase Projects
+
+Create three Supabase projects and copy each connection string:
+
+- `DATABASE_URL_DEV`
+- `DATABASE_URL_STAGING`
+- `DATABASE_URL_PROD`
+
+Use direct Postgres URLs for migrations. Keep these values private.
+
+## 2. Local Environment Variables
+
+Set these in your local `.env.local` (or shell):
+
+```bash
+DATABASE_URL=postgresql://...          # runtime URL for local app
+DATABASE_URL_DEV=postgresql://...      # drizzle migrations target for dev
+DATABASE_URL_STAGING=postgresql://...  # optional locally
+DATABASE_URL_PROD=postgresql://...     # optional locally
+```
+
+Notes:
+
+- `DATABASE_URL` is used by app runtime (`src/db/index.ts`).
+- Migration scripts require explicit target (`--env=dev|staging|prod`).
+
+## 3. Migration Workflow (Developer)
+
+When schema changes:
+
+1. Update Drizzle schema files under `src/db/schema/**`.
+2. Generate migration files:
+
+```bash
+bun run db:generate
+```
+
+3. Apply locally:
+
+```bash
+bun run db:migrate:dev
+```
+
+4. Commit all migration artifacts (`drizzle/*.sql`, `drizzle/meta/*`).
+
+## 4. GitHub Environments and Secrets
+
+Create GitHub environments:
+
+- `staging`
+- `production`
+
+Add secrets:
+
+- In `staging` environment: `DATABASE_URL_STAGING`
+- In `production` environment: `DATABASE_URL_PROD`
+
+Recommended:
+
+- Require reviewers for the `production` environment.
+- Restrict who can trigger production workflow runs.
+
+## 5. CI/CD Promotion
+
+### CI (`.github/workflows/ci.yml`)
+
+- Validates schema/migration sync (`db:check:migrations`).
+- Applies migration files to CI database with `db:migrate:dev`.
+- Runs typecheck, lint, unit tests, and e2e tests.
+
+### Staging migration (`.github/workflows/db-migrate-staging.yml`)
+
+- Runs on pushes to `master`.
+- Applies migration files to staging database.
+
+### Production migration (`.github/workflows/db-migrate-prod.yml`)
+
+- Manual trigger only.
+- Requires explicit confirmation string.
+- Generates pre-migration `pg_dump` backup and uploads it as workflow artifact.
+- Applies migration files to production database with `ALLOW_PROD_MIGRATION=true`.
+
+## 6. Operational Rules
+
+- Never use `drizzle-kit push` against shared/staging/prod databases.
+- Use migration files as the source of truth.
+- Always run staging migration before production migration.
+- Treat production migration as a controlled release step.

--- a/docs/database-environments.md
+++ b/docs/database-environments.md
@@ -15,21 +15,23 @@ Create three Supabase projects and copy each connection string:
 - `DATABASE_URL_PROD`
 
 Use direct Postgres URLs for migrations. Keep these values private.
+For local app runtime against Supabase, use a reachable transaction pooler / IPv4-safe URL for `DATABASE_URL`.
 
 ## 2. Local Environment Variables
 
 Set these in your local `.env.local` (or shell):
 
 ```bash
-DATABASE_URL=postgresql://...          # runtime URL for local app
-DATABASE_URL_DEV=postgresql://...      # drizzle migrations target for dev
-DATABASE_URL_STAGING=postgresql://...  # optional locally
-DATABASE_URL_PROD=postgresql://...     # optional locally
+DATABASE_URL=postgresql://...          # runtime URL for local app (Supabase: prefer pooler/pgbouncer URL)
+DATABASE_URL_DEV=postgresql://...      # drizzle migrations target for dev (Supabase: direct connection)
+DATABASE_URL_STAGING=postgresql://...  # optional locally (direct connection for migrations)
+DATABASE_URL_PROD=postgresql://...     # optional locally (direct connection for migrations)
 ```
 
 Notes:
 
 - `DATABASE_URL` is used by app runtime (`src/db/index.ts`).
+- The admin dashboard authenticates against the `api_keys` table, so local admin login depends on the runtime database being reachable.
 - Migration scripts require explicit target (`--env=dev|staging|prod`).
 
 ## 3. Migration Workflow (Developer)

--- a/docs/newsletter-studio-ui.md
+++ b/docs/newsletter-studio-ui.md
@@ -1,0 +1,76 @@
+# Newsletter Studio UI Redesign Spec
+
+## Goals
+- Make the Newsletter Studio feel like a purpose-built "editor" instead of a stack of forms.
+- Reduce cognitive load by splitting the UI into three clear modes: Compose, Queue, Templates.
+- Provide a live preview that reflects the selected type, period, and subject.
+- Keep all lifecycle logic server-driven (campaign creation, scheduling, template rendering).
+
+## Non-Goals
+- Building a full WYSIWYG email builder.
+- Adding new newsletter provider integrations (Resend remains the send provider).
+
+## Information Architecture
+- **Compose**
+  - Create campaign drafts (and optional schedule at creation).
+  - Live preview rendered from the saved template for the selected type.
+  - Quick action: auto-create weekly "news" draft (deduped server-side).
+- **Queue**
+  - Operational view of existing campaigns.
+  - Filter/search + quick schedule/send actions.
+  - Clear status visibility and failure surfacing.
+- **Templates**
+  - Edit stored templates per newsletter type.
+  - Placeholder insertion helper.
+  - Preview rendering with a configurable campaign subject + period.
+
+## Core Interactions
+### Compose
+- Inputs
+  - Newsletter type
+  - Period (days)
+  - Subject
+  - Preview text (optional)
+  - Schedule (optional)
+- Actions
+  - Create draft (POST campaign)
+  - Generate weekly draft (POST auto-create weekly; only valid for `news`)
+  - Refresh preview (POST template preview)
+- Preview
+  - Tabs: HTML, Text, Subject
+  - Uses server rendering, not client interpolation.
+  - Displays digest context (heading/summary) to explain why output changed.
+
+### Queue
+- Filters
+  - Status segmented control (all/draft/scheduled/sending/sent/failed)
+  - Search by subject/type
+- Row actions
+  - Schedule: datetime-local input + Set button (server stores UTC)
+  - Send now: triggers send endpoint (disabled for sent/sending)
+- Empty state
+  - Clear CTA back to Compose.
+
+### Templates
+- Inputs
+  - Template type selector
+  - Subject template / HTML template / Text template
+  - Preview subject + period (preview context)
+- Placeholders
+  - Clickable tokens inserted at cursor into the focused field.
+- Preview
+  - Tabs: HTML, Text, Subject
+  - Rendered via server preview endpoint using the current draft template content.
+
+## Backend Requirements
+- Template preview endpoint must accept an optional `campaignSubject` override to ensure live previews reflect the subject admins type in Compose/Preview.
+- Auth/permissions remain enforced via `requireAuth(request, "admin:read")`.
+
+## Rendering Safety
+- HTML preview should be shown in an `iframe` with `sandbox` enabled.
+- Preview links should open in a new tab (via `<base target="_blank">` in the iframe doc).
+
+## Copy/UX Notes
+- Primary CTAs use clear verbs: "Create draft", "Generate weekly draft", "Save", "Preview".
+- Templates show an "Unsaved" indicator when draft differs from persisted data.
+

--- a/docs/newsletter-studio-ui.md
+++ b/docs/newsletter-studio-ui.md
@@ -13,7 +13,8 @@
 ## Information Architecture
 - **Compose**
   - Create campaign drafts (and optional schedule at creation).
-  - Live preview rendered from the saved template for the selected type.
+  - Content modes: Template, Markdown, Manual.
+  - Live preview rendered server-side for the selected type and current content mode.
   - Quick action: auto-create weekly "news" draft (deduped server-side).
 - **Queue**
   - Operational view of existing campaigns.
@@ -32,14 +33,18 @@
   - Subject
   - Preview text (optional)
   - Schedule (optional)
+  - Content mode selector (Template / Markdown / Manual)
 - Actions
   - Create draft (POST campaign)
   - Generate weekly draft (POST auto-create weekly; only valid for `news`)
   - Refresh preview (POST template preview)
+  - Autofill Markdown starter from the current template
 - Preview
-  - Tabs: HTML, Text, Subject
+  - Tabs: HTML, Text, Subject, Starter
   - Uses server rendering, not client interpolation.
   - Displays digest context (heading/summary) to explain why output changed.
+  - Markdown preview should render through the same newsletter shell as Template mode, including avatar/header, digest cards, recommendation block, and footer links.
+  - Auto-preview should only fire when the current mode has enough content to render valid output.
 
 ### Queue
 - Filters
@@ -70,7 +75,11 @@
 - HTML preview should be shown in an `iframe` with `sandbox` enabled.
 - Preview links should open in a new tab (via `<base target="_blank">` in the iframe doc).
 
+## News Page Notes
+- The public `/news` page now uses a compact "News Tools" deck instead of three stacked cards.
+- Desktop keeps archive, subscribe, and recommendations inside a tabbed panel.
+- Mobile keeps the tools collapsed behind a toggle so the news list stays visible higher on the page.
+
 ## Copy/UX Notes
 - Primary CTAs use clear verbs: "Create draft", "Generate weekly draft", "Save", "Preview".
 - Templates show an "Unsaved" indicator when draft differs from persisted data.
-

--- a/docs/plans/2026-03-09-newsletter-preferences-and-delivery-design.md
+++ b/docs/plans/2026-03-09-newsletter-preferences-and-delivery-design.md
@@ -1,0 +1,64 @@
+# Newsletter Preferences And Delivery Design
+
+## Goal
+
+Fix three newsletter regressions on `con-14-newsletter-system` without changing the public token model:
+
+1. `Manage preferences` links in emails must open a usable subscriber page.
+2. Markdown-mode campaigns must preserve unsubscribe/preferences URLs in the plain-text body.
+3. Scheduled campaigns with zero eligible recipients must stop retrying forever.
+
+## Approved Direction
+
+Keep the existing `/api/v1/newsletter/preferences?token=...` URL stable and make its `GET` request render a real HTML preferences page. Keep `PUT` on the same route for updates so already-sent emails continue to work.
+
+## Architecture
+
+### Preferences Flow
+
+The current token validation and preference update logic in `src/services/newsletter.ts` remains the source of truth. The route at `src/app/api/v1/newsletter/preferences/route.ts` changes from JSON-only on `GET` to HTML on `GET`, while `PUT` stays JSON for programmatic updates from the page.
+
+The rendered page should:
+
+- validate the token through `getPreferenceContext`
+- display the subscriber email and current enabled newsletter types
+- submit updates back to the same route with the existing token
+- show a useful success/error state inline
+
+This keeps old links valid and avoids introducing a second public route just to wrap the same token workflow.
+
+### Markdown Text Rendering
+
+The markdown send path currently generates text by stripping links out of rendered HTML. Instead of trying to reconstruct URLs after HTML parsing, the plain-text output should be derived directly from the rendered markdown string so link targets survive in text-only email clients.
+
+The implementation should preserve:
+
+- inline markdown links as `label (url)` or equivalent
+- footer preference and unsubscribe URLs
+- recommended-link URLs
+
+HTML generation remains unchanged.
+
+### Zero-Recipient Campaign Handling
+
+When a due scheduled campaign has no active recipients, the send flow should move it into a terminal failed state with an explicit `failureReason`. That prevents cron from re-selecting and retrying the same campaign on every run.
+
+Manual/admin sends should surface the same failure result, but the stored campaign state should still be terminal and inspectable from the admin UI.
+
+## Error Handling
+
+- Invalid or expired preference tokens continue to return an error response.
+- Preference page submission errors should render a visible message without invalidating the token automatically.
+- Zero-recipient failures should set `status = "failed"` and a human-readable `failureReason`.
+
+## Testing Strategy
+
+- Route test proving the preference `GET` returns HTML instead of JSON.
+- Unit test proving markdown text output retains preference/unsubscribe URLs.
+- Service test proving zero-recipient scheduled campaigns transition to `failed` and stop looking schedulable.
+
+## Non-Goals
+
+- No redesign of the broader newsletter data model.
+- No separate public preferences page URL.
+- No change to the token schema or email provider integration beyond these bugfixes.

--- a/docs/plans/2026-03-09-newsletter-preferences-and-delivery.md
+++ b/docs/plans/2026-03-09-newsletter-preferences-and-delivery.md
@@ -1,0 +1,182 @@
+# Newsletter Preferences And Delivery Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix newsletter preference links, preserve plain-text URLs for markdown campaigns, and stop zero-recipient scheduled campaigns from retrying forever.
+
+**Architecture:** Keep the existing tokenized preferences URL and make `GET /api/v1/newsletter/preferences` render HTML, while `PUT` remains the update API. Move markdown plain-text generation to markdown-aware text rendering and mark zero-recipient scheduled campaigns as terminal failures.
+
+**Tech Stack:** Next.js App Router route handlers, Bun tests, Drizzle ORM, TypeScript
+
+---
+
+### Task 1: Render A Subscriber Preferences Page On The Existing URL
+
+**Files:**
+- Modify: `src/app/api/v1/newsletter/preferences/route.ts`
+- Test: `tests/newsletter-preferences-route.test.ts`
+
+**Step 1: Write the failing test**
+
+Add a route test that mocks `getPreferenceContext`, calls `GET /api/v1/newsletter/preferences?token=test-token`, and expects:
+
+- `content-type` includes `text/html`
+- response body includes the subscriber email
+- response body includes newsletter type labels and checked state markers
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test tests/newsletter-preferences-route.test.ts`
+Expected: FAIL because the route currently returns JSON.
+
+**Step 3: Write minimal implementation**
+
+Update the `GET` handler in `src/app/api/v1/newsletter/preferences/route.ts` to render an HTML page that:
+
+- reads the token from the query string
+- loads the context with `getPreferenceContext`
+- includes a form with current preferences
+- submits updates back to the same route with `fetch(..., { method: "PUT" })`
+- renders success/error copy inline
+
+Keep `PUT` JSON-based.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test tests/newsletter-preferences-route.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/newsletter-preferences-route.test.ts src/app/api/v1/newsletter/preferences/route.ts
+git commit -m "fix: render newsletter preferences page"
+```
+
+### Task 2: Preserve URLs In Markdown-Mode Plain Text Emails
+
+**Files:**
+- Modify: `src/services/newsletter.ts`
+- Test: `tests/newsletter-markdown-text.test.ts`
+
+**Step 1: Write the failing test**
+
+Add a test that exercises the markdown campaign rendering path and expects the plain-text output to include:
+
+- the preference URL
+- the unsubscribe URL
+- at least one rendered markdown link target
+
+Use public service helpers where possible; otherwise add a small exported helper only if needed for testability.
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test tests/newsletter-markdown-text.test.ts`
+Expected: FAIL because the current implementation strips links when converting HTML to text.
+
+**Step 3: Write minimal implementation**
+
+In `src/services/newsletter.ts`, derive markdown-mode text from the rendered markdown content rather than from stripped HTML. Preserve link targets in a plain-text-friendly format such as `label (url)`.
+
+Limit the change to the markdown-mode branch; do not rework template/manual behavior unless required by the test.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test tests/newsletter-markdown-text.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/newsletter-markdown-text.test.ts src/services/newsletter.ts
+git commit -m "fix: preserve markdown newsletter links in text output"
+```
+
+### Task 3: Mark Zero-Recipient Scheduled Campaigns As Terminal Failures
+
+**Files:**
+- Modify: `src/services/newsletter.ts`
+- Test: `tests/newsletter-send.test.ts`
+
+**Step 1: Write the failing test**
+
+Add a service test covering a due scheduled campaign with zero eligible recipients. Expect:
+
+- send result returns a conflict/error
+- campaign status is updated to `failed`
+- `failureReason` is set to a readable zero-recipient message
+
+Mock DB queries narrowly around the public `sendDueNewsletterCampaigns()` or `sendNewsletterCampaignNow()` entry point.
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test tests/newsletter-send.test.ts`
+Expected: FAIL because the current code restores the previous status and leaves the campaign schedulable.
+
+**Step 3: Write minimal implementation**
+
+In `src/services/newsletter.ts`, change the zero-recipient branch so it writes a terminal failure state instead of restoring the previous status. Keep the returned error intact for the caller.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test tests/newsletter-send.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/newsletter-send.test.ts src/services/newsletter.ts
+git commit -m "fix: fail empty newsletter campaigns once"
+```
+
+### Task 4: Verify The Full Fix Set
+
+**Files:**
+- Verify only
+
+**Step 1: Run targeted tests**
+
+Run:
+
+```bash
+bun test tests/newsletter-preferences-route.test.ts tests/newsletter-markdown-text.test.ts tests/newsletter-send.test.ts
+```
+
+Expected: PASS
+
+**Step 2: Run full unit suite**
+
+Run:
+
+```bash
+bun run test:unit
+```
+
+Expected: PASS
+
+**Step 3: Run typecheck**
+
+Run:
+
+```bash
+bunx tsc --noEmit
+```
+
+Expected: PASS
+
+**Step 4: Run production build**
+
+Run:
+
+```bash
+bun run build
+```
+
+Expected: PASS
+
+**Step 5: Commit final verification-backed changes**
+
+```bash
+git add src/app/api/v1/newsletter/preferences/route.ts src/services/newsletter.ts tests/newsletter-preferences-route.test.ts tests/newsletter-markdown-text.test.ts tests/newsletter-send.test.ts docs/plans/2026-03-09-newsletter-preferences-and-delivery-design.md docs/plans/2026-03-09-newsletter-preferences-and-delivery.md
+git commit -m "fix: harden newsletter preferences and delivery flows"
+```

--- a/docs/plans/2026-03-09-newsletter-subscribers-tab-design.md
+++ b/docs/plans/2026-03-09-newsletter-subscribers-tab-design.md
@@ -1,0 +1,210 @@
+# Newsletter Subscribers Tab Design
+
+## Goal
+
+Add a Subscribers view to Newsletter Studio so admin users can see every subscriber in one combined table and manage the three newsletter subscriptions (`news`, `jobs`, `candidates`) with toggles.
+
+## Scope
+
+This work adds:
+
+- a new `Subscribers` mode in Newsletter Studio
+- one combined table with one row per subscriber email
+- three toggle columns for `News`, `Jobs`, and `Candidates`
+- per-row `Save` and `Reset` actions
+- one admin write endpoint for updating a subscriber's enabled newsletter types
+
+This work does not add:
+
+- bulk editing
+- CSV export
+- advanced analytics drilldowns
+- a separate standalone admin page
+
+## Current State
+
+The branch already has:
+
+- `GET /api/v1/newsletter/subscribers` in `src/app/api/v1/newsletter/subscribers/route.ts`
+- subscriber records in `newsletter_subscribers`
+- per-type preferences in `newsletter_preferences`
+- Newsletter Studio modes for `Compose`, `Queue`, and `Templates`
+
+The data model is one subscriber with multiple preferences, not three separate mailing lists. The UI should reflect that directly.
+
+## Approved Direction
+
+Use one combined table in Newsletter Studio.
+
+Each row represents one subscriber and shows:
+
+- email
+- subscriber status
+- toggle for `News`
+- toggle for `Jobs`
+- toggle for `Candidates`
+- clicks in the last 7 days
+- last clicked link
+- created date
+- row-level actions
+
+Toggle changes stay local until the admin presses `Save` on that row. This avoids accidental live edits while still keeping the UI fast.
+
+## Data Flow
+
+### Read Path
+
+`NewsletterStudio` fetches `/api/v1/newsletter/subscribers?limit=...` and normalizes each row into UI state:
+
+- `enabledTypes: { news: boolean, jobs: boolean, candidates: boolean }`
+- `draftEnabledTypes` for local edits
+- `dirty` flag derived from current vs draft values
+
+### Write Path
+
+Add an admin write route for one subscriber, for example:
+
+- `PATCH /api/v1/newsletter/subscribers/[id]`
+
+Request body:
+
+```json
+{
+  "newsletterTypes": ["news", "candidates"]
+}
+```
+
+The handler should:
+
+- require `admin:write`
+- validate the subscriber exists
+- update preferences through shared newsletter service logic
+- update subscriber status using existing semantics:
+  - `pending` stays `pending`
+  - `active` or `unsubscribed` becomes `active` if any type remains enabled
+  - `active` or `unsubscribed` becomes `unsubscribed` if all are disabled
+
+This preserves double opt-in behavior. Admin preference edits should not silently confirm pending subscribers.
+
+## UI Design
+
+### Placement
+
+Add `Subscribers` as a fourth Newsletter Studio mode next to:
+
+- Compose
+- Queue
+- Templates
+
+### Table Behavior
+
+The initial version should be intentionally narrow:
+
+- one combined table
+- no pagination controls in the first pass beyond existing API `limit`
+- row-level unsaved indicator
+- row-level `Save` and `Reset`
+
+Recommended columns:
+
+1. `Email`
+2. `Status`
+3. `News`
+4. `Jobs`
+5. `Candidates`
+6. `Clicks 7d`
+7. `Last clicked`
+8. `Created`
+9. `Actions`
+
+### Toggle Semantics
+
+Each toggle changes the row draft only.
+
+When all three toggles are off:
+
+- the row is valid
+- saving it unsubscribes the subscriber unless they are still `pending`
+
+When one or more toggles are on:
+
+- saving it enables exactly those types
+
+### Feedback
+
+Each row should surface:
+
+- saving state
+- save error state
+- unsaved state
+
+Top-level page errors should still use the existing Newsletter Studio error surface.
+
+## Backend Logic
+
+Add a shared service helper in `src/services/newsletter.ts`, for example:
+
+- `adminUpdateSubscriberPreferences(subscriberId: string, newsletterTypes: string[])`
+
+Responsibilities:
+
+- validate subscriber exists
+- normalize types through `dedupeNewsletterTypes`
+- call `upsertPreferences`
+- update subscriber status according to the rules above
+- return the refreshed subscriber + preferences payload if helpful
+
+This keeps token-based preference updates and admin-based preference updates aligned around the same core preference mutation behavior.
+
+## Testing Strategy
+
+### Backend
+
+- route test for `PATCH /api/v1/newsletter/subscribers/[id]`
+- service test for status transitions:
+  - `active` + all off => `unsubscribed`
+  - `unsubscribed` + any on => `active`
+  - `pending` + changes => remains `pending`
+
+### Frontend
+
+Because `NewsletterStudio` is large, avoid full end-to-end component testing in the first pass.
+
+Extract small pure helpers for:
+
+- mapping subscriber API payload to toggle state
+- detecting dirty rows
+
+Test those helpers with Bun unit tests. Keep the component change straightforward and thin.
+
+## Risks
+
+### Risk: accidental silent confirmation
+
+Mitigation:
+
+- do not set `pending` subscribers to `active` from the admin subscriber table
+
+### Risk: component sprawl in `NewsletterStudio`
+
+Mitigation:
+
+- add a small presentational subcomponent or helper block for the subscribers table
+- keep table state separate from compose/queue/template state
+
+### Risk: misunderstanding the model as three separate lists
+
+Mitigation:
+
+- keep one row per subscriber
+- show all three toggles together in the same row
+
+## Success Criteria
+
+This feature is complete when:
+
+- Newsletter Studio has a `Subscribers` tab
+- the tab renders one combined table of subscribers
+- admins can see the `News`, `Jobs`, and `Candidates` subscriptions in one place
+- admins can toggle and save per-row subscription changes
+- pending subscribers are not auto-confirmed by admin edits

--- a/docs/plans/2026-03-09-newsletter-subscribers-tab.md
+++ b/docs/plans/2026-03-09-newsletter-subscribers-tab.md
@@ -1,0 +1,290 @@
+# Newsletter Subscribers Tab Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a Newsletter Studio subscribers tab with one combined table showing and editing `news`, `jobs`, and `candidates` subscriptions per subscriber.
+
+**Architecture:** Extend the existing subscribers read API with a new admin write path for one subscriber, then wire a new `Subscribers` mode into Newsletter Studio. Keep edits row-local with `Save` and `Reset`, and preserve the current subscriber lifecycle semantics so pending subscribers are not silently confirmed.
+
+**Tech Stack:** Next.js App Router, React client components, TypeScript, Bun tests, Drizzle ORM
+
+---
+
+### Task 1: Add Shared Admin Preference Update Logic
+
+**Files:**
+- Modify: `src/services/newsletter.ts`
+- Test: `tests/newsletter-admin-subscribers.test.ts`
+
+**Step 1: Write the failing test**
+
+Add a service-level test that exercises a new admin update helper and proves these status transitions:
+
+- `active` subscriber + `[]` => status becomes `unsubscribed`
+- `unsubscribed` subscriber + `["news"]` => status becomes `active`
+- `pending` subscriber + `["jobs"]` => status remains `pending`
+
+Mock the DB calls narrowly and assert the update payloads.
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test tests/newsletter-admin-subscribers.test.ts`
+Expected: FAIL because the admin helper does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+In `src/services/newsletter.ts`, add:
+
+```ts
+export async function adminUpdateSubscriberPreferences(
+  subscriberId: string,
+  newsletterTypes: string[],
+) {
+  // load subscriber
+  // normalize types with dedupeNewsletterTypes()
+  // upsert preferences
+  // update status with pending preserved
+}
+```
+
+Use the existing `upsertPreferences()` helper rather than duplicating preference write logic.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test tests/newsletter-admin-subscribers.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/services/newsletter.ts tests/newsletter-admin-subscribers.test.ts
+git commit -m "feat: add admin subscriber preference updates"
+```
+
+### Task 2: Add Admin Write Route For A Subscriber Row
+
+**Files:**
+- Create: `src/app/api/v1/newsletter/subscribers/[id]/route.ts`
+- Modify: `src/app/api/v1/newsletter/subscribers/route.ts`
+- Test: `tests/newsletter-subscribers-route.test.ts`
+
+**Step 1: Write the failing test**
+
+Add a route test for:
+
+- `PATCH /api/v1/newsletter/subscribers/[id]`
+- requires `admin:write`
+- accepts `{ newsletterTypes: [...] }`
+- calls the new service helper
+- returns updated row data or `{ data: ... }`
+
+Add one negative test for invalid JSON or missing `newsletterTypes`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test tests/newsletter-subscribers-route.test.ts`
+Expected: FAIL because the route file does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create `src/app/api/v1/newsletter/subscribers/[id]/route.ts`:
+
+```ts
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAuth(request, "admin:write");
+  // parse body
+  // call adminUpdateSubscriberPreferences(id, newsletterTypes)
+  // return JSON
+}
+```
+
+Leave the existing list route focused on reads.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test tests/newsletter-subscribers-route.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/app/api/v1/newsletter/subscribers/[id]/route.ts src/app/api/v1/newsletter/subscribers/route.ts tests/newsletter-subscribers-route.test.ts
+git commit -m "feat: add admin subscriber update route"
+```
+
+### Task 3: Add Subscriber Table Helpers
+
+**Files:**
+- Create: `src/lib/newsletter-subscribers.ts`
+- Test: `tests/newsletter-subscribers.test.ts`
+
+**Step 1: Write the failing test**
+
+Add pure helper tests for:
+
+- mapping API preferences into `{ news, jobs, candidates }`
+- deriving whether a row is dirty
+- building the outgoing `newsletterTypes` array from toggle state
+
+Example shape:
+
+```ts
+expect(buildNewsletterTypes({ news: true, jobs: false, candidates: true })).toEqual(["news", "candidates"]);
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test tests/newsletter-subscribers.test.ts`
+Expected: FAIL because the helper module does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create `src/lib/newsletter-subscribers.ts` with small pure helpers such as:
+
+```ts
+export function toPreferenceFlags(preferences) { ... }
+export function buildNewsletterTypes(flags) { ... }
+export function isPreferenceRowDirty(current, draft) { ... }
+```
+
+Keep the API tiny and UI-focused.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test tests/newsletter-subscribers.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/newsletter-subscribers.ts tests/newsletter-subscribers.test.ts
+git commit -m "feat: add newsletter subscriber table helpers"
+```
+
+### Task 4: Add Subscribers Mode To Newsletter Studio
+
+**Files:**
+- Modify: `src/components/admin/NewsletterStudio.tsx`
+- Modify: `src/app/admin/news/page.tsx` (only if new props or wiring are needed)
+- Reference: `src/app/api/v1/newsletter/subscribers/route.ts`
+- Reference: `src/lib/newsletter-subscribers.ts`
+
+**Step 1: Write the failing test**
+
+Because `NewsletterStudio` is large and currently untested at the component level, write the smallest practical test around the extracted helpers from Task 3 rather than a full component render. The failing condition for this task is functional and manual:
+
+- the UI should expose a `Subscribers` mode
+- the mode should fetch the subscribers API
+- rows should show toggles for `news`, `jobs`, `candidates`
+
+Add any small helper test needed before the component change, but avoid introducing a big rendering harness unless required.
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test tests/newsletter-subscribers.test.ts`
+Expected: helper tests cover the data shape; UI remains to implement.
+
+**Step 3: Write minimal implementation**
+
+In `src/components/admin/NewsletterStudio.tsx`:
+
+- extend `type Mode = "compose" | "queue" | "templates"` to include `"subscribers"`
+- add subscriber row types
+- load subscriber data with `adminFetch("/api/v1/newsletter/subscribers?limit=200")`
+- render a new `Subscribers` section with one combined table
+- add three toggle columns
+- track per-row draft state
+- show `Unsaved`, `Save`, and `Reset`
+- call `PATCH /api/v1/newsletter/subscribers/[id]` on save
+
+Recommended row structure:
+
+```ts
+type SubscriberRowDraft = {
+  id: string;
+  email: string;
+  status: string;
+  current: PreferenceFlags;
+  draft: PreferenceFlags;
+  clicks7d: number;
+  lastClickedLink: string | null;
+  createdAt: string;
+}
+```
+
+**Step 4: Run focused verification**
+
+Run:
+
+```bash
+bun test tests/newsletter-subscribers.test.ts
+```
+
+Expected: PASS
+
+Then manually inspect the relevant TypeScript compile path with:
+
+```bash
+bunx tsc --noEmit
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/components/admin/NewsletterStudio.tsx src/app/admin/news/page.tsx src/lib/newsletter-subscribers.ts tests/newsletter-subscribers.test.ts
+git commit -m "feat: add newsletter subscribers tab"
+```
+
+### Task 5: Full Verification
+
+**Files:**
+- Verify only
+
+**Step 1: Run targeted tests**
+
+Run:
+
+```bash
+bun test tests/newsletter-admin-subscribers.test.ts tests/newsletter-subscribers-route.test.ts tests/newsletter-subscribers.test.ts
+```
+
+Expected: PASS
+
+**Step 2: Run full unit suite**
+
+Run:
+
+```bash
+bun run test:unit
+```
+
+Expected: PASS
+
+**Step 3: Run typecheck**
+
+Run:
+
+```bash
+bunx tsc --noEmit
+```
+
+Expected: PASS
+
+**Step 4: Run production build**
+
+Run:
+
+```bash
+bun run build
+```
+
+Expected: PASS
+
+**Step 5: Commit final verified state**
+
+```bash
+git add src/services/newsletter.ts src/app/api/v1/newsletter/subscribers/[id]/route.ts src/app/api/v1/newsletter/subscribers/route.ts src/lib/newsletter-subscribers.ts src/components/admin/NewsletterStudio.tsx tests/newsletter-admin-subscribers.test.ts tests/newsletter-subscribers-route.test.ts tests/newsletter-subscribers.test.ts docs/plans/2026-03-09-newsletter-subscribers-tab-design.md docs/plans/2026-03-09-newsletter-subscribers-tab.md
+git commit -m "feat: add newsletter subscribers tab"
+```

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,10 +1,61 @@
 import { defineConfig } from "drizzle-kit";
 
+type DrizzleEnv = "dev" | "staging" | "prod";
+
+function isGenerateCommand(): boolean {
+  return process.argv.some((arg) => arg === "generate");
+}
+
+function resolveDrizzleEnv(): DrizzleEnv {
+  const target = (process.env.DRIZZLE_ENV || "dev").toLowerCase();
+  if (target === "dev" || target === "staging" || target === "prod") {
+    return target;
+  }
+  throw new Error(`Invalid DRIZZLE_ENV "${target}". Expected one of: dev, staging, prod.`);
+}
+
+function resolveDatabaseUrl(env: DrizzleEnv): string {
+  const shouldAllowPlaceholder = isGenerateCommand();
+
+  if (env === "dev") {
+    const url = process.env.DATABASE_URL_DEV || process.env.DATABASE_URL;
+    if (!url) {
+      if (shouldAllowPlaceholder) {
+        return "postgresql://localhost:5432/drizzle_generate_placeholder";
+      }
+      throw new Error("Missing DATABASE_URL_DEV (or DATABASE_URL fallback) for DRIZZLE_ENV=dev.");
+    }
+    return url;
+  }
+
+  if (env === "staging") {
+    const url = process.env.DATABASE_URL_STAGING;
+    if (!url) {
+      if (shouldAllowPlaceholder) {
+        return "postgresql://localhost:5432/drizzle_generate_placeholder";
+      }
+      throw new Error("Missing DATABASE_URL_STAGING for DRIZZLE_ENV=staging.");
+    }
+    return url;
+  }
+
+  const url = process.env.DATABASE_URL_PROD;
+  if (!url) {
+    if (shouldAllowPlaceholder) {
+      return "postgresql://localhost:5432/drizzle_generate_placeholder";
+    }
+    throw new Error("Missing DATABASE_URL_PROD for DRIZZLE_ENV=prod.");
+  }
+  return url;
+}
+
+const drizzleEnv = resolveDrizzleEnv();
+
 export default defineConfig({
   schema: "./src/db/schema",
   out: "./drizzle",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    url: resolveDatabaseUrl(drizzleEnv),
   },
 });

--- a/drizzle/0004_fast_hiroim.sql
+++ b/drizzle/0004_fast_hiroim.sql
@@ -1,0 +1,84 @@
+CREATE TABLE "newsletter_campaign_recipients" (
+	"id" text PRIMARY KEY NOT NULL,
+	"campaign_id" text NOT NULL,
+	"subscriber_id" text NOT NULL,
+	"email" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"sent_at" timestamp,
+	"error_message" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "newsletter_campaigns" (
+	"id" text PRIMARY KEY NOT NULL,
+	"newsletter_type" text NOT NULL,
+	"subject" text NOT NULL,
+	"preview_text" text,
+	"status" text DEFAULT 'draft' NOT NULL,
+	"period_days" integer DEFAULT 7 NOT NULL,
+	"scheduled_at" timestamp,
+	"sent_at" timestamp,
+	"failure_reason" text,
+	"created_by" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "newsletter_preferences" (
+	"id" text PRIMARY KEY NOT NULL,
+	"subscriber_id" text NOT NULL,
+	"newsletter_type" text NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "newsletter_send_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"campaign_id" text NOT NULL,
+	"recipient_id" text,
+	"event_type" text NOT NULL,
+	"provider" text,
+	"provider_message_id" text,
+	"payload" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "newsletter_subscribers" (
+	"id" text PRIMARY KEY NOT NULL,
+	"email" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"confirmed_at" timestamp,
+	"unsubscribed_at" timestamp,
+	"source" text DEFAULT 'news-page' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "newsletter_subscribers_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "newsletter_unsub_tokens" (
+	"id" text PRIMARY KEY NOT NULL,
+	"subscriber_id" text NOT NULL,
+	"newsletter_type" text,
+	"token_type" text DEFAULT 'unsubscribe' NOT NULL,
+	"token" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"used_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "newsletter_unsub_tokens_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+ALTER TABLE "curated_links" ADD COLUMN "source_image" text;--> statement-breakpoint
+CREATE INDEX "newsletter_campaign_recipients_campaign_idx" ON "newsletter_campaign_recipients" USING btree ("campaign_id");--> statement-breakpoint
+CREATE INDEX "newsletter_campaign_recipients_subscriber_idx" ON "newsletter_campaign_recipients" USING btree ("subscriber_id");--> statement-breakpoint
+CREATE INDEX "newsletter_campaigns_status_idx" ON "newsletter_campaigns" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "newsletter_campaigns_type_idx" ON "newsletter_campaigns" USING btree ("newsletter_type");--> statement-breakpoint
+CREATE INDEX "newsletter_campaigns_scheduled_idx" ON "newsletter_campaigns" USING btree ("scheduled_at");--> statement-breakpoint
+CREATE INDEX "newsletter_preferences_subscriber_idx" ON "newsletter_preferences" USING btree ("subscriber_id");--> statement-breakpoint
+CREATE INDEX "newsletter_preferences_type_idx" ON "newsletter_preferences" USING btree ("newsletter_type");--> statement-breakpoint
+CREATE INDEX "newsletter_send_events_campaign_idx" ON "newsletter_send_events" USING btree ("campaign_id");--> statement-breakpoint
+CREATE INDEX "newsletter_send_events_type_idx" ON "newsletter_send_events" USING btree ("event_type");--> statement-breakpoint
+CREATE INDEX "newsletter_subscribers_status_idx" ON "newsletter_subscribers" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "newsletter_unsub_tokens_subscriber_idx" ON "newsletter_unsub_tokens" USING btree ("subscriber_id");--> statement-breakpoint
+CREATE INDEX "newsletter_unsub_tokens_token_idx" ON "newsletter_unsub_tokens" USING btree ("token");

--- a/drizzle/0005_tearful_robbie_robertson.sql
+++ b/drizzle/0005_tearful_robbie_robertson.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX "newsletter_campaign_recipients_campaign_subscriber_uidx" ON "newsletter_campaign_recipients" USING btree ("campaign_id","subscriber_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "newsletter_preferences_subscriber_type_uidx" ON "newsletter_preferences" USING btree ("subscriber_id","newsletter_type");

--- a/drizzle/0006_next_mystique.sql
+++ b/drizzle/0006_next_mystique.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "newsletter_templates" (
+	"id" text PRIMARY KEY NOT NULL,
+	"newsletter_type" text NOT NULL,
+	"subject_template" text NOT NULL,
+	"html_template" text NOT NULL,
+	"text_template" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "newsletter_templates_newsletter_type_unique" UNIQUE("newsletter_type")
+);
+--> statement-breakpoint
+CREATE INDEX "newsletter_templates_type_idx" ON "newsletter_templates" USING btree ("newsletter_type");

--- a/drizzle/0007_brave_boomer.sql
+++ b/drizzle/0007_brave_boomer.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "newsletter_campaigns" ADD COLUMN "content_mode" text DEFAULT 'template' NOT NULL;--> statement-breakpoint
+ALTER TABLE "newsletter_campaigns" ADD COLUMN "markdown_content" text;--> statement-breakpoint
+ALTER TABLE "newsletter_campaigns" ADD COLUMN "manual_html" text;--> statement-breakpoint
+ALTER TABLE "newsletter_campaigns" ADD COLUMN "manual_text" text;--> statement-breakpoint
+ALTER TABLE "newsletter_templates" ADD COLUMN "markdown_template" text DEFAULT '{{default_markdown_body}}' NOT NULL;

--- a/drizzle/0008_bitter_mulholland_black.sql
+++ b/drizzle/0008_bitter_mulholland_black.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "newsletter_campaigns" ADD COLUMN "rendered_html" text;--> statement-breakpoint
+ALTER TABLE "newsletter_campaigns" ADD COLUMN "rendered_text" text;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1891 @@
+{
+  "id": "0dd95cb2-af0c-4126-b1b7-a31044f9fe3b",
+  "prevId": "fa0a7a65-90bd-4d83-ba2b-1aad9713c87f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blog_posts": {
+      "name": "blog_posts",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blog_posts_date_idx": {
+          "name": "blog_posts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_posts_published_idx": {
+          "name": "blog_posts_published_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidates": {
+      "name": "candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience": {
+          "name": "experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education": {
+          "name": "education",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cv": {
+          "name": "cv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'looking'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendly": {
+          "name": "calendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidates_featured_idx": {
+          "name": "candidates_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidates_available_idx": {
+          "name": "candidates_available_idx",
+          "columns": [
+            {
+              "expression": "available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_roles": {
+      "name": "job_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_roles_slug_idx": {
+          "name": "job_roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_roles_slug_unique": {
+          "name": "job_roles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_tags": {
+      "name": "job_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_tags_slug_idx": {
+          "name": "job_tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_tags_slug_unique": {
+          "name": "job_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote": {
+          "name": "remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary": {
+          "name": "salary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_x": {
+          "name": "company_x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_github": {
+          "name": "company_github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_company_idx": {
+          "name": "jobs_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_category_idx": {
+          "name": "jobs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_featured_idx": {
+          "name": "jobs_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_company_idx": {
+          "name": "announcements_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_date_idx": {
+          "name": "announcements_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_links": {
+      "name": "curated_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_image": {
+          "name": "source_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curated_links_category_idx": {
+          "name": "curated_links_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "curated_links_date_idx": {
+          "name": "curated_links_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investment_categories": {
+      "name": "investment_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investment_categories_slug_idx": {
+          "name": "investment_categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "investment_categories_slug_unique": {
+          "name": "investment_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investments_tier_idx": {
+          "name": "investments_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investments_featured_idx": {
+          "name": "investments_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_begin": {
+          "name": "date_begin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_title_idx": {
+          "name": "affiliations_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate_redirects": {
+      "name": "candidate_redirects",
+      "schema": "",
+      "columns": {
+        "old_id": {
+          "name": "old_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_id": {
+          "name": "new_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_redirects_new_id_idx": {
+          "name": "candidate_redirects_new_id_idx",
+          "columns": [
+            {
+              "expression": "new_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_campaign_recipients": {
+      "name": "newsletter_campaign_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_campaign_recipients_campaign_idx": {
+          "name": "newsletter_campaign_recipients_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaign_recipients_subscriber_idx": {
+          "name": "newsletter_campaign_recipients_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_campaigns": {
+      "name": "newsletter_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "period_days": {
+          "name": "period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_campaigns_status_idx": {
+          "name": "newsletter_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_type_idx": {
+          "name": "newsletter_campaigns_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_scheduled_idx": {
+          "name": "newsletter_campaigns_scheduled_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_preferences": {
+      "name": "newsletter_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_preferences_subscriber_idx": {
+          "name": "newsletter_preferences_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_preferences_type_idx": {
+          "name": "newsletter_preferences_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_send_events": {
+      "name": "newsletter_send_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_send_events_campaign_idx": {
+          "name": "newsletter_send_events_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_send_events_type_idx": {
+          "name": "newsletter_send_events_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'news-page'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_status_idx": {
+          "name": "newsletter_subscribers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscribers_email_unique": {
+          "name": "newsletter_subscribers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_unsub_tokens": {
+      "name": "newsletter_unsub_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unsubscribe'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_unsub_tokens_subscriber_idx": {
+          "name": "newsletter_unsub_tokens_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_unsub_tokens_token_idx": {
+          "name": "newsletter_unsub_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_unsub_tokens_token_unique": {
+          "name": "newsletter_unsub_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1933 @@
+{
+  "id": "8e90ed32-c8ce-4bd0-8d99-5266fe7fd911",
+  "prevId": "0dd95cb2-af0c-4126-b1b7-a31044f9fe3b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blog_posts": {
+      "name": "blog_posts",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blog_posts_date_idx": {
+          "name": "blog_posts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_posts_published_idx": {
+          "name": "blog_posts_published_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidates": {
+      "name": "candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience": {
+          "name": "experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education": {
+          "name": "education",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cv": {
+          "name": "cv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'looking'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendly": {
+          "name": "calendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidates_featured_idx": {
+          "name": "candidates_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidates_available_idx": {
+          "name": "candidates_available_idx",
+          "columns": [
+            {
+              "expression": "available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_roles": {
+      "name": "job_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_roles_slug_idx": {
+          "name": "job_roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_roles_slug_unique": {
+          "name": "job_roles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_tags": {
+      "name": "job_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_tags_slug_idx": {
+          "name": "job_tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_tags_slug_unique": {
+          "name": "job_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote": {
+          "name": "remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary": {
+          "name": "salary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_x": {
+          "name": "company_x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_github": {
+          "name": "company_github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_company_idx": {
+          "name": "jobs_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_category_idx": {
+          "name": "jobs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_featured_idx": {
+          "name": "jobs_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_company_idx": {
+          "name": "announcements_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_date_idx": {
+          "name": "announcements_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_links": {
+      "name": "curated_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_image": {
+          "name": "source_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curated_links_category_idx": {
+          "name": "curated_links_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "curated_links_date_idx": {
+          "name": "curated_links_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investment_categories": {
+      "name": "investment_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investment_categories_slug_idx": {
+          "name": "investment_categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "investment_categories_slug_unique": {
+          "name": "investment_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investments_tier_idx": {
+          "name": "investments_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investments_featured_idx": {
+          "name": "investments_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_begin": {
+          "name": "date_begin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_title_idx": {
+          "name": "affiliations_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate_redirects": {
+      "name": "candidate_redirects",
+      "schema": "",
+      "columns": {
+        "old_id": {
+          "name": "old_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_id": {
+          "name": "new_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_redirects_new_id_idx": {
+          "name": "candidate_redirects_new_id_idx",
+          "columns": [
+            {
+              "expression": "new_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_campaign_recipients": {
+      "name": "newsletter_campaign_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_campaign_recipients_campaign_idx": {
+          "name": "newsletter_campaign_recipients_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaign_recipients_subscriber_idx": {
+          "name": "newsletter_campaign_recipients_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaign_recipients_campaign_subscriber_uidx": {
+          "name": "newsletter_campaign_recipients_campaign_subscriber_uidx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_campaigns": {
+      "name": "newsletter_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "period_days": {
+          "name": "period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_campaigns_status_idx": {
+          "name": "newsletter_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_type_idx": {
+          "name": "newsletter_campaigns_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_scheduled_idx": {
+          "name": "newsletter_campaigns_scheduled_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_preferences": {
+      "name": "newsletter_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_preferences_subscriber_idx": {
+          "name": "newsletter_preferences_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_preferences_type_idx": {
+          "name": "newsletter_preferences_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_preferences_subscriber_type_uidx": {
+          "name": "newsletter_preferences_subscriber_type_uidx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_send_events": {
+      "name": "newsletter_send_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_send_events_campaign_idx": {
+          "name": "newsletter_send_events_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_send_events_type_idx": {
+          "name": "newsletter_send_events_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'news-page'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_status_idx": {
+          "name": "newsletter_subscribers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscribers_email_unique": {
+          "name": "newsletter_subscribers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_unsub_tokens": {
+      "name": "newsletter_unsub_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unsubscribe'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_unsub_tokens_subscriber_idx": {
+          "name": "newsletter_unsub_tokens_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_unsub_tokens_token_idx": {
+          "name": "newsletter_unsub_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_unsub_tokens_token_unique": {
+          "name": "newsletter_unsub_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,2014 @@
+{
+  "id": "f29c62ea-2391-49f6-ac68-db77fe6a2689",
+  "prevId": "8e90ed32-c8ce-4bd0-8d99-5266fe7fd911",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blog_posts": {
+      "name": "blog_posts",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blog_posts_date_idx": {
+          "name": "blog_posts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_posts_published_idx": {
+          "name": "blog_posts_published_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidates": {
+      "name": "candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience": {
+          "name": "experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education": {
+          "name": "education",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cv": {
+          "name": "cv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'looking'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendly": {
+          "name": "calendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidates_featured_idx": {
+          "name": "candidates_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidates_available_idx": {
+          "name": "candidates_available_idx",
+          "columns": [
+            {
+              "expression": "available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_roles": {
+      "name": "job_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_roles_slug_idx": {
+          "name": "job_roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_roles_slug_unique": {
+          "name": "job_roles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_tags": {
+      "name": "job_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_tags_slug_idx": {
+          "name": "job_tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_tags_slug_unique": {
+          "name": "job_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote": {
+          "name": "remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary": {
+          "name": "salary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_x": {
+          "name": "company_x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_github": {
+          "name": "company_github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_company_idx": {
+          "name": "jobs_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_category_idx": {
+          "name": "jobs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_featured_idx": {
+          "name": "jobs_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_company_idx": {
+          "name": "announcements_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_date_idx": {
+          "name": "announcements_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_links": {
+      "name": "curated_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_image": {
+          "name": "source_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curated_links_category_idx": {
+          "name": "curated_links_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "curated_links_date_idx": {
+          "name": "curated_links_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investment_categories": {
+      "name": "investment_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investment_categories_slug_idx": {
+          "name": "investment_categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "investment_categories_slug_unique": {
+          "name": "investment_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investments_tier_idx": {
+          "name": "investments_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investments_featured_idx": {
+          "name": "investments_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_begin": {
+          "name": "date_begin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_title_idx": {
+          "name": "affiliations_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate_redirects": {
+      "name": "candidate_redirects",
+      "schema": "",
+      "columns": {
+        "old_id": {
+          "name": "old_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_id": {
+          "name": "new_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_redirects_new_id_idx": {
+          "name": "candidate_redirects_new_id_idx",
+          "columns": [
+            {
+              "expression": "new_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_campaign_recipients": {
+      "name": "newsletter_campaign_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_campaign_recipients_campaign_idx": {
+          "name": "newsletter_campaign_recipients_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaign_recipients_subscriber_idx": {
+          "name": "newsletter_campaign_recipients_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaign_recipients_campaign_subscriber_uidx": {
+          "name": "newsletter_campaign_recipients_campaign_subscriber_uidx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_campaigns": {
+      "name": "newsletter_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "period_days": {
+          "name": "period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_campaigns_status_idx": {
+          "name": "newsletter_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_type_idx": {
+          "name": "newsletter_campaigns_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_scheduled_idx": {
+          "name": "newsletter_campaigns_scheduled_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_preferences": {
+      "name": "newsletter_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_preferences_subscriber_idx": {
+          "name": "newsletter_preferences_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_preferences_type_idx": {
+          "name": "newsletter_preferences_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_preferences_subscriber_type_uidx": {
+          "name": "newsletter_preferences_subscriber_type_uidx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_send_events": {
+      "name": "newsletter_send_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_send_events_campaign_idx": {
+          "name": "newsletter_send_events_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_send_events_type_idx": {
+          "name": "newsletter_send_events_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'news-page'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_status_idx": {
+          "name": "newsletter_subscribers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscribers_email_unique": {
+          "name": "newsletter_subscribers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_templates": {
+      "name": "newsletter_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_template": {
+          "name": "subject_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_template": {
+          "name": "html_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_template": {
+          "name": "text_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_templates_type_idx": {
+          "name": "newsletter_templates_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_templates_newsletter_type_unique": {
+          "name": "newsletter_templates_newsletter_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "newsletter_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_unsub_tokens": {
+      "name": "newsletter_unsub_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unsubscribe'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_unsub_tokens_subscriber_idx": {
+          "name": "newsletter_unsub_tokens_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_unsub_tokens_token_idx": {
+          "name": "newsletter_unsub_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_unsub_tokens_token_unique": {
+          "name": "newsletter_unsub_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,2046 @@
+{
+  "id": "3ae8508e-274a-4b22-89c4-f9193cda63e0",
+  "prevId": "f29c62ea-2391-49f6-ac68-db77fe6a2689",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blog_posts": {
+      "name": "blog_posts",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blog_posts_date_idx": {
+          "name": "blog_posts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_posts_published_idx": {
+          "name": "blog_posts_published_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidates": {
+      "name": "candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience": {
+          "name": "experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education": {
+          "name": "education",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cv": {
+          "name": "cv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'looking'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendly": {
+          "name": "calendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidates_featured_idx": {
+          "name": "candidates_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidates_available_idx": {
+          "name": "candidates_available_idx",
+          "columns": [
+            {
+              "expression": "available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_roles": {
+      "name": "job_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_roles_slug_idx": {
+          "name": "job_roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_roles_slug_unique": {
+          "name": "job_roles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_tags": {
+      "name": "job_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_tags_slug_idx": {
+          "name": "job_tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_tags_slug_unique": {
+          "name": "job_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote": {
+          "name": "remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary": {
+          "name": "salary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_x": {
+          "name": "company_x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_github": {
+          "name": "company_github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_company_idx": {
+          "name": "jobs_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_category_idx": {
+          "name": "jobs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_featured_idx": {
+          "name": "jobs_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_company_idx": {
+          "name": "announcements_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_date_idx": {
+          "name": "announcements_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_links": {
+      "name": "curated_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_image": {
+          "name": "source_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curated_links_category_idx": {
+          "name": "curated_links_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "curated_links_date_idx": {
+          "name": "curated_links_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investment_categories": {
+      "name": "investment_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investment_categories_slug_idx": {
+          "name": "investment_categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "investment_categories_slug_unique": {
+          "name": "investment_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investments_tier_idx": {
+          "name": "investments_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investments_featured_idx": {
+          "name": "investments_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_begin": {
+          "name": "date_begin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_title_idx": {
+          "name": "affiliations_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate_redirects": {
+      "name": "candidate_redirects",
+      "schema": "",
+      "columns": {
+        "old_id": {
+          "name": "old_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_id": {
+          "name": "new_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_redirects_new_id_idx": {
+          "name": "candidate_redirects_new_id_idx",
+          "columns": [
+            {
+              "expression": "new_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_campaign_recipients": {
+      "name": "newsletter_campaign_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_campaign_recipients_campaign_idx": {
+          "name": "newsletter_campaign_recipients_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaign_recipients_subscriber_idx": {
+          "name": "newsletter_campaign_recipients_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaign_recipients_campaign_subscriber_uidx": {
+          "name": "newsletter_campaign_recipients_campaign_subscriber_uidx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_campaigns": {
+      "name": "newsletter_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'template'"
+        },
+        "markdown_content": {
+          "name": "markdown_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_html": {
+          "name": "manual_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_text": {
+          "name": "manual_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "period_days": {
+          "name": "period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_campaigns_status_idx": {
+          "name": "newsletter_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_type_idx": {
+          "name": "newsletter_campaigns_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_scheduled_idx": {
+          "name": "newsletter_campaigns_scheduled_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_preferences": {
+      "name": "newsletter_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_preferences_subscriber_idx": {
+          "name": "newsletter_preferences_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_preferences_type_idx": {
+          "name": "newsletter_preferences_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_preferences_subscriber_type_uidx": {
+          "name": "newsletter_preferences_subscriber_type_uidx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_send_events": {
+      "name": "newsletter_send_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_send_events_campaign_idx": {
+          "name": "newsletter_send_events_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_send_events_type_idx": {
+          "name": "newsletter_send_events_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'news-page'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_status_idx": {
+          "name": "newsletter_subscribers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscribers_email_unique": {
+          "name": "newsletter_subscribers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_templates": {
+      "name": "newsletter_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_template": {
+          "name": "subject_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_template": {
+          "name": "html_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_template": {
+          "name": "text_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown_template": {
+          "name": "markdown_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{{default_markdown_body}}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_templates_type_idx": {
+          "name": "newsletter_templates_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_templates_newsletter_type_unique": {
+          "name": "newsletter_templates_newsletter_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "newsletter_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_unsub_tokens": {
+      "name": "newsletter_unsub_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unsubscribe'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_unsub_tokens_subscriber_idx": {
+          "name": "newsletter_unsub_tokens_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_unsub_tokens_token_idx": {
+          "name": "newsletter_unsub_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_unsub_tokens_token_unique": {
+          "name": "newsletter_unsub_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,2058 @@
+{
+  "id": "cf8489b8-4399-4886-8e1a-e2994a39a762",
+  "prevId": "3ae8508e-274a-4b22-89c4-f9193cda63e0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blog_posts": {
+      "name": "blog_posts",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blog_posts_date_idx": {
+          "name": "blog_posts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_posts_published_idx": {
+          "name": "blog_posts_published_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidates": {
+      "name": "candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience": {
+          "name": "experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education": {
+          "name": "education",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cv": {
+          "name": "cv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'looking'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendly": {
+          "name": "calendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidates_featured_idx": {
+          "name": "candidates_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidates_available_idx": {
+          "name": "candidates_available_idx",
+          "columns": [
+            {
+              "expression": "available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_roles": {
+      "name": "job_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_roles_slug_idx": {
+          "name": "job_roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_roles_slug_unique": {
+          "name": "job_roles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_tags": {
+      "name": "job_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_tags_slug_idx": {
+          "name": "job_tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_tags_slug_unique": {
+          "name": "job_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote": {
+          "name": "remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary": {
+          "name": "salary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_x": {
+          "name": "company_x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_github": {
+          "name": "company_github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_company_idx": {
+          "name": "jobs_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_category_idx": {
+          "name": "jobs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_featured_idx": {
+          "name": "jobs_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_company_idx": {
+          "name": "announcements_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_date_idx": {
+          "name": "announcements_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_links": {
+      "name": "curated_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_image": {
+          "name": "source_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curated_links_category_idx": {
+          "name": "curated_links_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "curated_links_date_idx": {
+          "name": "curated_links_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investment_categories": {
+      "name": "investment_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investment_categories_slug_idx": {
+          "name": "investment_categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "investment_categories_slug_unique": {
+          "name": "investment_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investments_tier_idx": {
+          "name": "investments_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investments_featured_idx": {
+          "name": "investments_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_begin": {
+          "name": "date_begin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_title_idx": {
+          "name": "affiliations_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate_redirects": {
+      "name": "candidate_redirects",
+      "schema": "",
+      "columns": {
+        "old_id": {
+          "name": "old_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_id": {
+          "name": "new_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_redirects_new_id_idx": {
+          "name": "candidate_redirects_new_id_idx",
+          "columns": [
+            {
+              "expression": "new_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_campaign_recipients": {
+      "name": "newsletter_campaign_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_campaign_recipients_campaign_idx": {
+          "name": "newsletter_campaign_recipients_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaign_recipients_subscriber_idx": {
+          "name": "newsletter_campaign_recipients_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaign_recipients_campaign_subscriber_uidx": {
+          "name": "newsletter_campaign_recipients_campaign_subscriber_uidx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_campaigns": {
+      "name": "newsletter_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'template'"
+        },
+        "markdown_content": {
+          "name": "markdown_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_html": {
+          "name": "manual_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_text": {
+          "name": "manual_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rendered_html": {
+          "name": "rendered_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rendered_text": {
+          "name": "rendered_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "period_days": {
+          "name": "period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_campaigns_status_idx": {
+          "name": "newsletter_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_type_idx": {
+          "name": "newsletter_campaigns_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_scheduled_idx": {
+          "name": "newsletter_campaigns_scheduled_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_preferences": {
+      "name": "newsletter_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_preferences_subscriber_idx": {
+          "name": "newsletter_preferences_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_preferences_type_idx": {
+          "name": "newsletter_preferences_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_preferences_subscriber_type_uidx": {
+          "name": "newsletter_preferences_subscriber_type_uidx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_send_events": {
+      "name": "newsletter_send_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_send_events_campaign_idx": {
+          "name": "newsletter_send_events_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_send_events_type_idx": {
+          "name": "newsletter_send_events_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'news-page'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_status_idx": {
+          "name": "newsletter_subscribers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscribers_email_unique": {
+          "name": "newsletter_subscribers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_templates": {
+      "name": "newsletter_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_template": {
+          "name": "subject_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_template": {
+          "name": "html_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_template": {
+          "name": "text_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown_template": {
+          "name": "markdown_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{{default_markdown_body}}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_templates_type_idx": {
+          "name": "newsletter_templates_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_templates_newsletter_type_unique": {
+          "name": "newsletter_templates_newsletter_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "newsletter_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_unsub_tokens": {
+      "name": "newsletter_unsub_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unsubscribe'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_unsub_tokens_subscriber_idx": {
+          "name": "newsletter_unsub_tokens_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_unsub_tokens_token_idx": {
+          "name": "newsletter_unsub_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_unsub_tokens_token_unique": {
+          "name": "newsletter_unsub_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1770378778068,
       "tag": "0004_fast_hiroim",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1770380635475,
+      "tag": "0005_tearful_robbie_robertson",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1770380635475,
       "tag": "0005_tearful_robbie_robertson",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1770392464228,
+      "tag": "0006_next_mystique",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1770201446093,
       "tag": "0003_breezy_silverclaw",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1770378778068,
+      "tag": "0004_fast_hiroim",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1771190114848,
       "tag": "0007_brave_boomer",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1772201420401,
+      "tag": "0008_bitter_mulholland_black",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1770392464228,
       "tag": "0006_next_mystique",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1771190114848,
+      "tag": "0007_brave_boomer",
+      "breakpoints": true
     }
   ]
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
+    qualities: [75, 90],
     remotePatterns: [
       {
         protocol: "https",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "playwright test",
     "test:unit": "bun test tests/*.test.ts",
     "test:e2e": "playwright test",
-    "test:all": "bun run test:unit && bun run test:e2e"
+    "test:all": "bun run test:unit && bun run test:e2e",
+    "newsletter:send-due": "bun run scripts/send-due-newsletters.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,14 @@
     "test:unit": "bun test tests/*.test.ts",
     "test:e2e": "playwright test",
     "test:all": "bun run test:unit && bun run test:e2e",
-    "newsletter:send-due": "bun run scripts/send-due-newsletters.ts"
+    "newsletter:send-due": "bun run scripts/send-due-newsletters.ts",
+    "db:generate": "bunx drizzle-kit generate --config drizzle.config.ts",
+    "db:studio": "bunx drizzle-kit studio --config drizzle.config.ts",
+    "db:migrate": "bun run scripts/db/migrate.ts",
+    "db:migrate:dev": "bun run scripts/db/migrate.ts --env=dev",
+    "db:migrate:staging": "bun run scripts/db/migrate.ts --env=staging",
+    "db:migrate:prod": "bun run scripts/db/migrate.ts --env=prod",
+    "db:check:migrations": "bun run scripts/db/check-schema-migration-sync.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "drizzle-orm": "^0.45.1",
     "gray-matter": "^4.0.3",
     "next": "^16.1.6",
-    "next-mdx-remote": "^5.0.0",
+    "next-mdx-remote": "^6.0.0",
     "next-themes": "^0.4.6",
     "postgres": "^3.4.8",
     "posthog-js": "^1.336.1",

--- a/scripts/add-curated-link.ts
+++ b/scripts/add-curated-link.ts
@@ -1,0 +1,155 @@
+/**
+ * Insert a curated link into the news feed.
+ *
+ * Usage:
+ *   bunx dotenv -e .env.local -- bun run scripts/add-curated-link.ts \
+ *     --title "..." --url "..." --source "..." --category x_post --date 2026-02-10
+ *
+ * If --date is omitted and the URL is an X status URL, the date is derived from the
+ * tweet snowflake ID (UTC) and then truncated to YYYY-MM-DD.
+ */
+
+import { db } from "../src/db";
+import { curatedLinks } from "../src/db/schema";
+
+type Args = {
+  title?: string;
+  url?: string;
+  source?: string;
+  sourceImage?: string;
+  date?: string;
+  description?: string;
+  category?: string;
+  featured?: boolean;
+  dryRun?: boolean;
+  help?: boolean;
+};
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") {
+      args.help = true;
+      continue;
+    }
+    if (a === "--dry-run") {
+      args.dryRun = true;
+      continue;
+    }
+    if (a === "--featured") {
+      args.featured = true;
+      continue;
+    }
+
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) continue;
+
+    if (a === "--title") {
+      args.title = next;
+      i++;
+    } else if (a === "--url") {
+      args.url = next;
+      i++;
+    } else if (a === "--source") {
+      args.source = next;
+      i++;
+    } else if (a === "--source-image") {
+      args.sourceImage = next;
+      i++;
+    } else if (a === "--date") {
+      args.date = next;
+      i++;
+    } else if (a === "--description") {
+      args.description = next;
+      i++;
+    } else if (a === "--category") {
+      args.category = next;
+      i++;
+    }
+  }
+
+  return args;
+}
+
+function usage(): string {
+  return [
+    "scripts/add-curated-link.ts",
+    "",
+    "Required:",
+    "  --title        Title/headline",
+    "  --url          Full URL",
+    "  --source       Author/publication (e.g. \"Trail of Bits\")",
+    "",
+    "Optional:",
+    "  --category     Defaults to x_post for X URLs, otherwise general",
+    "  --date         YYYY-MM-DD or ISO date; defaults to derived X status date or today",
+    "  --description  Short description",
+    "  --source-image Profile image URL",
+    "  --featured     Mark as featured",
+    "  --dry-run      Print payload without writing to the DB",
+  ].join("\n");
+}
+
+function isXUrl(url: string): boolean {
+  return /^https?:\/\/(x\.com|twitter\.com)\//i.test(url);
+}
+
+function dateFromXStatusUrl(url: string): string | null {
+  const m = url.match(/\/status\/(\d+)/);
+  if (!m) return null;
+  try {
+    // Twitter/X snowflake: (id >> 22) + 1288834974657 (ms since epoch)
+    const id = BigInt(m[1]);
+    const epoch = 1288834974657n;
+    const tsMs = (id >> 22n) + epoch;
+    const iso = new Date(Number(tsMs)).toISOString();
+    return iso.split("T")[0];
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    process.exit(0);
+  }
+
+  if (!args.title || !args.url || !args.source) {
+    console.error("Missing required args.\n\n" + usage());
+    process.exit(2);
+  }
+
+  const category = args.category ?? (isXUrl(args.url) ? "x_post" : "general");
+  const date =
+    args.date ?? dateFromXStatusUrl(args.url) ?? new Date().toISOString().split("T")[0];
+
+  const payload = {
+    title: args.title,
+    url: args.url,
+    source: args.source,
+    sourceImage: args.sourceImage,
+    date: new Date(date),
+    description: args.description,
+    category,
+    featured: args.featured ?? false,
+  };
+
+  if (args.dryRun) {
+    console.log(JSON.stringify({ payload, dateIso: payload.date.toISOString() }, null, 2));
+    process.exit(0);
+  }
+
+  const created = await db.insert(curatedLinks).values(payload).returning();
+  console.log(JSON.stringify(created, null, 2));
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Failed to add curated link:", err);
+  process.exit(1);
+});
+

--- a/scripts/db/check-schema-migration-sync.ts
+++ b/scripts/db/check-schema-migration-sync.ts
@@ -1,0 +1,46 @@
+import { execSync } from "node:child_process";
+
+function parseArg(name: string): string | undefined {
+  const withEquals = process.argv.find((arg) => arg.startsWith(`${name}=`));
+  if (withEquals) return withEquals.slice(name.length + 1);
+
+  const idx = process.argv.indexOf(name);
+  if (idx >= 0 && process.argv[idx + 1]) return process.argv[idx + 1];
+
+  return undefined;
+}
+
+function getChangedFiles(base: string, head: string): string[] {
+  const output = execSync(`git diff --name-only ${base}...${head}`, { encoding: "utf8" });
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function run() {
+  const base = parseArg("--base") || "origin/master";
+  const head = parseArg("--head") || "HEAD";
+
+  const changedFiles = getChangedFiles(base, head);
+  const schemaChanged = changedFiles.some((file) => file.startsWith("src/db/schema/"));
+  const sqlMigrationChanged = changedFiles.some(
+    (file) => file.startsWith("drizzle/") && file.endsWith(".sql")
+  );
+
+  if (schemaChanged && !sqlMigrationChanged) {
+    console.error("[db:check:migrations] Schema files changed without SQL migration files.");
+    console.error("[db:check:migrations] Add and commit a drizzle/*.sql migration before merging.");
+    process.exit(1);
+  }
+
+  console.log("[db:check:migrations] OK");
+}
+
+try {
+  run();
+} catch (error) {
+  const message = error instanceof Error ? error.message : "Unknown schema/migration sync error";
+  console.error(`[db:check:migrations] ${message}`);
+  process.exit(1);
+}

--- a/scripts/db/migrate.ts
+++ b/scripts/db/migrate.ts
@@ -1,0 +1,76 @@
+import { spawnSync } from "node:child_process";
+
+type TargetEnv = "dev" | "staging" | "prod";
+
+const VALID_ENVS: TargetEnv[] = ["dev", "staging", "prod"];
+
+function parseEnvArg(argv: string[]): TargetEnv {
+  const arg = argv.find((value) => value.startsWith("--env="));
+  if (!arg) {
+    throw new Error("Missing required argument --env=dev|staging|prod");
+  }
+
+  const value = arg.slice("--env=".length).toLowerCase();
+  if (!VALID_ENVS.includes(value as TargetEnv)) {
+    throw new Error(`Invalid --env value \"${value}\". Expected dev, staging, or prod.`);
+  }
+
+  return value as TargetEnv;
+}
+
+function resolveUrl(targetEnv: TargetEnv): string {
+  if (targetEnv === "dev") {
+    const devUrl = process.env.DATABASE_URL_DEV || process.env.DATABASE_URL;
+    if (!devUrl) {
+      throw new Error("DATABASE_URL_DEV (or DATABASE_URL fallback) is required for --env=dev.");
+    }
+    return devUrl;
+  }
+
+  if (targetEnv === "staging") {
+    const stagingUrl = process.env.DATABASE_URL_STAGING;
+    if (!stagingUrl) {
+      throw new Error("DATABASE_URL_STAGING is required for --env=staging.");
+    }
+    return stagingUrl;
+  }
+
+  const prodUrl = process.env.DATABASE_URL_PROD;
+  if (!prodUrl) {
+    throw new Error("DATABASE_URL_PROD is required for --env=prod.");
+  }
+
+  return prodUrl;
+}
+
+function run() {
+  const targetEnv = parseEnvArg(process.argv.slice(2));
+
+  if (targetEnv === "prod" && process.env.ALLOW_PROD_MIGRATION !== "true") {
+    throw new Error("Refusing prod migration. Set ALLOW_PROD_MIGRATION=true to continue.");
+  }
+
+  const databaseUrl = resolveUrl(targetEnv);
+  console.log(`[db:migrate] Applying migrations to ${targetEnv}`);
+
+  const child = spawnSync("bunx", ["drizzle-kit", "migrate", "--config", "drizzle.config.ts"], {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      DRIZZLE_ENV: targetEnv,
+      DATABASE_URL: databaseUrl,
+    },
+  });
+
+  if (child.status !== 0) {
+    process.exit(child.status ?? 1);
+  }
+}
+
+try {
+  run();
+} catch (error) {
+  const message = error instanceof Error ? error.message : "Unknown migration error";
+  console.error(`[db:migrate] ${message}`);
+  process.exit(1);
+}

--- a/scripts/send-due-newsletters.ts
+++ b/scripts/send-due-newsletters.ts
@@ -1,0 +1,11 @@
+import { sendDueNewsletterCampaigns } from "../src/services/newsletter";
+
+async function main() {
+  const result = await sendDueNewsletterCampaigns();
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((error) => {
+  console.error("[send-due-newsletters] Failed:", error);
+  process.exit(1);
+});

--- a/scripts/sql/2026-02-10-trailofbits-curated-link.sql
+++ b/scripts/sql/2026-02-10-trailofbits-curated-link.sql
@@ -1,0 +1,29 @@
+-- Curated link: Trail of Bits contributes skills for security engineering
+-- URL: https://x.com/trailofbits/status/2021255004414185904?s=20
+-- Date (derived from X status ID snowflake): 2026-02-10 (UTC)
+--
+-- Note: `id` is a TEXT primary key with no DB default in this project; the
+-- application normally generates a CUID2. This file uses a pre-generated CUID2.
+
+INSERT INTO curated_links (
+  id,
+  title,
+  url,
+  source,
+  date,
+  category,
+  featured,
+  created_at,
+  updated_at
+) VALUES (
+  'xnckz5edjq62txsyd76ov5sg',
+  'Trail of Bits contributes skills for security engineering',
+  'https://x.com/trailofbits/status/2021255004414185904?s=20',
+  'Trail of Bits',
+  '2026-02-10'::timestamp,
+  'x_post',
+  false,
+  now(),
+  now()
+);
+

--- a/src/app/about/opengraph-image.tsx
+++ b/src/app/about/opengraph-image.tsx
@@ -1,0 +1,76 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+export const alt = "About | dcbuilder.eth";
+export const size = {
+	width: 1200,
+	height: 630,
+};
+export const contentType = "image/png";
+
+export default async function Image() {
+	return new ImageResponse(
+		(
+			<div
+				style={{
+					height: "100%",
+					width: "100%",
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+					justifyContent: "center",
+					backgroundColor: "#0a0a0a",
+					backgroundImage:
+						"radial-gradient(circle at 50% 20%, #1a2636 0%, #0a0a0a 55%)",
+				}}
+			>
+				<div
+					style={{
+						width: 220,
+						height: 220,
+						borderRadius: "50%",
+						overflow: "hidden",
+						border: "4px solid #2a2a2a",
+						marginBottom: 32,
+						display: "flex",
+					}}
+				>
+					<img
+						src="https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png"
+						alt="dcbuilder"
+						width={220}
+						height={220}
+						style={{ objectFit: "cover" }}
+					/>
+				</div>
+
+				<div
+					style={{
+						fontSize: 84,
+						fontWeight: 700,
+						color: "#ffffff",
+						marginBottom: 18,
+						textAlign: "center",
+					}}
+				>
+					About | dcbuilder.eth
+				</div>
+
+				<div
+					style={{
+						fontSize: 36,
+						color: "#ddd",
+						textAlign: "center",
+						maxWidth: 900,
+						lineHeight: 1.25,
+					}}
+				>
+					Affiliations, background, and what I am building toward
+				</div>
+			</div>
+		),
+		{ ...size }
+	);
+}
+

--- a/src/app/admin/news/page.tsx
+++ b/src/app/admin/news/page.tsx
@@ -8,6 +8,7 @@ import { getSkillColor } from "@/lib/skill-colors";
 import { TableSkeleton } from "@/components/admin/TableSkeleton";
 import { getAdminApiKey, adminFetch, withMinDelay } from "@/lib/admin-utils";
 import { EditButton, DeleteButton, ErrorAlert } from "@/components/admin/ActionButtons";
+import { NewsletterStudio } from "@/components/admin/NewsletterStudio";
 import { ADMIN_THEMES } from "@/lib/admin-themes";
 
 interface CuratedLink {
@@ -56,7 +57,7 @@ const emptyAnnouncement: Partial<Announcement> = {
   featured: false,
 };
 
-type TabType = "curated" | "announcements";
+type TabType = "curated" | "announcements" | "newsletter";
 
 export default function AdminNews() {
   const searchParams = useSearchParams();
@@ -429,53 +430,56 @@ export default function AdminNews() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">News</h1>
-        <div className="flex gap-2">
-          <button
-            onClick={() => {
-              setEditingItem(emptyCuratedLink);
-              setIsNew(true);
-              setActiveTab("curated");
-            }}
-            className={`px-4 py-2 ${curatedTheme.addButtonBg} text-white rounded-lg font-medium`}
-          >
-            Add Curated Link
-          </button>
-          <button
-            onClick={() => {
-              setEditingItem(emptyAnnouncement);
-              setIsNew(true);
-              setActiveTab("announcements");
-            }}
-            className={`px-4 py-2 ${announcementsTheme.addButtonBg} text-white rounded-lg font-medium`}
-          >
-            Add Announcement
-          </button>
-        </div>
+        {activeTab !== "newsletter" && (
+          <div className="flex gap-2">
+            <button
+              onClick={() => {
+                setEditingItem(emptyCuratedLink);
+                setIsNew(true);
+                setActiveTab("curated");
+              }}
+              className={`px-4 py-2 ${curatedTheme.addButtonBg} text-white rounded-lg font-medium`}
+            >
+              Add Curated Link
+            </button>
+            <button
+              onClick={() => {
+                setEditingItem(emptyAnnouncement);
+                setIsNew(true);
+                setActiveTab("announcements");
+              }}
+              className={`px-4 py-2 ${announcementsTheme.addButtonBg} text-white rounded-lg font-medium`}
+            >
+              Add Announcement
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Error Alert */}
       {error && <ErrorAlert message={error} onRetry={() => { setError(null); fetchData(); }} />}
 
-      {/* Search */}
-      <div className="relative max-w-md">
-        <input
-          type="text"
-          placeholder="Search news..."
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full px-4 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
-        />
-        {searchQuery && (
-          <button
-            onClick={() => setSearchQuery("")}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-neutral-400 hover:text-neutral-600"
-          >
-            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
-        )}
-      </div>
+      {activeTab !== "newsletter" && (
+        <div className="relative max-w-md">
+          <input
+            type="text"
+            placeholder="Search news..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full px-4 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
+          />
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery("")}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-neutral-400 hover:text-neutral-600"
+            >
+              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Tabs */}
       <div className="flex gap-2 border-b border-neutral-200 dark:border-neutral-800">
@@ -499,10 +503,22 @@ export default function AdminNews() {
         >
           Announcements ({announcements.length})
         </button>
+        <button
+          onClick={() => setActiveTab("newsletter")}
+          className={`px-4 py-2 font-medium border-b-2 transition-colors ${
+            activeTab === "newsletter"
+              ? "border-indigo-600 text-indigo-600"
+              : "border-transparent text-neutral-500 hover:text-neutral-700"
+          }`}
+        >
+          Newsletter Studio
+        </button>
       </div>
 
       {/* Content */}
-      {loading ? (
+      {activeTab === "newsletter" ? (
+        <NewsletterStudio />
+      ) : loading ? (
         <TableSkeleton
           headers={
             activeTab === "curated"

--- a/src/app/admin/opengraph-image.tsx
+++ b/src/app/admin/opengraph-image.tsx
@@ -1,0 +1,58 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+export const alt = "Admin | dcbuilder.eth";
+export const size = {
+	width: 1200,
+	height: 630,
+};
+export const contentType = "image/png";
+
+export default async function Image() {
+	return new ImageResponse(
+		(
+			<div
+				style={{
+					height: "100%",
+					width: "100%",
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+					justifyContent: "center",
+					backgroundColor: "#0a0a0a",
+					backgroundImage:
+						"radial-gradient(circle at 50% 0%, #2a2a2a 0%, #0a0a0a 60%)",
+				}}
+			>
+				<div style={{ fontSize: 100, marginBottom: 32 }}>🔧</div>
+
+				<div
+					style={{
+						fontSize: 84,
+						fontWeight: 700,
+						color: "#ffffff",
+						marginBottom: 18,
+						textAlign: "center",
+					}}
+				>
+					Admin | dcbuilder.eth
+				</div>
+
+				<div
+					style={{
+						fontSize: 34,
+						color: "#ddd",
+						textAlign: "center",
+						maxWidth: 900,
+						lineHeight: 1.25,
+					}}
+				>
+					Dashboard and content management
+				</div>
+			</div>
+		),
+		{ ...size }
+	);
+}
+

--- a/src/app/api/cron/newsletter-issue-create/route.ts
+++ b/src/app/api/cron/newsletter-issue-create/route.ts
@@ -1,0 +1,35 @@
+import { createWeeklyNewsCampaignIssue } from "@/services/newsletter";
+
+export const runtime = "nodejs";
+
+function isAuthorized(request: Request): boolean {
+  const configuredSecret = process.env.CRON_SECRET;
+  if (!configuredSecret) return false;
+
+  const bearerToken = request.headers.get("authorization")?.replace(/^Bearer\s+/i, "");
+  const headerToken = request.headers.get("x-cron-secret");
+  const token = bearerToken || headerToken;
+
+  return token === configuredSecret;
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const result = await createWeeklyNewsCampaignIssue({
+    periodDays: 7,
+    createdBy: "cron:newsletter-issue-create",
+  });
+
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json({ data: result.data });
+}
+
+export async function GET(request: Request) {
+  return POST(request);
+}

--- a/src/app/api/cron/newsletter-send/route.ts
+++ b/src/app/api/cron/newsletter-send/route.ts
@@ -1,0 +1,27 @@
+import { sendDueNewsletterCampaigns } from "@/services/newsletter";
+
+export const runtime = "nodejs";
+
+function isAuthorized(request: Request): boolean {
+  const configuredSecret = process.env.CRON_SECRET;
+  if (!configuredSecret) return false;
+
+  const bearerToken = request.headers.get("authorization")?.replace(/^Bearer\s+/i, "");
+  const headerToken = request.headers.get("x-cron-secret");
+  const token = bearerToken || headerToken;
+
+  return token === configuredSecret;
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const result = await sendDueNewsletterCampaigns();
+  return Response.json(result.data);
+}
+
+export async function GET(request: Request) {
+  return POST(request);
+}

--- a/src/app/api/cron/newsletter-send/route.ts
+++ b/src/app/api/cron/newsletter-send/route.ts
@@ -13,12 +13,43 @@ function isAuthorized(request: Request): boolean {
   return token === configuredSecret;
 }
 
+function getSendFailures(results: Array<{ campaignId: string; result: unknown }>) {
+  return results.flatMap((entry) => {
+    const result = entry.result as
+      | { ok: false; error: string }
+      | { ok: true; data?: { failed?: number } };
+
+    if (!result?.ok) {
+      return `${entry.campaignId}: ${result?.error || "unknown send failure"}`;
+    }
+
+    const failedRecipients = typeof result.data?.failed === "number" ? result.data.failed : 0;
+    if (failedRecipients > 0) {
+      return `${entry.campaignId}: ${failedRecipients} recipient(s) failed`;
+    }
+
+    return [];
+  });
+}
+
 export async function POST(request: Request) {
   if (!isAuthorized(request)) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const result = await sendDueNewsletterCampaigns();
+  const failedCampaigns = getSendFailures(result.data.results);
+  if (failedCampaigns.length > 0) {
+    return Response.json(
+      {
+        error: `Newsletter send failures: ${failedCampaigns.join("; ")}`,
+        ...result.data,
+        failedCampaigns,
+      },
+      { status: 500 }
+    );
+  }
+
   return Response.json(result.data);
 }
 

--- a/src/app/api/hot-jobs/route.ts
+++ b/src/app/api/hot-jobs/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
 import { getJobApplyClicksLast7Days, determineHotJobs } from "@/services/posthog";
-import { db, jobs } from "@/db";
-import { inArray } from "drizzle-orm";
 
 export const revalidate = 3600; // Cache for 1 hour
 
@@ -17,15 +15,7 @@ export async function GET() {
     );
   }
 
-  // PostHog can contain stale job IDs; filter to jobs that still exist.
-  const ids = result.data.map((c) => c.id);
-  const existing = ids.length
-    ? await db.select({ id: jobs.id }).from(jobs).where(inArray(jobs.id, ids))
-    : [];
-  const existingSet = new Set(existing.map((r) => r.id));
-  const filteredClicks = result.data.filter((c) => existingSet.has(c.id));
-
-  const hotJobIds = determineHotJobs(filteredClicks, 5); // Top 5% by clicks
+  const hotJobIds = determineHotJobs(result.data, 5); // Top 5% by clicks
 
   return NextResponse.json({
     hotJobIds,

--- a/src/app/api/hot-jobs/route.ts
+++ b/src/app/api/hot-jobs/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { getJobApplyClicksLast7Days, determineHotJobs } from "@/services/posthog";
+import { db, jobs } from "@/db";
+import { inArray } from "drizzle-orm";
 
 export const revalidate = 3600; // Cache for 1 hour
 
@@ -15,7 +17,15 @@ export async function GET() {
     );
   }
 
-  const hotJobIds = determineHotJobs(result.data, 5); // Top 5% by clicks
+  // PostHog can contain stale job IDs; filter to jobs that still exist.
+  const ids = result.data.map((c) => c.id);
+  const existing = ids.length
+    ? await db.select({ id: jobs.id }).from(jobs).where(inArray(jobs.id, ids))
+    : [];
+  const existingSet = new Set(existing.map((r) => r.id));
+  const filteredClicks = result.data.filter((c) => existingSet.has(c.id));
+
+  const hotJobIds = determineHotJobs(filteredClicks, 5); // Top 5% by clicks
 
   return NextResponse.json({
     hotJobIds,

--- a/src/app/api/hot-news/route.ts
+++ b/src/app/api/hot-news/route.ts
@@ -16,9 +16,15 @@ export async function GET() {
   }
 
   const hotNewsIds = determineHotNews(result.data, 5); // Top 5 by clicks
+  const clickCounts: Record<string, number> = {};
+
+  for (const item of result.data) {
+    clickCounts[item.id] = item.count;
+  }
 
   return NextResponse.json({
     hotNewsIds,
+    clickCounts,
     updatedAt: new Date().toISOString(),
   });
 }

--- a/src/app/api/v1/admin/analytics/route.ts
+++ b/src/app/api/v1/admin/analytics/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { requireAuth } from "@/services/auth";
+import { db, jobs } from "@/db";
 import {
   getJobApplyClicksLast7Days,
   getCandidateViewsLast7Days,
@@ -7,6 +8,22 @@ import {
   getSiteStats,
   isPostHogConfigured,
 } from "@/services/posthog";
+import { inArray } from "drizzle-orm";
+
+async function filterJobClicksToExistingJobs(jobClicks: Record<string, number>) {
+  const ids = Object.keys(jobClicks);
+  if (ids.length === 0) return jobClicks;
+
+  // PostHog can contain stale job IDs (e.g. deleted jobs). Filter to current DB rows.
+  const existing = await db.select({ id: jobs.id }).from(jobs).where(inArray(jobs.id, ids));
+  const existingSet = new Set(existing.map((r) => r.id));
+
+  const filtered: Record<string, number> = {};
+  for (const [id, count] of Object.entries(jobClicks)) {
+    if (existingSet.has(id)) filtered[id] = count;
+  }
+  return filtered;
+}
 
 // GET /api/v1/admin/analytics - Get analytics data for admin
 export async function GET(request: NextRequest) {
@@ -33,7 +50,8 @@ export async function GET(request: NextRequest) {
       result.data.forEach(({ id, count }) => {
         jobClicks[id] = count;
       });
-      return Response.json({ data: jobClicks, configured });
+      const filtered = await filterJobClicksToExistingJobs(jobClicks);
+      return Response.json({ data: filtered, configured });
     }
 
     if (type === "candidates") {
@@ -87,6 +105,7 @@ export async function GET(request: NextRequest) {
         jobClicksMap[id] = count;
       });
     }
+    const filteredJobClicksMap = await filterJobClicksToExistingJobs(jobClicksMap);
 
     const candidateViewsMap: Record<string, number> = {};
     if (candidateResult.success) {
@@ -104,7 +123,7 @@ export async function GET(request: NextRequest) {
 
     return Response.json({
       data: {
-        jobClicks: jobClicksMap,
+        jobClicks: filteredJobClicksMap,
         candidateViews: candidateViewsMap,
         blogViews: blogViewsMap,
         siteStats,

--- a/src/app/api/v1/newsletter/campaigns/[id]/route.ts
+++ b/src/app/api/v1/newsletter/campaigns/[id]/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/services/auth";
+import {
+  deleteNewsletterCampaign,
+  getNewsletterCampaignById,
+  updateNewsletterCampaign,
+} from "@/services/newsletter";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await requireAuth(request, "admin:read");
+  if (auth instanceof Response) return auth;
+
+  const { id } = await params;
+  const result = await getNewsletterCampaignById(id);
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json({ data: result.data });
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+
+  let body: {
+    newsletterType?: string;
+    subject?: string;
+    previewText?: string | null;
+    periodDays?: number;
+    scheduledAt?: string | null;
+    contentMode?: string;
+    markdownContent?: string | null;
+    manualHtml?: string | null;
+    manualText?: string | null;
+  };
+
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { id } = await params;
+  const result = await updateNewsletterCampaign(id, body);
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json({ data: result.data });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+
+  const { id } = await params;
+  const result = await deleteNewsletterCampaign(id);
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json({ data: result.data });
+}
+

--- a/src/app/api/v1/newsletter/campaigns/[id]/schedule/route.ts
+++ b/src/app/api/v1/newsletter/campaigns/[id]/schedule/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/services/auth";
+import { scheduleNewsletterCampaign } from "@/services/newsletter";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+
+  let body: { scheduledAt?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.scheduledAt) {
+    return Response.json({ error: "scheduledAt is required" }, { status: 400 });
+  }
+
+  const { id } = await params;
+  const result = await scheduleNewsletterCampaign(id, body.scheduledAt);
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json({ data: result.data });
+}

--- a/src/app/api/v1/newsletter/campaigns/[id]/send/route.ts
+++ b/src/app/api/v1/newsletter/campaigns/[id]/send/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/services/auth";
+import { sendNewsletterCampaignNow } from "@/services/newsletter";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+
+  const { id } = await params;
+  const result = await sendNewsletterCampaignNow(id);
+
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json(result.data);
+}

--- a/src/app/api/v1/newsletter/campaigns/auto-create-weekly/route.ts
+++ b/src/app/api/v1/newsletter/campaigns/auto-create-weekly/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/services/auth";
+import { createWeeklyNewsCampaignIssue } from "@/services/newsletter";
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+
+  let body: {
+    periodDays?: number;
+    createdBy?: string;
+    scheduledAt?: string;
+  };
+
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const result = await createWeeklyNewsCampaignIssue({
+    periodDays: body.periodDays,
+    createdBy: body.createdBy,
+    scheduledAt: body.scheduledAt,
+  });
+
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json({ data: result.data }, { status: result.data.created ? 201 : 200 });
+}

--- a/src/app/api/v1/newsletter/campaigns/preview/route.ts
+++ b/src/app/api/v1/newsletter/campaigns/preview/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { requireAuth } from "@/services/auth";
-import { renderNewsletterTemplatePreview } from "@/services/newsletter";
+import { previewNewsletterCampaignDraft } from "@/services/newsletter";
 
 export async function POST(request: NextRequest) {
   const auth = await requireAuth(request, "admin:read");
@@ -8,12 +8,12 @@ export async function POST(request: NextRequest) {
 
   let body: {
     newsletterType?: string;
+    subject?: string;
     periodDays?: number;
-    campaignSubject?: string;
-    subjectTemplate?: string;
-    htmlTemplate?: string;
-    textTemplate?: string;
-    markdownTemplate?: string;
+    contentMode?: string;
+    markdownContent?: string | null;
+    manualHtml?: string | null;
+    manualText?: string | null;
   };
 
   try {
@@ -22,14 +22,14 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const result = await renderNewsletterTemplatePreview({
+  const result = await previewNewsletterCampaignDraft({
     newsletterType: body.newsletterType || "",
+    subject: body.subject || "",
     periodDays: body.periodDays,
-    campaignSubject: body.campaignSubject,
-    subjectTemplate: body.subjectTemplate,
-    htmlTemplate: body.htmlTemplate,
-    textTemplate: body.textTemplate,
-    markdownTemplate: body.markdownTemplate,
+    contentMode: body.contentMode,
+    markdownContent: body.markdownContent,
+    manualHtml: body.manualHtml,
+    manualText: body.manualText,
   });
 
   if (!result.ok) {
@@ -38,3 +38,4 @@ export async function POST(request: NextRequest) {
 
   return Response.json({ data: result.data });
 }
+

--- a/src/app/api/v1/newsletter/campaigns/route.ts
+++ b/src/app/api/v1/newsletter/campaigns/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/services/auth";
+import { createNewsletterCampaign, listNewsletterCampaigns } from "@/services/newsletter";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request, "admin:read");
+  if (auth instanceof Response) return auth;
+
+  const url = new URL(request.url);
+  const limit = parseInt(url.searchParams.get("limit") || "50", 10);
+  const campaigns = await listNewsletterCampaigns(Number.isNaN(limit) ? 50 : limit);
+  return Response.json({ data: campaigns });
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+
+  let body: {
+    newsletterType?: string;
+    subject?: string;
+    previewText?: string;
+    periodDays?: number;
+    scheduledAt?: string;
+    createdBy?: string;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await createNewsletterCampaign({
+    newsletterType: body.newsletterType || "",
+    subject: body.subject || "",
+    previewText: body.previewText,
+    periodDays: body.periodDays,
+    scheduledAt: body.scheduledAt,
+    createdBy: body.createdBy,
+  });
+
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json({ data: result.data }, { status: 201 });
+}

--- a/src/app/api/v1/newsletter/campaigns/route.ts
+++ b/src/app/api/v1/newsletter/campaigns/route.ts
@@ -23,6 +23,10 @@ export async function POST(request: NextRequest) {
     periodDays?: number;
     scheduledAt?: string;
     createdBy?: string;
+    contentMode?: string;
+    markdownContent?: string;
+    manualHtml?: string;
+    manualText?: string;
   };
   try {
     body = await request.json();
@@ -37,6 +41,10 @@ export async function POST(request: NextRequest) {
     periodDays: body.periodDays,
     scheduledAt: body.scheduledAt,
     createdBy: body.createdBy,
+    contentMode: body.contentMode,
+    markdownContent: body.markdownContent,
+    manualHtml: body.manualHtml,
+    manualText: body.manualText,
   });
 
   if (!result.ok) {

--- a/src/app/api/v1/newsletter/confirm/route.ts
+++ b/src/app/api/v1/newsletter/confirm/route.ts
@@ -1,0 +1,19 @@
+import { confirmNewsletterSubscription } from "@/services/newsletter";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+  if (!token) {
+    return Response.json({ error: "Missing token" }, { status: 400 });
+  }
+
+  const result = await confirmNewsletterSubscription(token);
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return new Response(
+    "<html><body><h2>Subscription confirmed</h2><p>You can close this page.</p></body></html>",
+    { headers: { "Content-Type": "text/html; charset=utf-8" } }
+  );
+}

--- a/src/app/api/v1/newsletter/confirm/route.ts
+++ b/src/app/api/v1/newsletter/confirm/route.ts
@@ -12,8 +12,74 @@ export async function GET(request: Request) {
     return Response.json({ error: result.error }, { status: result.status });
   }
 
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://dcbuilder.dev";
   return new Response(
-    "<html><body><h2>Subscription confirmed</h2><p>You can close this page.</p></body></html>",
+    `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Subscription confirmed</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+      background: #fafafa;
+      color: #171717;
+    }
+    .card {
+      max-width: 400px;
+      width: 100%;
+      margin: 24px;
+      padding: 48px 32px;
+      background: #fff;
+      border: 1px solid #e5e5e5;
+      border-radius: 16px;
+      text-align: center;
+    }
+    .check {
+      width: 56px;
+      height: 56px;
+      margin: 0 auto 24px;
+      background: #171717;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .check svg { width: 28px; height: 28px; }
+    h1 { font-size: 22px; font-weight: 700; margin-bottom: 8px; }
+    p { font-size: 15px; color: #525252; line-height: 1.5; margin-bottom: 24px; }
+    a {
+      display: inline-block;
+      background: #171717;
+      color: #fff;
+      font-size: 14px;
+      font-weight: 600;
+      padding: 10px 28px;
+      border-radius: 8px;
+      text-decoration: none;
+    }
+    a:hover { background: #404040; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="check">
+      <svg fill="none" viewBox="0 0 24 24" stroke="white" stroke-width="2.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+      </svg>
+    </div>
+    <h1>You're subscribed!</h1>
+    <p>Your subscription has been confirmed. You'll receive updates in your inbox soon.</p>
+    <a href="${baseUrl}/news">Browse latest news</a>
+  </div>
+</body>
+</html>`,
     { headers: { "Content-Type": "text/html; charset=utf-8" } }
   );
 }

--- a/src/app/api/v1/newsletter/preferences/route.ts
+++ b/src/app/api/v1/newsletter/preferences/route.ts
@@ -1,0 +1,36 @@
+import { getPreferenceContext, updatePreferencesByToken } from "@/services/newsletter";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+  if (!token) {
+    return Response.json({ error: "Missing token" }, { status: 400 });
+  }
+
+  const result = await getPreferenceContext(token);
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json(result.data);
+}
+
+export async function PUT(request: Request) {
+  let body: { token?: string; newsletterTypes?: string[] };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.token) {
+    return Response.json({ error: "Missing token" }, { status: 400 });
+  }
+
+  const result = await updatePreferencesByToken(body.token, body.newsletterTypes || []);
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json({ ok: true });
+}

--- a/src/app/api/v1/newsletter/preferences/route.ts
+++ b/src/app/api/v1/newsletter/preferences/route.ts
@@ -1,5 +1,189 @@
 import { getPreferenceContext, updatePreferencesByToken } from "@/services/newsletter";
 
+const NEWSLETTER_LABELS: Record<string, string> = {
+  news: "News digest",
+  jobs: "Jobs updates",
+  candidates: "Candidate updates",
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function renderPreferencePage(token: string, data: {
+  email: string;
+  preferences: Array<{ type: string; enabled: boolean }>;
+}) {
+  const checkboxes = data.preferences.map((preference) => `
+    <label class="option">
+      <input
+        type="checkbox"
+        name="newsletterType"
+        value="${escapeHtml(preference.type)}"
+        ${preference.enabled ? "checked" : ""}
+      />
+      <span>${escapeHtml(NEWSLETTER_LABELS[preference.type] || preference.type)}</span>
+    </label>
+  `).join("");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Newsletter preferences</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      background: #fafafa;
+      color: #171717;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    .card {
+      width: 100%;
+      max-width: 560px;
+      background: #fff;
+      border: 1px solid #e5e5e5;
+      border-radius: 20px;
+      padding: 32px;
+      box-shadow: 0 12px 48px rgba(23, 23, 23, 0.06);
+    }
+    h1 {
+      margin: 0 0 12px;
+      font-size: 28px;
+      line-height: 1.1;
+    }
+    p {
+      margin: 0 0 16px;
+      color: #525252;
+      line-height: 1.6;
+    }
+    .email {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      background: #f5f5f5;
+      padding: 8px 12px;
+      margin-bottom: 20px;
+      font-size: 14px;
+      color: #404040;
+    }
+    form {
+      display: grid;
+      gap: 12px;
+    }
+    .option {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 16px;
+      border: 1px solid #e5e5e5;
+      border-radius: 14px;
+      background: #fafafa;
+      font-size: 15px;
+    }
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-top: 8px;
+      flex-wrap: wrap;
+    }
+    button {
+      border: 0;
+      border-radius: 999px;
+      background: #171717;
+      color: #fff;
+      padding: 12px 18px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    button:disabled {
+      opacity: 0.6;
+      cursor: default;
+    }
+    .status {
+      min-height: 20px;
+      font-size: 14px;
+      color: #525252;
+    }
+    .status.error {
+      color: #b91c1c;
+    }
+    .status.success {
+      color: #15803d;
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <h1>Manage your newsletter preferences</h1>
+    <p>Choose which updates you want to keep receiving.</p>
+    <div class="email">${escapeHtml(data.email)}</div>
+    <form id="preferences-form">
+      ${checkboxes}
+      <div class="actions">
+        <button id="submit-button" type="submit">Save preferences</button>
+        <div id="status" class="status" aria-live="polite"></div>
+      </div>
+    </form>
+  </main>
+  <script>
+    const token = ${JSON.stringify(token)};
+    const form = document.getElementById("preferences-form");
+    const status = document.getElementById("status");
+    const submitButton = document.getElementById("submit-button");
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      submitButton.disabled = true;
+      status.className = "status";
+      status.textContent = "Saving...";
+
+      const newsletterTypes = Array.from(form.querySelectorAll('input[name="newsletterType"]:checked'))
+        .map((input) => input.value);
+
+      try {
+        const response = await fetch(window.location.pathname, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token, newsletterTypes }),
+        });
+        const payload = await response.json();
+
+        if (!response.ok) {
+          status.className = "status error";
+          status.textContent = payload.error || "Unable to save preferences.";
+          return;
+        }
+
+        status.className = "status success";
+        status.textContent = newsletterTypes.length > 0
+          ? "Preferences saved."
+          : "You have been unsubscribed from all newsletter updates.";
+      } catch {
+        status.className = "status error";
+        status.textContent = "Unable to save preferences right now.";
+      } finally {
+        submitButton.disabled = false;
+      }
+    });
+  </script>
+</body>
+</html>`;
+}
+
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const token = url.searchParams.get("token");
@@ -12,7 +196,9 @@ export async function GET(request: Request) {
     return Response.json({ error: result.error }, { status: result.status });
   }
 
-  return Response.json(result.data);
+  return new Response(renderPreferencePage(token, result.data), {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
 }
 
 export async function PUT(request: Request) {

--- a/src/app/api/v1/newsletter/subscribe/route.ts
+++ b/src/app/api/v1/newsletter/subscribe/route.ts
@@ -1,0 +1,22 @@
+import { subscribeToNewsletters } from "@/services/newsletter";
+
+export async function POST(request: Request) {
+  let body: { email?: string; newsletterTypes?: string[]; source?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await subscribeToNewsletters({
+    email: body.email || "",
+    newsletterTypes: body.newsletterTypes || [],
+    source: body.source || "news-page",
+  });
+
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json(result);
+}

--- a/src/app/api/v1/newsletter/subscribers/[id]/route.ts
+++ b/src/app/api/v1/newsletter/subscribers/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/services/auth";
+import { adminUpdateSubscriberPreferences } from "@/services/newsletter-admin";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+
+  let body: { newsletterTypes?: string[] };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!Array.isArray(body.newsletterTypes)) {
+    return Response.json({ error: "newsletterTypes must be an array" }, { status: 400 });
+  }
+
+  const { id } = await params;
+  const result = await adminUpdateSubscriberPreferences(id, body.newsletterTypes);
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json({ data: result.data });
+}

--- a/src/app/api/v1/newsletter/subscribers/route.ts
+++ b/src/app/api/v1/newsletter/subscribers/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { requireAuth } from "@/services/auth";
 import { db, newsletterSubscribers, newsletterPreferences } from "@/db";
 import { count, desc, eq, inArray } from "drizzle-orm";
+import { getEmailClicksLast7Days } from "@/services/posthog";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAuth(request, "admin:read");
@@ -42,6 +43,9 @@ export async function GET(request: NextRequest) {
           .where(inArray(newsletterPreferences.subscriberId, subscriberIds))
       : [];
 
+  // Fetch click analytics from PostHog
+  const clickResult = await getEmailClicksLast7Days();
+
   // Group preferences by subscriber ID
   const preferencesBySubscriber = new Map<string, typeof preferences>();
   for (const pref of preferences) {
@@ -53,11 +57,27 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  // Merge subscribers with their preferences
-  const data = subscribers.map((subscriber) => ({
-    ...subscriber,
-    preferences: preferencesBySubscriber.get(subscriber.id) || [],
-  }));
+  // Build click data map keyed by email
+  const clicksByEmail = new Map<string, { clicks7d: number; lastClickedLink: string }>();
+  if (clickResult.success) {
+    for (const row of clickResult.data) {
+      clicksByEmail.set(row.email, {
+        clicks7d: row.count,
+        lastClickedLink: row.lastClickedLink,
+      });
+    }
+  }
+
+  // Merge subscribers with their preferences and click analytics
+  const data = subscribers.map((subscriber) => {
+    const clickData = clicksByEmail.get(subscriber.email);
+    return {
+      ...subscriber,
+      preferences: preferencesBySubscriber.get(subscriber.id) || [],
+      clicks7d: clickData?.clicks7d ?? 0,
+      lastClickedLink: clickData?.lastClickedLink ?? null,
+    };
+  });
 
   return Response.json({
     data,

--- a/src/app/api/v1/newsletter/subscribers/route.ts
+++ b/src/app/api/v1/newsletter/subscribers/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/services/auth";
+import { db, newsletterSubscribers, newsletterPreferences } from "@/db";
+import { count, desc, eq, inArray } from "drizzle-orm";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request, "admin:read");
+  if (auth instanceof Response) return auth;
+
+  const url = new URL(request.url);
+  const rawLimit = parseInt(url.searchParams.get("limit") || "100", 10);
+  const limit = Math.min(Number.isNaN(rawLimit) ? 100 : rawLimit, 500);
+  const rawOffset = parseInt(url.searchParams.get("offset") || "0", 10);
+  const offset = Number.isNaN(rawOffset) ? 0 : rawOffset;
+  const status = url.searchParams.get("status");
+
+  // Build where condition
+  const where = status ? eq(newsletterSubscribers.status, status) : undefined;
+
+  // Fetch subscribers and total count in parallel
+  const [subscribers, [totalRow]] = await Promise.all([
+    db
+      .select()
+      .from(newsletterSubscribers)
+      .where(where)
+      .orderBy(desc(newsletterSubscribers.createdAt))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ total: count() })
+      .from(newsletterSubscribers)
+      .where(where),
+  ]);
+
+  // Fetch preferences for the returned subscribers
+  const subscriberIds = subscribers.map((s) => s.id);
+  const preferences =
+    subscriberIds.length > 0
+      ? await db
+          .select()
+          .from(newsletterPreferences)
+          .where(inArray(newsletterPreferences.subscriberId, subscriberIds))
+      : [];
+
+  // Group preferences by subscriber ID
+  const preferencesBySubscriber = new Map<string, typeof preferences>();
+  for (const pref of preferences) {
+    const existing = preferencesBySubscriber.get(pref.subscriberId);
+    if (existing) {
+      existing.push(pref);
+    } else {
+      preferencesBySubscriber.set(pref.subscriberId, [pref]);
+    }
+  }
+
+  // Merge subscribers with their preferences
+  const data = subscribers.map((subscriber) => ({
+    ...subscriber,
+    preferences: preferencesBySubscriber.get(subscriber.id) || [],
+  }));
+
+  return Response.json({
+    data,
+    total: totalRow?.total ?? 0,
+    limit,
+    offset,
+  });
+}

--- a/src/app/api/v1/newsletter/templates/preview/route.ts
+++ b/src/app/api/v1/newsletter/templates/preview/route.ts
@@ -9,6 +9,7 @@ export async function POST(request: NextRequest) {
   let body: {
     newsletterType?: string;
     periodDays?: number;
+    campaignSubject?: string;
     subjectTemplate?: string;
     htmlTemplate?: string;
     textTemplate?: string;
@@ -23,6 +24,7 @@ export async function POST(request: NextRequest) {
   const result = await renderNewsletterTemplatePreview({
     newsletterType: body.newsletterType || "",
     periodDays: body.periodDays,
+    campaignSubject: body.campaignSubject,
     subjectTemplate: body.subjectTemplate,
     htmlTemplate: body.htmlTemplate,
     textTemplate: body.textTemplate,

--- a/src/app/api/v1/newsletter/templates/preview/route.ts
+++ b/src/app/api/v1/newsletter/templates/preview/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/services/auth";
+import { renderNewsletterTemplatePreview } from "@/services/newsletter";
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request, "admin:read");
+  if (auth instanceof Response) return auth;
+
+  let body: {
+    newsletterType?: string;
+    periodDays?: number;
+    subjectTemplate?: string;
+    htmlTemplate?: string;
+    textTemplate?: string;
+  };
+
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await renderNewsletterTemplatePreview({
+    newsletterType: body.newsletterType || "",
+    periodDays: body.periodDays,
+    subjectTemplate: body.subjectTemplate,
+    htmlTemplate: body.htmlTemplate,
+    textTemplate: body.textTemplate,
+  });
+
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json({ data: result.data });
+}

--- a/src/app/api/v1/newsletter/templates/route.ts
+++ b/src/app/api/v1/newsletter/templates/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/services/auth";
+import { listNewsletterTemplates, upsertNewsletterTemplate } from "@/services/newsletter";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request, "admin:read");
+  if (auth instanceof Response) return auth;
+
+  const templates = await listNewsletterTemplates();
+  return Response.json({ data: templates });
+}
+
+export async function PUT(request: NextRequest) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+
+  let body: {
+    newsletterType?: string;
+    subjectTemplate?: string;
+    htmlTemplate?: string;
+    textTemplate?: string;
+  };
+
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await upsertNewsletterTemplate({
+    newsletterType: body.newsletterType || "",
+    subjectTemplate: body.subjectTemplate || "",
+    htmlTemplate: body.htmlTemplate || "",
+    textTemplate: body.textTemplate || "",
+  });
+
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return Response.json({ data: result.data });
+}

--- a/src/app/api/v1/newsletter/templates/route.ts
+++ b/src/app/api/v1/newsletter/templates/route.ts
@@ -19,6 +19,7 @@ export async function PUT(request: NextRequest) {
     subjectTemplate?: string;
     htmlTemplate?: string;
     textTemplate?: string;
+    markdownTemplate?: string;
   };
 
   try {
@@ -32,6 +33,7 @@ export async function PUT(request: NextRequest) {
     subjectTemplate: body.subjectTemplate || "",
     htmlTemplate: body.htmlTemplate || "",
     textTemplate: body.textTemplate || "",
+    markdownTemplate: body.markdownTemplate || "",
   });
 
   if (!result.ok) {

--- a/src/app/api/v1/newsletter/unsubscribe/route.ts
+++ b/src/app/api/v1/newsletter/unsubscribe/route.ts
@@ -1,0 +1,19 @@
+import { unsubscribeByToken } from "@/services/newsletter";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+  if (!token) {
+    return Response.json({ error: "Missing token" }, { status: 400 });
+  }
+
+  const result = await unsubscribeByToken(token);
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
+
+  return new Response(
+    "<html><body><h2>Unsubscribed</h2><p>You will no longer receive this newsletter type.</p></body></html>",
+    { headers: { "Content-Type": "text/html; charset=utf-8" } }
+  );
+}

--- a/src/app/api/v1/webhooks/resend/route.ts
+++ b/src/app/api/v1/webhooks/resend/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createHmac, timingSafeEqual } from "crypto";
 import { db, newsletterSendEvents } from "@/db";
 
 interface ResendWebhookPayload {
@@ -20,17 +21,41 @@ interface ResendWebhookPayload {
 
 const RESEND_WEBHOOK_SECRET = process.env.RESEND_WEBHOOK_SECRET;
 
+function verifySvixSignature(secret: string, msgId: string, timestamp: string, body: string, signatures: string): boolean {
+  const toSign = `${msgId}.${timestamp}.${body}`;
+  // Svix secrets are base64-encoded with "whsec_" prefix
+  const secretBytes = Buffer.from(secret.startsWith("whsec_") ? secret.slice(6) : secret, "base64");
+  const expected = createHmac("sha256", secretBytes).update(toSign).digest("base64");
+  // signatures is space-separated list of "v1,<base64>" entries
+  return signatures.split(" ").some((sig) => {
+    const parts = sig.split(",");
+    if (parts.length < 2 || parts[0] !== "v1") return false;
+    try {
+      return timingSafeEqual(Buffer.from(expected), Buffer.from(parts[1]));
+    } catch {
+      return false;
+    }
+  });
+}
+
 export async function POST(request: NextRequest) {
+  const body = await request.text();
+
   if (RESEND_WEBHOOK_SECRET) {
-    const signature = request.headers.get("svix-signature");
-    if (!signature) {
-      return NextResponse.json({ error: "Missing signature" }, { status: 401 });
+    const svixId = request.headers.get("svix-id");
+    const svixTimestamp = request.headers.get("svix-timestamp");
+    const svixSignature = request.headers.get("svix-signature");
+    if (!svixId || !svixTimestamp || !svixSignature) {
+      return NextResponse.json({ error: "Missing signature headers" }, { status: 401 });
+    }
+    if (!verifySvixSignature(RESEND_WEBHOOK_SECRET, svixId, svixTimestamp, body, svixSignature)) {
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
     }
   }
 
   let payload: ResendWebhookPayload;
   try {
-    payload = await request.json();
+    payload = JSON.parse(body);
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }

--- a/src/app/api/v1/webhooks/resend/route.ts
+++ b/src/app/api/v1/webhooks/resend/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db, newsletterSendEvents } from "@/db";
+
+interface ResendWebhookPayload {
+  type: string;
+  created_at: string;
+  data: {
+    email_id: string;
+    from: string;
+    to: string[];
+    subject: string;
+    click?: {
+      ipAddress: string;
+      link: string;
+      timestamp: string;
+      userAgent: string;
+    };
+  };
+}
+
+const RESEND_WEBHOOK_SECRET = process.env.RESEND_WEBHOOK_SECRET;
+
+export async function POST(request: NextRequest) {
+  if (RESEND_WEBHOOK_SECRET) {
+    const signature = request.headers.get("svix-signature");
+    if (!signature) {
+      return NextResponse.json({ error: "Missing signature" }, { status: 401 });
+    }
+  }
+
+  let payload: ResendWebhookPayload;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const eventType = payload.type;
+
+  // Forward click events to PostHog
+  if (eventType === "email.clicked" && payload.data.click) {
+    const posthogApiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    const posthogHost =
+      process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.posthog.com";
+
+    if (posthogApiKey) {
+      const distinctId = payload.data.to?.[0] || "anonymous";
+      await fetch(`${posthogHost}/capture/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          api_key: posthogApiKey,
+          event: "email_link_clicked",
+          distinct_id: distinctId,
+          properties: {
+            email_id: payload.data.email_id,
+            link: payload.data.click.link,
+            subject: payload.data.subject,
+            user_agent: payload.data.click.userAgent,
+            ip: payload.data.click.ipAddress,
+            $current_url: payload.data.click.link,
+          },
+          timestamp: payload.data.click.timestamp,
+        }),
+      }).catch(() => {});
+    }
+  }
+
+  // Log bounce/complaint events to newsletter_send_events
+  if (eventType === "email.bounced" || eventType === "email.complained") {
+    const mappedType =
+      eventType === "email.bounced" ? "bounced" : "complained";
+    await db
+      .insert(newsletterSendEvents)
+      .values({
+        campaignId: "webhook",
+        eventType: mappedType,
+        provider: "resend",
+        providerMessageId: payload.data.email_id,
+        payload: JSON.stringify(payload.data),
+      })
+      .catch(() => {});
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/src/app/api/v1/webhooks/resend/route.ts
+++ b/src/app/api/v1/webhooks/resend/route.ts
@@ -19,8 +19,6 @@ interface ResendWebhookPayload {
   };
 }
 
-const RESEND_WEBHOOK_SECRET = process.env.RESEND_WEBHOOK_SECRET;
-
 function verifySvixSignature(secret: string, msgId: string, timestamp: string, body: string, signatures: string): boolean {
   const toSign = `${msgId}.${timestamp}.${body}`;
   // Svix secrets are base64-encoded with "whsec_" prefix
@@ -40,17 +38,23 @@ function verifySvixSignature(secret: string, msgId: string, timestamp: string, b
 
 export async function POST(request: NextRequest) {
   const body = await request.text();
+  const resendWebhookSecret = process.env.RESEND_WEBHOOK_SECRET;
 
-  if (RESEND_WEBHOOK_SECRET) {
-    const svixId = request.headers.get("svix-id");
-    const svixTimestamp = request.headers.get("svix-timestamp");
-    const svixSignature = request.headers.get("svix-signature");
-    if (!svixId || !svixTimestamp || !svixSignature) {
-      return NextResponse.json({ error: "Missing signature headers" }, { status: 401 });
-    }
-    if (!verifySvixSignature(RESEND_WEBHOOK_SECRET, svixId, svixTimestamp, body, svixSignature)) {
-      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
-    }
+  if (!resendWebhookSecret) {
+    return NextResponse.json(
+      { error: "RESEND_WEBHOOK_SECRET is not configured" },
+      { status: 503 }
+    );
+  }
+
+  const svixId = request.headers.get("svix-id");
+  const svixTimestamp = request.headers.get("svix-timestamp");
+  const svixSignature = request.headers.get("svix-signature");
+  if (!svixId || !svixTimestamp || !svixSignature) {
+    return NextResponse.json({ error: "Missing signature headers" }, { status: 401 });
+  }
+  if (!verifySvixSignature(resendWebhookSecret, svixId, svixTimestamp, body, svixSignature)) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
   }
 
   let payload: ResendWebhookPayload;

--- a/src/app/news/opengraph-image.tsx
+++ b/src/app/news/opengraph-image.tsx
@@ -1,0 +1,58 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+export const alt = "News | dcbuilder.eth";
+export const size = {
+	width: 1200,
+	height: 630,
+};
+export const contentType = "image/png";
+
+export default async function Image() {
+	return new ImageResponse(
+		(
+			<div
+				style={{
+					height: "100%",
+					width: "100%",
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+					justifyContent: "center",
+					backgroundColor: "#0a0a0a",
+					backgroundImage:
+						"radial-gradient(circle at 50% 100%, #2a1a2e 0%, #0a0a0a 55%)",
+				}}
+			>
+				<div style={{ fontSize: 100, marginBottom: 32 }}>📰</div>
+
+				<div
+					style={{
+						fontSize: 84,
+						fontWeight: 700,
+						color: "#ffffff",
+						marginBottom: 18,
+						textAlign: "center",
+					}}
+				>
+					News | dcbuilder.eth
+				</div>
+
+				<div
+					style={{
+						fontSize: 36,
+						color: "#ddd",
+						textAlign: "center",
+						maxWidth: 900,
+						lineHeight: 1.25,
+					}}
+				>
+					Curated links, blog posts, and portfolio announcements
+				</div>
+			</div>
+		),
+		{ ...size }
+	);
+}
+

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { Navbar } from "@/components/Navbar";
 import { NewsGrid } from "@/components/NewsGrid";
+import { NewsletterSignup } from "@/components/NewsletterSignup";
 import { getAllNews } from "@/lib/news";
 
 export const metadata = {
@@ -27,6 +28,10 @@ export default async function NewsPage() {
               Curated articles, my blog posts, and announcements from portfolio
               companies.
             </p>
+          </div>
+
+          <div className="mb-8 sm:mb-10">
+            <NewsletterSignup />
           </div>
 
           {/* News Grid */}

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { Navbar } from "@/components/Navbar";
 import { NewsGrid } from "@/components/NewsGrid";
+import { NewsletterArchivePreview } from "@/components/NewsletterArchivePreview";
 import { NewsletterSignup } from "@/components/NewsletterSignup";
 import { Recommendations } from "@/components/Recommendations";
 import { getAllNews } from "@/lib/news";
@@ -33,6 +34,7 @@ export default async function NewsPage() {
 
           <div className="mb-8 sm:mb-10 space-y-4">
             <NewsletterSignup />
+            <NewsletterArchivePreview />
             <Recommendations />
           </div>
 

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,9 +1,7 @@
 import { Suspense } from "react";
 import { Navbar } from "@/components/Navbar";
 import { NewsGrid } from "@/components/NewsGrid";
-import { NewsletterArchivePreview } from "@/components/NewsletterArchivePreview";
-import { NewsletterSignup } from "@/components/NewsletterSignup";
-import { Recommendations } from "@/components/Recommendations";
+import { NewsTools } from "@/components/NewsTools";
 import { getAllNews } from "@/lib/news";
 
 export const metadata = {
@@ -22,9 +20,9 @@ export default async function NewsPage() {
     <>
       <Navbar />
       <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
-        <div className="max-w-4xl mx-auto py-8 sm:py-12">
+        <div className="max-w-5xl mx-auto py-8 sm:py-10">
           {/* Header */}
-          <div className="text-center mb-8 sm:mb-12">
+          <div className="text-center mb-6 sm:mb-8">
             <h1 className="text-3xl sm:text-4xl font-bold mb-4">News</h1>
             <p className="text-neutral-600 dark:text-neutral-400 max-w-2xl mx-auto">
               Curated articles, my blog posts, and announcements from portfolio
@@ -32,10 +30,8 @@ export default async function NewsPage() {
             </p>
           </div>
 
-          <div className="mb-8 sm:mb-10 space-y-4">
-            <NewsletterSignup />
-            <NewsletterArchivePreview />
-            <Recommendations />
+          <div className="mb-6 sm:mb-8">
+            <NewsTools />
           </div>
 
           {/* News Grid */}

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { Navbar } from "@/components/Navbar";
 import { NewsGrid } from "@/components/NewsGrid";
 import { NewsletterSignup } from "@/components/NewsletterSignup";
+import { Recommendations } from "@/components/Recommendations";
 import { getAllNews } from "@/lib/news";
 
 export const metadata = {
@@ -30,8 +31,9 @@ export default async function NewsPage() {
             </p>
           </div>
 
-          <div className="mb-8 sm:mb-10">
+          <div className="mb-8 sm:mb-10 space-y-4">
             <NewsletterSignup />
+            <Recommendations />
           </div>
 
           {/* News Grid */}

--- a/src/app/newsletters/[id]/loading.tsx
+++ b/src/app/newsletters/[id]/loading.tsx
@@ -1,0 +1,23 @@
+import { Navbar } from "@/components/Navbar";
+
+export default function NewsletterViewLoading() {
+  return (
+    <>
+      <Navbar />
+      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+        <div className="max-w-4xl mx-auto py-8 sm:py-12">
+          <div className="mb-6">
+            <div className="h-4 w-28 bg-neutral-200 dark:bg-neutral-800 rounded animate-pulse" />
+          </div>
+
+          <div className="mb-6 space-y-3">
+            <div className="h-8 w-2/3 bg-neutral-200 dark:bg-neutral-800 rounded-lg animate-pulse" />
+            <div className="h-4 w-40 bg-neutral-100 dark:bg-neutral-800/60 rounded animate-pulse" />
+          </div>
+
+          <div className="rounded-xl border border-neutral-200 dark:border-neutral-800 overflow-hidden bg-white min-h-[400px] animate-pulse" />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/newsletters/[id]/page.tsx
+++ b/src/app/newsletters/[id]/page.tsx
@@ -1,0 +1,73 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { Navbar } from "@/components/Navbar";
+import { NewsletterIframe } from "@/components/NewsletterIframe";
+import { getSentNewsletterCampaignForArchive } from "@/services/newsletter";
+
+export const dynamic = "force-dynamic";
+
+type Props = { params: Promise<{ id: string }> };
+
+export async function generateMetadata({ params }: Props) {
+  const { id } = await params;
+  const campaign = await getSentNewsletterCampaignForArchive(id);
+
+  if (!campaign) {
+    return { title: "Newsletter Not Found" };
+  }
+
+  return {
+    title: campaign.subject,
+    description: campaign.previewText ?? `Newsletter: ${campaign.subject}`,
+  };
+}
+
+export default async function NewsletterViewPage({ params }: Props) {
+  const { id } = await params;
+  const campaign = await getSentNewsletterCampaignForArchive(id);
+
+  if (!campaign) {
+    notFound();
+  }
+
+  return (
+    <>
+      <Navbar />
+      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+        <div className="max-w-4xl mx-auto py-8 sm:py-12">
+          <div className="mb-6">
+            <Link
+              href="/newsletters"
+              className="text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
+            >
+              &larr; All Newsletters
+            </Link>
+          </div>
+
+          <div className="mb-6">
+            <h1 className="text-2xl sm:text-3xl font-bold mb-2">
+              {campaign.subject}
+            </h1>
+            {campaign.sentAt && (
+              <time
+                dateTime={campaign.sentAt.toISOString()}
+                className="text-sm text-neutral-500 dark:text-neutral-400"
+              >
+                {campaign.sentAt.toLocaleDateString("en-US", {
+                  weekday: "long",
+                  month: "long",
+                  day: "numeric",
+                  year: "numeric",
+                })}
+              </time>
+            )}
+          </div>
+
+          <div className="rounded-xl border border-neutral-200 dark:border-neutral-800 overflow-hidden bg-white">
+            <NewsletterIframe html={campaign.renderedHtml!} />
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/newsletters/loading.tsx
+++ b/src/app/newsletters/loading.tsx
@@ -1,0 +1,37 @@
+import { Navbar } from "@/components/Navbar";
+
+export default function NewslettersLoading() {
+  return (
+    <>
+      <Navbar />
+      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+        <div className="max-w-4xl mx-auto py-8 sm:py-12">
+          <div className="text-center mb-8 sm:mb-12">
+            <div className="h-9 w-64 bg-neutral-200 dark:bg-neutral-800 rounded-lg mx-auto mb-4 animate-pulse" />
+            <div className="h-5 w-48 bg-neutral-200 dark:bg-neutral-800 rounded mx-auto animate-pulse" />
+          </div>
+
+          <div className="space-y-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="rounded-xl border border-neutral-200 dark:border-neutral-800 p-4 sm:p-5 animate-pulse"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1 space-y-2">
+                    <div className="h-5 w-3/4 bg-neutral-200 dark:bg-neutral-800 rounded" />
+                    <div className="h-4 w-1/2 bg-neutral-100 dark:bg-neutral-800/60 rounded" />
+                  </div>
+                  <div className="flex flex-col items-end gap-2">
+                    <div className="h-5 w-14 bg-neutral-200 dark:bg-neutral-800 rounded-full" />
+                    <div className="h-3 w-20 bg-neutral-100 dark:bg-neutral-800/60 rounded" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/newsletters/page.tsx
+++ b/src/app/newsletters/page.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+import { Navbar } from "@/components/Navbar";
+import {
+  listSentNewsletterCampaigns,
+} from "@/services/newsletter";
+
+export const metadata = {
+  title: "Newsletter Archive",
+  description:
+    "Browse past newsletter issues from dcbuilder — news digests, job updates, and candidate highlights.",
+};
+
+export const dynamic = "force-dynamic";
+
+const TYPE_LABELS: Record<string, string> = {
+  news: "News",
+  jobs: "Jobs",
+  candidates: "Candidates",
+};
+
+const TYPE_COLORS: Record<string, string> = {
+  news: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
+  jobs: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300",
+  candidates: "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300",
+};
+
+export default async function NewslettersPage() {
+  const campaigns = await listSentNewsletterCampaigns();
+
+  return (
+    <>
+      <Navbar />
+      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+        <div className="max-w-4xl mx-auto py-8 sm:py-12">
+          <div className="mb-6">
+            <Link
+              href="/news"
+              className="text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
+            >
+              &larr; Back to News
+            </Link>
+          </div>
+
+          <div className="text-center mb-8 sm:mb-12">
+            <h1 className="text-3xl sm:text-4xl font-bold mb-4">
+              Newsletter Archive
+            </h1>
+            <p className="text-neutral-600 dark:text-neutral-400 max-w-2xl mx-auto">
+              Browse past newsletter issues.
+            </p>
+          </div>
+
+          {campaigns.length === 0 ? (
+            <p className="text-center text-neutral-500 py-12">
+              No newsletters have been sent yet. Check back soon!
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {campaigns.map((campaign) => (
+                <Link
+                  key={campaign.id}
+                  href={`/newsletters/${campaign.id}`}
+                  className="block rounded-xl border border-neutral-200 dark:border-neutral-800 p-4 sm:p-5 hover:border-neutral-400 dark:hover:border-neutral-600 hover:bg-neutral-50 dark:hover:bg-neutral-900/40 transition-colors"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <h2 className="font-semibold text-neutral-900 dark:text-neutral-100 truncate">
+                        {campaign.subject}
+                      </h2>
+                      {campaign.previewText && (
+                        <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400 line-clamp-2">
+                          {campaign.previewText}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex flex-col items-end gap-2 flex-shrink-0">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                          TYPE_COLORS[campaign.newsletterType] ?? TYPE_COLORS.news
+                        }`}
+                      >
+                        {TYPE_LABELS[campaign.newsletterType] ?? campaign.newsletterType}
+                      </span>
+                      {campaign.sentAt && (
+                        <time
+                          dateTime={campaign.sentAt.toISOString()}
+                          className="text-xs text-neutral-400 dark:text-neutral-500 whitespace-nowrap"
+                        >
+                          {campaign.sentAt.toLocaleDateString("en-US", {
+                            month: "short",
+                            day: "numeric",
+                            year: "numeric",
+                          })}
+                        </time>
+                      )}
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/components/CandidatesGrid.tsx
+++ b/src/components/CandidatesGrid.tsx
@@ -624,10 +624,11 @@ const CandidateCard = memo(function CandidateCard({
 			? CARD_STYLES.top
 			: CARD_STYLES.default;
 
-	return (
-		<div
-			className={cn("p-4 rounded-xl border transition-[border-color,box-shadow,background-color] overflow-hidden", cardStyle)}
-		>
+		return (
+			<div
+				data-testid="candidate-card"
+				className={cn("p-4 rounded-xl border transition-[border-color,box-shadow,background-color] overflow-hidden", cardStyle)}
+			>
 			{/* Header */}
 			<div className="flex flex-col items-center gap-3 text-center">
 				{/* Profile Image */}

--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -109,6 +109,21 @@ export function NewsGrid({ news }: NewsGridProps) {
 		return dateFormatter.format(date);
 	};
 
+	const renderCommaSeparatedTokens = (value: string | undefined, keyPrefix: string) => {
+		if (!value?.trim()) return null;
+		const tokens = value
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean);
+
+		return tokens.flatMap((token, idx) => {
+			const parts: React.ReactNode[] = [];
+			if (idx > 0) parts.push(<span key={`${keyPrefix}:sep:${idx}`}> - </span>);
+			parts.push(<span key={`${keyPrefix}:${idx}`}>{token}</span>);
+			return parts;
+		});
+	};
+
 	// Extract X/Twitter handle from URL
 	const getXHandle = (url: string): string | null => {
 		const match = url.match(/x\.com\/([^/]+)/);
@@ -141,12 +156,28 @@ export function NewsGrid({ news }: NewsGridProps) {
 	const getTypeIcon = (item: AggregatedNewsItem) => {
 		// Check if it's an X post (url contains x.com)
 		if (item.url.includes("x.com/")) {
-			const handle = getXHandle(item.url);
 			const imageKey = `${item.id}:x`;
-			if (handle) {
-				if (failedImageKeys[imageKey]) {
-					return <span className="text-5xl group-hover:scale-[1.08] transition-transform duration-150 inline-block">𝕏</span>;
-				}
+			const sourceImage = item.sourceImage?.trim();
+			if (sourceImage && !failedImageKeys[imageKey]) {
+				return (
+					<div className="relative group-hover:scale-[1.08] transition-transform duration-150">
+						<Image
+							src={sourceImage}
+							alt={item.source || "X source"}
+							width={NEWS_THUMBNAIL_SIZE}
+							height={NEWS_THUMBNAIL_SIZE}
+							sizes={NEWS_THUMBNAIL_REQUEST_SIZE}
+							quality={NEWS_THUMBNAIL_QUALITY}
+							className="rounded-full w-14 h-14 object-cover"
+							onError={() => markImageFailed(imageKey)}
+						/>
+						<XLogo />
+					</div>
+				);
+			}
+
+			const handle = getXHandle(item.url);
+			if (handle && !failedImageKeys[imageKey]) {
 				return (
 					<div className="relative group-hover:scale-[1.08] transition-transform duration-150">
 						<Image
@@ -163,6 +194,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 					</div>
 				);
 			}
+			return <span className="text-5xl group-hover:scale-[1.08] transition-transform duration-150 inline-block">𝕏</span>;
 		}
 
 		switch (item.type) {
@@ -187,6 +219,24 @@ export function NewsGrid({ news }: NewsGridProps) {
 				}
 				return <span className="text-5xl group-hover:scale-[1.08] transition-transform duration-150 inline-block">📝</span>;
 			case "curated":
+				if (item.sourceImage?.trim()) {
+					const imageKey = `${item.id}:curated`;
+					if (failedImageKeys[imageKey]) {
+						return <span className="text-5xl group-hover:scale-[1.08] transition-transform duration-150 inline-block">🔗</span>;
+					}
+					return (
+						<Image
+							src={item.sourceImage.trim()}
+							alt={item.source || item.title}
+							width={NEWS_THUMBNAIL_SIZE}
+							height={NEWS_THUMBNAIL_SIZE}
+							sizes={NEWS_THUMBNAIL_REQUEST_SIZE}
+							quality={NEWS_THUMBNAIL_QUALITY}
+							className="rounded-full w-14 h-14 object-cover group-hover:scale-[1.08] transition-transform duration-150"
+							onError={() => markImageFailed(imageKey)}
+						/>
+					);
+				}
 				return <span className="text-5xl group-hover:scale-[1.08] transition-transform duration-150 inline-block">🔗</span>;
 			case "announcement":
 				if (item.companyLogo?.trim()) {
@@ -381,7 +431,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 									{/* Meta info */}
 									<div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-neutral-500">
 										<span>{formatDate(item.date)}</span>
-										{item.source && <span>{item.source}</span>}
+										{renderCommaSeparatedTokens(item.source, `${item.id}:source`)}
 										{item.company && <span>{item.company}</span>}
 										{item.readingTime && <span>{item.readingTime}</span>}
 										<span

--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -6,6 +6,7 @@ import { AggregatedNewsItem } from "@/lib/news";
 import { NewsCategory, categoryLabels } from "@/data/news";
 import { CustomSelect } from "./CustomSelect";
 import { trackNewsClick } from "@/lib/posthog";
+import { useNewsClicks } from "@/hooks/useNewsClicks";
 
 type NewsType = "all" | "blog" | "curated" | "announcement";
 
@@ -45,6 +46,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 	const [categoryFilter, setCategoryFilter] = useState<"all" | NewsCategory>("all");
 	const [searchQuery, setSearchQuery] = useState("");
 	const [failedImageKeys, setFailedImageKeys] = useState<Record<string, true>>({});
+	const { getClickCount, isPopular, loaded: clicksLoaded } = useNewsClicks();
 	const deferredSearchQuery = useDeferredValue(searchQuery);
 	const dateFormatter = useMemo(
 		() =>
@@ -404,6 +406,11 @@ export function NewsGrid({ news }: NewsGridProps) {
 												✨ FRESH
 											</span>
 										)}
+										{clicksLoaded && isPopular(item.id) && (
+											<span className="flex-shrink-0 px-2 py-0.5 text-xs font-semibold rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400">
+												🔥 POPULAR
+											</span>
+										)}
 										{isExternalLink(item) && (
 											<svg
 												className="w-4 h-4 flex-shrink-0 text-neutral-400"
@@ -431,6 +438,9 @@ export function NewsGrid({ news }: NewsGridProps) {
 									{/* Meta info */}
 									<div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-neutral-500">
 										<span>{formatDate(item.date)}</span>
+										{clicksLoaded && getClickCount(item.id) > 0 && (
+											<span>{getClickCount(item.id)} clicks</span>
+										)}
 										{renderCommaSeparatedTokens(item.source, `${item.id}:source`)}
 										{item.company && <span>{item.company}</span>}
 										{item.readingTime && <span>{item.readingTime}</span>}

--- a/src/components/NewsTools.tsx
+++ b/src/components/NewsTools.tsx
@@ -1,0 +1,18 @@
+import { listSentNewsletterCampaigns } from "@/services/newsletter";
+import { NewsToolsClient } from "@/components/NewsToolsClient";
+
+export async function NewsTools() {
+  const campaigns = await listSentNewsletterCampaigns(4);
+
+  return (
+    <NewsToolsClient
+      campaigns={campaigns.map((campaign) => ({
+        id: campaign.id,
+        subject: campaign.subject,
+        previewText: campaign.previewText ?? null,
+        newsletterType: campaign.newsletterType,
+        sentAt: campaign.sentAt ? campaign.sentAt.toISOString() : null,
+      }))}
+    />
+  );
+}

--- a/src/components/NewsToolsClient.tsx
+++ b/src/components/NewsToolsClient.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import Link from "next/link";
+import { FormEvent, useId, useState } from "react";
+import {
+  OTHER_CONTENT_I_LIKE,
+  getRecommendedLinks,
+} from "@/lib/recommendations";
+import { getNewsToolsRecommendationSummary } from "@/lib/news-tools";
+import { cn } from "@/lib/utils";
+
+type NewsToolsTab = "archive" | "subscribe" | "recommendations";
+
+type ArchiveCampaignPreview = {
+  id: string;
+  subject: string;
+  previewText: string | null;
+  newsletterType: string;
+  sentAt: string | null;
+};
+
+type NewsToolsClientProps = {
+  campaigns: ArchiveCampaignPreview[];
+};
+
+const TAB_LABELS: Record<NewsToolsTab, { title: string; blurb: string }> = {
+  archive: {
+    title: "Latest issue",
+    blurb: "Jump into recent newsletters without leaving the page.",
+  },
+  subscribe: {
+    title: "Subscribe",
+    blurb: "Choose what lands in your inbox and keep it lightweight.",
+  },
+  recommendations: {
+    title: "Recommendations",
+    blurb: "A tighter shortlist of links, newsletters, and media worth following.",
+  },
+};
+
+const NEWSLETTER_OPTIONS = [
+  { value: "news", label: "News digest" },
+  { value: "jobs", label: "Jobs updates" },
+  { value: "candidates", label: "Candidate updates" },
+] as const;
+
+const TYPE_LABELS: Record<string, string> = {
+  news: "News",
+  jobs: "Jobs",
+  candidates: "Candidates",
+};
+
+const TYPE_ACCENTS: Record<string, string> = {
+  news: "bg-blue-500/10 text-blue-700 ring-blue-500/20 dark:bg-blue-400/10 dark:text-blue-200 dark:ring-blue-400/20",
+  jobs: "bg-emerald-500/10 text-emerald-700 ring-emerald-500/20 dark:bg-emerald-400/10 dark:text-emerald-200 dark:ring-emerald-400/20",
+  candidates: "bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:bg-amber-400/10 dark:text-amber-200 dark:ring-amber-400/20",
+};
+
+function formatShortDate(value: string | null) {
+  if (!value) return null;
+
+  return new Date(value).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function ArchivePanel({ campaigns }: { campaigns: ArchiveCampaignPreview[] }) {
+  if (campaigns.length === 0) {
+    return (
+      <div className="rounded-[1.5rem] border border-dashed border-neutral-300/80 bg-white/70 px-4 py-5 text-sm text-neutral-500 dark:border-neutral-700 dark:bg-neutral-950/60 dark:text-neutral-400">
+        No newsletter issues yet.
+      </div>
+    );
+  }
+
+  const [lead, ...rest] = campaigns;
+
+  return (
+    <div className="grid gap-3 lg:grid-cols-[minmax(0,1.45fr)_minmax(16rem,0.95fr)]">
+      <Link
+        href={`/newsletters/${lead.id}`}
+        className="group rounded-[1.5rem] border border-neutral-900 bg-neutral-950 px-4 py-4 text-white transition-transform duration-200 hover:-translate-y-0.5 dark:border-neutral-200 dark:bg-white dark:text-neutral-950"
+      >
+        <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/60 dark:text-neutral-500">
+          <span>Lead issue</span>
+          {lead.sentAt && <span>{formatShortDate(lead.sentAt)}</span>}
+        </div>
+        <h3 className="mt-3 text-lg font-semibold leading-tight">{lead.subject}</h3>
+        {lead.previewText && (
+          <p className="mt-2 line-clamp-2 text-sm text-white/72 dark:text-neutral-600">
+            {lead.previewText}
+          </p>
+        )}
+        <div className="mt-4 inline-flex items-center gap-2 text-sm font-medium">
+          Read issue
+          <span aria-hidden="true">/</span>
+        </div>
+      </Link>
+
+      <div className="flex flex-col gap-2">
+        {rest.map((campaign) => (
+          <Link
+            key={campaign.id}
+            href={`/newsletters/${campaign.id}`}
+            className="group rounded-[1.25rem] border border-neutral-200 bg-white/80 px-3.5 py-3 transition-colors hover:border-neutral-300 hover:bg-white dark:border-neutral-800 dark:bg-neutral-950/60 dark:hover:border-neutral-700 dark:hover:bg-neutral-950"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="line-clamp-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+                  {campaign.subject}
+                </p>
+                {campaign.previewText && (
+                  <p className="mt-1 line-clamp-1 text-xs text-neutral-500 dark:text-neutral-400">
+                    {campaign.previewText}
+                  </p>
+                )}
+              </div>
+              <span
+                className={cn(
+                  "inline-flex shrink-0 items-center rounded-full px-2 py-1 text-[10px] font-semibold ring-1",
+                  TYPE_ACCENTS[campaign.newsletterType] ?? TYPE_ACCENTS.news,
+                )}
+              >
+                {TYPE_LABELS[campaign.newsletterType] ?? campaign.newsletterType}
+              </span>
+            </div>
+          </Link>
+        ))}
+
+        <Link
+          href="/newsletters"
+          className="inline-flex items-center justify-between rounded-[1.25rem] border border-dashed border-neutral-300 px-3.5 py-3 text-sm font-medium text-neutral-600 transition-colors hover:border-neutral-400 hover:text-neutral-900 dark:border-neutral-700 dark:text-neutral-300 dark:hover:border-neutral-500 dark:hover:text-white"
+        >
+          Browse full archive
+          <span aria-hidden="true">/</span>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function SubscribePanel() {
+  const [email, setEmail] = useState("");
+  const [selected, setSelected] = useState<string[]>(["news"]);
+  const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [message, setMessage] = useState("");
+
+  const toggleOption = (value: string) => {
+    setSelected((current) => (
+      current.includes(value)
+        ? current.filter((item) => item !== value)
+        : [...current, value]
+    ));
+  };
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus("submitting");
+    setMessage("");
+
+    try {
+      const response = await fetch("/api/v1/newsletter/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email,
+          newsletterTypes: selected,
+          source: "news-page-compact-tools",
+        }),
+      });
+      const payload = await response.json();
+
+      if (!response.ok) {
+        setStatus("error");
+        setMessage(payload.error || "Unable to subscribe");
+        return;
+      }
+
+      setStatus("success");
+      setMessage("Check your inbox to confirm.");
+      setEmail("");
+    } catch {
+      setStatus("error");
+      setMessage("Unable to subscribe right now. Try again later.");
+    }
+  };
+
+  return (
+    <form className="grid gap-4 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.95fr)]" onSubmit={onSubmit}>
+      <div>
+        <p className="max-w-xl text-sm leading-6 text-neutral-600 dark:text-neutral-300">
+          Choose the streams you care about and keep the full archive off to the side until you need it.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {NEWSLETTER_OPTIONS.map((option) => {
+            const active = selected.includes(option.value);
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => toggleOption(option.value)}
+                className={cn(
+                  "rounded-full px-3 py-1.5 text-sm font-medium transition-colors",
+                  active
+                    ? "bg-neutral-900 text-white dark:bg-white dark:text-neutral-900"
+                    : "bg-neutral-200/70 text-neutral-600 hover:bg-neutral-300 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700",
+                )}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="rounded-[1.25rem] border border-neutral-200 bg-white/80 p-3 dark:border-neutral-800 dark:bg-neutral-950/60">
+        <label className="block">
+          <span className="text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400 dark:text-neutral-500">
+            Email
+          </span>
+          <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="you@example.com"
+              className="min-w-0 flex-1 rounded-full border border-neutral-300 bg-white px-4 py-2.5 text-sm text-neutral-900 outline-none transition focus:border-neutral-500 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:focus:border-neutral-500"
+            />
+            <button
+              type="submit"
+              disabled={status === "submitting" || selected.length === 0}
+              className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-200"
+            >
+              {status === "submitting" ? "Joining..." : "Join"}
+            </button>
+          </div>
+        </label>
+
+        {message && (
+          <p
+            className={cn(
+              "mt-2 text-sm",
+              status === "error"
+                ? "text-red-600 dark:text-red-400"
+                : "text-emerald-700 dark:text-emerald-400",
+            )}
+          >
+            {message}
+          </p>
+        )}
+      </div>
+    </form>
+  );
+}
+
+function RecommendationsPanel() {
+  const [showFullList, setShowFullList] = useState(false);
+  const recommendationSummary = getNewsToolsRecommendationSummary();
+  const remainingRecommendations = getRecommendedLinks().filter(
+    (link) => !recommendationSummary.highlights.some((highlight) => highlight.name === link.name),
+  );
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(15rem,0.8fr)]">
+      <div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {recommendationSummary.highlights.map((item) => (
+            <a
+              key={item.name}
+              href={item.url}
+              target={item.url.startsWith("http") ? "_blank" : undefined}
+              rel={item.url.startsWith("http") ? "noopener noreferrer" : undefined}
+              className="group rounded-[1.25rem] border border-neutral-200 bg-white/80 px-3.5 py-3 transition-colors hover:border-neutral-300 hover:bg-white dark:border-neutral-800 dark:bg-neutral-950/60 dark:hover:border-neutral-700 dark:hover:bg-neutral-950"
+            >
+              <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+                {item.name}
+              </p>
+              <p className="mt-1 line-clamp-2 text-xs leading-5 text-neutral-500 dark:text-neutral-400">
+                {item.description}
+              </p>
+            </a>
+          ))}
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setShowFullList((current) => !current)}
+            className="inline-flex items-center rounded-full border border-neutral-300 px-3 py-1.5 text-sm font-medium text-neutral-700 transition hover:border-neutral-400 hover:text-neutral-900 dark:border-neutral-700 dark:text-neutral-300 dark:hover:border-neutral-500 dark:hover:text-white"
+          >
+            {showFullList ? "Hide full list" : `Show ${recommendationSummary.hiddenCount} more`}
+          </button>
+          <span className="text-xs uppercase tracking-[0.18em] text-neutral-400 dark:text-neutral-500">
+            Compact by default
+          </span>
+        </div>
+
+        {showFullList && (
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {remainingRecommendations.map((item) => (
+              <a
+                key={item.name}
+                href={item.url}
+                target={item.url.startsWith("http") ? "_blank" : undefined}
+                rel={item.url.startsWith("http") ? "noopener noreferrer" : undefined}
+                className="rounded-[1rem] border border-neutral-200 bg-white px-3 py-2.5 text-sm text-neutral-700 transition-colors hover:border-neutral-300 hover:text-neutral-950 dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-neutral-300 dark:hover:border-neutral-700 dark:hover:text-white"
+              >
+                {item.name}
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-[1.5rem] border border-neutral-900 bg-neutral-950 px-4 py-4 text-white dark:border-neutral-700 dark:bg-neutral-900">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
+          Other content I like
+        </p>
+        <div className="mt-3 space-y-2">
+          {OTHER_CONTENT_I_LIKE.map((item) => (
+            <a
+              key={item.name}
+              href={item.url}
+              target={item.url.startsWith("http") ? "_blank" : undefined}
+              rel={item.url.startsWith("http") ? "noopener noreferrer" : undefined}
+              className="block rounded-[1rem] border border-white/10 bg-white/5 px-3 py-2.5 transition-colors hover:bg-white/10"
+            >
+              <p className="text-sm font-semibold">{item.name}</p>
+              <p className="mt-1 text-xs leading-5 text-white/65">{item.description}</p>
+            </a>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function NewsToolsClient({ campaigns }: NewsToolsClientProps) {
+  const [activeTab, setActiveTab] = useState<NewsToolsTab>("archive");
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
+  const panelId = useId();
+  const recommendationSummary = getNewsToolsRecommendationSummary();
+
+  return (
+    <section className="relative overflow-hidden rounded-[2rem] border border-neutral-200 bg-[linear-gradient(180deg,rgba(250,250,250,0.96),rgba(245,245,245,0.88))] px-4 py-4 shadow-[0_18px_40px_rgba(0,0,0,0.04)] dark:border-neutral-800 dark:bg-[linear-gradient(180deg,rgba(18,18,18,0.96),rgba(10,10,10,0.9))] sm:px-5">
+      <div className="pointer-events-none absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent via-neutral-300/70 to-transparent dark:via-neutral-700/70" />
+
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-neutral-400 dark:text-neutral-500">
+            News tools
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-neutral-950 dark:text-white">
+            Stay close to the signal
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-neutral-600 dark:text-neutral-300">
+            One compact deck for archive access, subscription controls, and a tighter recommendation list.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 md:hidden">
+          <span className="rounded-full bg-neutral-200/80 px-3 py-1 text-xs font-medium text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300">
+            {campaigns.length} issues
+          </span>
+          <button
+            type="button"
+            aria-expanded={isMobileOpen}
+            aria-controls={panelId}
+            onClick={() => setIsMobileOpen((current) => !current)}
+            className="inline-flex items-center justify-center rounded-full border border-neutral-300 bg-white px-4 py-2 text-sm font-semibold text-neutral-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-neutral-700 dark:bg-neutral-950 dark:text-white"
+          >
+            {isMobileOpen ? "Close tools" : "Open tools"}
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.18em] text-neutral-400 dark:text-neutral-500">
+        <span>{campaigns.length} recent issues</span>
+        <span className="h-1 w-1 rounded-full bg-current/40" />
+        <span>{recommendationSummary.highlights.length} highlighted picks</span>
+      </div>
+
+      <div
+        id={panelId}
+        className={cn("mt-4 md:mt-5", isMobileOpen ? "block" : "hidden md:block")}
+      >
+        <div className="flex flex-wrap gap-2">
+          {(Object.keys(TAB_LABELS) as NewsToolsTab[]).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              onClick={() => setActiveTab(tab)}
+              className={cn(
+                "rounded-full px-3.5 py-2 text-sm font-medium transition-colors",
+                activeTab === tab
+                  ? "bg-neutral-900 text-white dark:bg-white dark:text-neutral-900"
+                  : "bg-neutral-200/70 text-neutral-600 hover:bg-neutral-300 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700",
+              )}
+            >
+              {TAB_LABELS[tab].title}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-4 rounded-[1.6rem] border border-neutral-200/80 bg-white/80 px-4 py-4 dark:border-neutral-800 dark:bg-neutral-950/70 sm:px-5">
+          <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-lg font-semibold text-neutral-950 dark:text-white">
+                {TAB_LABELS[activeTab].title}
+              </p>
+              <p className="text-sm text-neutral-500 dark:text-neutral-400">
+                {TAB_LABELS[activeTab].blurb}
+              </p>
+            </div>
+          </div>
+
+          {activeTab === "archive" && <ArchivePanel campaigns={campaigns} />}
+          {activeTab === "subscribe" && <SubscribePanel />}
+          {activeTab === "recommendations" && <RecommendationsPanel />}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/NewsletterArchivePreview.tsx
+++ b/src/components/NewsletterArchivePreview.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+import { listSentNewsletterCampaigns } from "@/services/newsletter";
+
+const TYPE_LABELS: Record<string, string> = {
+  news: "News",
+  jobs: "Jobs",
+  candidates: "Candidates",
+};
+
+const TYPE_COLORS: Record<string, string> = {
+  news: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
+  jobs: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300",
+  candidates: "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300",
+};
+
+export async function NewsletterArchivePreview() {
+  const campaigns = await listSentNewsletterCampaigns(3);
+
+  if (campaigns.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-5 sm:p-6 bg-neutral-50 dark:bg-neutral-900/40">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Newsletter Archive</h2>
+          <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+            Recent newsletter issues.
+          </p>
+        </div>
+
+        <Link
+          href="/newsletters"
+          className="group inline-flex items-center justify-center rounded-full border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-950 px-5 py-2.5 text-sm font-semibold tracking-wide text-neutral-900 dark:text-neutral-100 shadow-sm hover:-translate-y-0.5 hover:shadow-md transition-all"
+        >
+          View All
+        </Link>
+      </div>
+
+      <div className="mt-4 space-y-2">
+        {campaigns.map((campaign) => (
+          <Link
+            key={campaign.id}
+            href={`/newsletters/${campaign.id}`}
+            className="group flex items-start gap-3 rounded-lg border border-neutral-200 dark:border-neutral-700/60 p-3 hover:border-neutral-400 dark:hover:border-neutral-500 hover:bg-neutral-100/50 dark:hover:bg-neutral-800/40 transition-colors"
+          >
+            <div className="min-w-0 flex-1">
+              <span className="font-semibold text-sm text-neutral-900 dark:text-neutral-100">
+                {campaign.subject}
+              </span>
+              {campaign.previewText && (
+                <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-0.5 line-clamp-1">
+                  {campaign.previewText}
+                </p>
+              )}
+            </div>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                  TYPE_COLORS[campaign.newsletterType] ?? TYPE_COLORS.news
+                }`}
+              >
+                {TYPE_LABELS[campaign.newsletterType] ?? campaign.newsletterType}
+              </span>
+              {campaign.sentAt && (
+                <time
+                  dateTime={campaign.sentAt.toISOString()}
+                  className="text-xs text-neutral-400 dark:text-neutral-500 whitespace-nowrap"
+                >
+                  {campaign.sentAt.toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </time>
+              )}
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/NewsletterIframe.tsx
+++ b/src/components/NewsletterIframe.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+
+export function NewsletterIframe({ html }: { html: string }) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const handleLoad = useCallback(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    const doc = iframe.contentDocument;
+    if (!doc) return;
+
+    // Resize to fit content
+    const height = doc.documentElement.scrollHeight;
+    iframe.style.height = `${height}px`;
+  }, []);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      srcDoc={html}
+      sandbox="allow-same-origin"
+      onLoad={handleLoad}
+      title="Newsletter content"
+      className="w-full border-0 min-h-[400px]"
+      style={{ colorScheme: "light" }}
+    />
+  );
+}

--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -9,6 +9,7 @@ const OPTIONS = [
 ] as const;
 
 export function NewsletterSignup() {
+  const [isOpen, setIsOpen] = useState(false);
   const [email, setEmail] = useState("");
   const [selected, setSelected] = useState<string[]>(["news"]);
   const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
@@ -56,49 +57,65 @@ export function NewsletterSignup() {
 
   return (
     <section className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-5 sm:p-6 bg-neutral-50 dark:bg-neutral-900/40">
-      <h2 className="text-xl font-semibold">Newsletter</h2>
-      <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
-        Subscribe to news digests and performance updates for jobs and candidates.
-      </p>
-
-      <form className="mt-4 space-y-4" onSubmit={onSubmit}>
-        <label className="block">
-          <span className="text-sm text-neutral-700 dark:text-neutral-300">Email</span>
-          <input
-            type="email"
-            required
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            placeholder="you@example.com"
-            className="mt-1 w-full rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
-          />
-        </label>
-
-        <fieldset className="space-y-2">
-          <legend className="text-sm text-neutral-700 dark:text-neutral-300">Newsletter types</legend>
-          <div className="flex flex-col sm:flex-row gap-2 sm:gap-4">
-            {OPTIONS.map((option) => (
-              <label key={option.value} className="inline-flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={selected.includes(option.value)}
-                  onChange={() => toggleOption(option.value)}
-                  className="h-4 w-4 rounded border-neutral-300 dark:border-neutral-700"
-                />
-                <span>{option.label}</span>
-              </label>
-            ))}
-          </div>
-        </fieldset>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Newsletter</h2>
+          <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+            Subscribe to news digests and performance updates for jobs and candidates.
+          </p>
+        </div>
 
         <button
-          type="submit"
-          disabled={status === "submitting" || selected.length === 0}
-          className="inline-flex items-center justify-center rounded-lg bg-neutral-900 text-white dark:bg-white dark:text-neutral-900 px-4 py-2 text-sm font-medium disabled:opacity-50"
+          type="button"
+          aria-expanded={isOpen}
+          aria-controls="newsletter-signup-form"
+          onClick={() => setIsOpen((value) => !value)}
+          className="group inline-flex items-center justify-center rounded-full border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-950 px-5 py-2.5 text-sm font-semibold tracking-wide text-neutral-900 dark:text-neutral-100 shadow-sm hover:-translate-y-0.5 hover:shadow-md transition-all"
         >
-          {status === "submitting" ? "Subscribing..." : "Subscribe"}
+          {isOpen ? "Hide Subscribe Form" : "Subscribe"}
         </button>
-      </form>
+      </div>
+
+      {isOpen && (
+        <form id="newsletter-signup-form" className="mt-4 space-y-4" onSubmit={onSubmit}>
+          <label className="block">
+            <span className="text-sm text-neutral-700 dark:text-neutral-300">Email</span>
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="you@example.com"
+              className="mt-1 w-full rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
+            />
+          </label>
+
+          <fieldset className="space-y-2">
+            <legend className="text-sm text-neutral-700 dark:text-neutral-300">Newsletter types</legend>
+            <div className="flex flex-col sm:flex-row gap-2 sm:gap-4">
+              {OPTIONS.map((option) => (
+                <label key={option.value} className="inline-flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(option.value)}
+                    onChange={() => toggleOption(option.value)}
+                    className="h-4 w-4 rounded border-neutral-300 dark:border-neutral-700"
+                  />
+                  <span>{option.label}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <button
+            type="submit"
+            disabled={status === "submitting" || selected.length === 0}
+            className="inline-flex items-center justify-center rounded-lg bg-neutral-900 text-white dark:bg-white dark:text-neutral-900 px-4 py-2 text-sm font-medium disabled:opacity-50"
+          >
+            {status === "submitting" ? "Subscribing..." : "Subscribe"}
+          </button>
+        </form>
+      )}
 
       {message && (
         <p

--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+
+const OPTIONS = [
+  { value: "news", label: "News digest" },
+  { value: "jobs", label: "Jobs performance updates" },
+  { value: "candidates", label: "Candidates performance updates" },
+] as const;
+
+export function NewsletterSignup() {
+  const [email, setEmail] = useState("");
+  const [selected, setSelected] = useState<string[]>(["news"]);
+  const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [message, setMessage] = useState("");
+
+  const toggleOption = (value: string) => {
+    setSelected((current) => (
+      current.includes(value)
+        ? current.filter((item) => item !== value)
+        : [...current, value]
+    ));
+  };
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus("submitting");
+    setMessage("");
+
+    try {
+      const response = await fetch("/api/v1/newsletter/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email,
+          newsletterTypes: selected,
+          source: "news-page",
+        }),
+      });
+      const payload = await response.json();
+
+      if (!response.ok) {
+        setStatus("error");
+        setMessage(payload.error || "Unable to subscribe");
+        return;
+      }
+
+      setStatus("success");
+      setMessage("Please check your inbox and confirm your subscription.");
+      setEmail("");
+    } catch {
+      setStatus("error");
+      setMessage("Unable to subscribe right now. Try again later.");
+    }
+  };
+
+  return (
+    <section className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-5 sm:p-6 bg-neutral-50 dark:bg-neutral-900/40">
+      <h2 className="text-xl font-semibold">Newsletter</h2>
+      <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+        Subscribe to news digests and performance updates for jobs and candidates.
+      </p>
+
+      <form className="mt-4 space-y-4" onSubmit={onSubmit}>
+        <label className="block">
+          <span className="text-sm text-neutral-700 dark:text-neutral-300">Email</span>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="you@example.com"
+            className="mt-1 w-full rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-neutral-400 dark:focus:ring-neutral-600"
+          />
+        </label>
+
+        <fieldset className="space-y-2">
+          <legend className="text-sm text-neutral-700 dark:text-neutral-300">Newsletter types</legend>
+          <div className="flex flex-col sm:flex-row gap-2 sm:gap-4">
+            {OPTIONS.map((option) => (
+              <label key={option.value} className="inline-flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={selected.includes(option.value)}
+                  onChange={() => toggleOption(option.value)}
+                  className="h-4 w-4 rounded border-neutral-300 dark:border-neutral-700"
+                />
+                <span>{option.label}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <button
+          type="submit"
+          disabled={status === "submitting" || selected.length === 0}
+          className="inline-flex items-center justify-center rounded-lg bg-neutral-900 text-white dark:bg-white dark:text-neutral-900 px-4 py-2 text-sm font-medium disabled:opacity-50"
+        >
+          {status === "submitting" ? "Subscribing..." : "Subscribe"}
+        </button>
+      </form>
+
+      {message && (
+        <p
+          className={`mt-3 text-sm ${
+            status === "error"
+              ? "text-red-600 dark:text-red-400"
+              : "text-green-700 dark:text-green-400"
+          }`}
+        >
+          {message}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/components/Recommendations.tsx
+++ b/src/components/Recommendations.tsx
@@ -1,21 +1,7 @@
 "use client";
 
 import { useState } from "react";
-
-const RECOMMENDED_LINKS = [
-  { name: "TBPN", url: "https://tbpn.substack.com", description: "Technology Business Programming Network — daily live business & tech podcast by @johncoogan & @jordihays" },
-  { name: "SemiAnalysis", url: "https://semianalysis.com", description: "Deep dives on semiconductors, AI infrastructure, and compute" },
-  { name: "Ethereal News", url: "https://etherealnews.substack.com", description: "Ethereum ecosystem news and analysis" },
-  { name: "ZK Mesh", url: "https://zkmesh.substack.com", description: "Monthly zero-knowledge newsletter (zkmesh+ for premium)" },
-  { name: "dcbuilder.dev/blog", url: "/blog", description: "Long-form thoughts and writeups" },
-  { name: "@dcbuilder on X", url: "https://x.com/dcbuilder", description: "More curated content on X" },
-] as const;
-
-const OTHER_CONTENT = [
-  { name: "Zero Knowledge FM", url: "https://zeroknowledge.fm", description: "Podcast on ZK proofs and the decentralized web" },
-  { name: "TBPN Podcast", url: "https://tbpn.substack.com", description: "Daily live video & audio show on business and tech by @johncoogan & @jordihays" },
-  { name: "Hardcore History", url: "https://www.dancarlin.com/hardcore-history-series", description: "Dan Carlin's epic deep-dives into history" },
-] as const;
+import { getRecommendedLinks, OTHER_CONTENT_I_LIKE } from "@/lib/recommendations";
 
 function ExternalIcon() {
   return (
@@ -52,6 +38,7 @@ function LinkItem({ item }: { item: { name: string; url: string; description: st
 
 export function Recommendations() {
   const [isOpen, setIsOpen] = useState(false);
+  const recommendedLinks = getRecommendedLinks();
 
   return (
     <section className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-5 sm:p-6 bg-neutral-50 dark:bg-neutral-900/40">
@@ -81,7 +68,7 @@ export function Recommendations() {
               Recommended newsletters &amp; links
             </h3>
             <div className="space-y-2">
-              {RECOMMENDED_LINKS.map((item) => (
+              {recommendedLinks.map((item) => (
                 <LinkItem key={item.name} item={item} />
               ))}
             </div>
@@ -92,7 +79,7 @@ export function Recommendations() {
               Other content I like
             </h3>
             <div className="space-y-2">
-              {OTHER_CONTENT.map((item) => (
+              {OTHER_CONTENT_I_LIKE.map((item) => (
                 <LinkItem key={item.name} item={item} />
               ))}
             </div>

--- a/src/components/Recommendations.tsx
+++ b/src/components/Recommendations.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+
+const RECOMMENDED_LINKS = [
+  { name: "TBPN", url: "https://tbpn.substack.com", description: "Technology Business Programming Network — daily live business & tech podcast by @johncoogan & @jordihays" },
+  { name: "SemiAnalysis", url: "https://semianalysis.com", description: "Deep dives on semiconductors, AI infrastructure, and compute" },
+  { name: "Ethereal News", url: "https://etherealnews.substack.com", description: "Ethereum ecosystem news and analysis" },
+  { name: "ZK Mesh", url: "https://zkmesh.substack.com", description: "Monthly zero-knowledge newsletter (zkmesh+ for premium)" },
+  { name: "dcbuilder.dev/blog", url: "/blog", description: "Long-form thoughts and writeups" },
+  { name: "@dcbuilder on X", url: "https://x.com/dcbuilder", description: "More curated content on X" },
+] as const;
+
+const OTHER_CONTENT = [
+  { name: "Zero Knowledge FM", url: "https://zeroknowledge.fm", description: "Podcast on ZK proofs and the decentralized web" },
+  { name: "TBPN Podcast", url: "https://tbpn.substack.com", description: "Daily live video & audio show on business and tech by @johncoogan & @jordihays" },
+  { name: "Hardcore History", url: "https://www.dancarlin.com/hardcore-history-series", description: "Dan Carlin's epic deep-dives into history" },
+] as const;
+
+function ExternalIcon() {
+  return (
+    <svg className="inline-block w-3.5 h-3.5 ml-1 opacity-40 group-hover:opacity-70 transition-opacity" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
+      <polyline points="15 3 21 3 21 9" />
+      <line x1="10" y1="14" x2="21" y2="3" />
+    </svg>
+  );
+}
+
+function LinkItem({ item }: { item: { name: string; url: string; description: string } }) {
+  const isExternal = item.url.startsWith("http");
+  return (
+    <a
+      href={item.url}
+      target={isExternal ? "_blank" : undefined}
+      rel={isExternal ? "noopener noreferrer" : undefined}
+      className="group flex items-start gap-3 rounded-lg border border-neutral-200 dark:border-neutral-700/60 p-3 hover:border-neutral-400 dark:hover:border-neutral-500 hover:bg-neutral-100/50 dark:hover:bg-neutral-800/40 transition-colors"
+    >
+      <div className="min-w-0 flex-1">
+        <span className="font-semibold text-sm text-neutral-900 dark:text-neutral-100 underline underline-offset-2 decoration-neutral-300 dark:decoration-neutral-600 group-hover:decoration-neutral-500 dark:group-hover:decoration-neutral-400 transition-colors">
+          {item.name}
+        </span>
+        {isExternal && <ExternalIcon />}
+        <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-0.5">{item.description}</p>
+      </div>
+      <svg className="w-4 h-4 mt-0.5 flex-shrink-0 text-neutral-300 dark:text-neutral-600 group-hover:text-neutral-500 dark:group-hover:text-neutral-400 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="9 18 15 12 9 6" />
+      </svg>
+    </a>
+  );
+}
+
+export function Recommendations() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <section className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-5 sm:p-6 bg-neutral-50 dark:bg-neutral-900/40">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Recommendations</h2>
+          <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+            Newsletters, podcasts, and other content I follow and enjoy.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          aria-expanded={isOpen}
+          aria-controls="recommendations-panel"
+          onClick={() => setIsOpen((v) => !v)}
+          className="group inline-flex items-center justify-center rounded-full border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-950 px-5 py-2.5 text-sm font-semibold tracking-wide text-neutral-900 dark:text-neutral-100 shadow-sm hover:-translate-y-0.5 hover:shadow-md transition-all"
+        >
+          {isOpen ? "Hide" : "Show"}
+        </button>
+      </div>
+
+      {isOpen && (
+        <div id="recommendations-panel" className="mt-6 space-y-6">
+          <div>
+            <h3 className="text-xs font-bold uppercase tracking-wider text-neutral-400 dark:text-neutral-500 mb-2">
+              Recommended newsletters &amp; links
+            </h3>
+            <div className="space-y-2">
+              {RECOMMENDED_LINKS.map((item) => (
+                <LinkItem key={item.name} item={item} />
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-xs font-bold uppercase tracking-wider text-neutral-400 dark:text-neutral-500 mb-2">
+              Other content I like
+            </h3>
+            <div className="space-y-2">
+              {OTHER_CONTENT.map((item) => (
+                <LinkItem key={item.name} item={item} />
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/admin/NewsletterStudio.tsx
+++ b/src/components/admin/NewsletterStudio.tsx
@@ -211,6 +211,7 @@ export function NewsletterStudio() {
   const subjectTemplateRef = useRef<HTMLInputElement | null>(null);
   const htmlTemplateRef = useRef<HTMLTextAreaElement | null>(null);
   const textTemplateRef = useRef<HTMLTextAreaElement | null>(null);
+  const statusMessageTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [composePreview, setComposePreview] = useState<TemplatePreview | null>(null);
   const [composePreviewTab, setComposePreviewTab] = useState<PreviewTab>("html");
@@ -280,8 +281,22 @@ export function NewsletterStudio() {
 
   const setStatusMessage = (value: string) => {
     setMessage(value);
-    setTimeout(() => setMessage(null), 4000);
+    if (statusMessageTimerRef.current) {
+      clearTimeout(statusMessageTimerRef.current);
+    }
+    statusMessageTimerRef.current = setTimeout(() => {
+      setMessage(null);
+      statusMessageTimerRef.current = null;
+    }, 4000);
   };
+
+  useEffect(() => {
+    return () => {
+      if (statusMessageTimerRef.current) {
+        clearTimeout(statusMessageTimerRef.current);
+      }
+    };
+  }, []);
 
   const handleTemplateTypeChange = (nextType: NewsletterType) => {
     setActiveTemplateType(nextType);

--- a/src/components/admin/NewsletterStudio.tsx
+++ b/src/components/admin/NewsletterStudio.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { adminFetch, getAdminApiKey } from "@/lib/admin-utils";
 import { ErrorAlert } from "@/components/admin/ActionButtons";
 
@@ -25,20 +25,162 @@ interface NewsletterTemplate {
   textTemplate: string;
 }
 
+interface TemplatePreviewContextDigestItem {
+  title: string;
+  subtitle?: string;
+  url?: string;
+  currentViews?: number;
+  delta?: number;
+}
+
+interface TemplatePreviewContext {
+  digest: {
+    heading: string;
+    summary: string;
+    periodDays: number;
+    totalViews?: number;
+    deltaViews?: number;
+    items: TemplatePreviewContextDigestItem[];
+  };
+  recentNews: Array<{
+    title: string;
+    url: string;
+    date: string;
+    type: string;
+    source: string;
+  }>;
+}
+
 interface TemplatePreview {
   placeholders: string[];
+  template: NewsletterTemplate;
   rendered: {
     subject: string;
     html: string;
     text: string;
   };
+  context: TemplatePreviewContext;
 }
 
 const NEWSLETTER_TYPES = ["news", "jobs", "candidates"] as const;
-
 type NewsletterType = (typeof NEWSLETTER_TYPES)[number];
 
+type Mode = "compose" | "queue" | "templates";
+
+type PreviewTab = "html" | "text" | "subject";
+type TemplateFieldKey = "subjectTemplate" | "htmlTemplate" | "textTemplate";
+
+function cx(...parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(" ");
+}
+
+function formatStatus(status: NewsletterCampaign["status"]) {
+  return status === "sending" ? "Sending" : status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function StatusPill({ status }: { status: NewsletterCampaign["status"] }) {
+  const styles = {
+    draft: "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200",
+    scheduled: "bg-indigo-50 text-indigo-700 border border-indigo-100 dark:bg-indigo-500/15 dark:text-indigo-200 dark:border-indigo-500/25",
+    sending: "bg-amber-50 text-amber-800 border border-amber-100 dark:bg-amber-500/15 dark:text-amber-200 dark:border-amber-500/25",
+    sent: "bg-emerald-50 text-emerald-800 border border-emerald-100 dark:bg-emerald-500/15 dark:text-emerald-200 dark:border-emerald-500/25",
+    failed: "bg-red-50 text-red-700 border border-red-100 dark:bg-red-500/15 dark:text-red-200 dark:border-red-500/25",
+  }[status];
+
+  return (
+    <span className={cx("inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold", styles)}>
+      {formatStatus(status)}
+    </span>
+  );
+}
+
+function SegmentedControl<T extends string>(props: {
+  value: T;
+  onChange: (value: T) => void;
+  options: Array<{ value: T; label: string; hint?: string }>;
+}) {
+  return (
+    <div className="inline-flex rounded-full bg-neutral-100 p-1 dark:bg-neutral-800/80">
+      {props.options.map((opt) => {
+        const active = opt.value === props.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => props.onChange(opt.value)}
+            className={cx(
+              "relative rounded-full px-3 py-1.5 text-sm font-semibold transition",
+              active
+                ? "bg-white text-neutral-900 shadow-sm ring-1 ring-neutral-200 dark:bg-neutral-950 dark:text-neutral-50 dark:ring-neutral-800"
+                : "text-neutral-600 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-white"
+            )}
+            title={opt.hint}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function HtmlPreviewFrame({ html }: { html: string }) {
+  const srcDoc = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <base target="_blank" />
+    <style>
+      :root { color-scheme: light; }
+      body {
+        margin: 0;
+        padding: 18px;
+        font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+        line-height: 1.45;
+      }
+      img { max-width: 100%; height: auto; }
+      hr { border: none; border-top: 1px solid #e5e7eb; margin: 18px 0; }
+      a { color: #4338ca; }
+      pre, code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    </style>
+  </head>
+  <body>${html}</body>
+</html>`;
+
+  return (
+    <iframe
+      title="Newsletter HTML Preview"
+      sandbox="allow-popups allow-popups-to-escape-sandbox"
+      referrerPolicy="no-referrer"
+      className="h-[520px] w-full rounded-xl border border-neutral-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-950"
+      srcDoc={srcDoc}
+    />
+  );
+}
+
+function computeUtcWindow(periodDays: number, now: Date) {
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 23, 59, 59, 999));
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (periodDays - 1));
+  start.setUTCHours(0, 0, 0, 0);
+  return { start, end };
+}
+
+function isoDay(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function suggestedWeeklySubject(type: NewsletterType, periodDays: number) {
+  const now = new Date();
+  const { start, end } = computeUtcWindow(periodDays, now);
+  const label = type === "news" ? "Weekly News Digest" : `${type[0].toUpperCase()}${type.slice(1)} Digest`;
+  return `${label} (${isoDay(start)} to ${isoDay(end)})`;
+}
+
 export function NewsletterStudio() {
+  const [mode, setMode] = useState<Mode>("compose");
+
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -46,7 +188,6 @@ export function NewsletterStudio() {
 
   const [campaigns, setCampaigns] = useState<NewsletterCampaign[]>([]);
   const [templates, setTemplates] = useState<Record<NewsletterType, NewsletterTemplate> | null>(null);
-  const [activeTemplateType, setActiveTemplateType] = useState<NewsletterType>("news");
 
   const [campaignForm, setCampaignForm] = useState({
     newsletterType: "news" as NewsletterType,
@@ -56,9 +197,24 @@ export function NewsletterStudio() {
     scheduledAtLocal: "",
   });
 
+  const [queueFilter, setQueueFilter] = useState<NewsletterCampaign["status"] | "all">("all");
+  const [queueSearch, setQueueSearch] = useState("");
   const [scheduleDrafts, setScheduleDrafts] = useState<Record<string, string>>({});
+
+  const [activeTemplateType, setActiveTemplateType] = useState<NewsletterType>("news");
   const [templateDraft, setTemplateDraft] = useState<NewsletterTemplate | null>(null);
   const [templatePreview, setTemplatePreview] = useState<TemplatePreview | null>(null);
+  const [templatePreviewTab, setTemplatePreviewTab] = useState<PreviewTab>("html");
+  const [templatePreviewContext, setTemplatePreviewContext] = useState({ periodDays: 7, campaignSubject: "Weekly News Digest" });
+  const [focusedTemplateField, setFocusedTemplateField] = useState<TemplateFieldKey | null>(null);
+
+  const subjectTemplateRef = useRef<HTMLInputElement | null>(null);
+  const htmlTemplateRef = useRef<HTMLTextAreaElement | null>(null);
+  const textTemplateRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const [composePreview, setComposePreview] = useState<TemplatePreview | null>(null);
+  const [composePreviewTab, setComposePreviewTab] = useState<PreviewTab>("html");
+  const [composePreviewLoading, setComposePreviewLoading] = useState(false);
 
   const refreshData = useCallback(async () => {
     setError(null);
@@ -82,7 +238,9 @@ export function NewsletterStudio() {
         (templatesResult.data || []).map((item) => [item.newsletterType, item])
       ) as Record<NewsletterType, NewsletterTemplate>;
       setTemplates(byType);
-      setTemplateDraft(byType[activeTemplateType]);
+
+      const current = byType[activeTemplateType];
+      setTemplateDraft(current || null);
     }
   }, [activeTemplateType]);
 
@@ -97,10 +255,28 @@ export function NewsletterStudio() {
   }, [refreshData]);
 
   const sortedCampaigns = useMemo(() => {
-    return [...campaigns].sort((a, b) => {
-      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-    });
+    return [...campaigns].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   }, [campaigns]);
+
+  const filteredCampaigns = useMemo(() => {
+    const q = queueSearch.trim().toLowerCase();
+    return sortedCampaigns.filter((c) => {
+      if (queueFilter !== "all" && c.status !== queueFilter) return false;
+      if (!q) return true;
+      return c.subject.toLowerCase().includes(q) || c.newsletterType.toLowerCase().includes(q);
+    });
+  }, [queueFilter, queueSearch, sortedCampaigns]);
+
+  const templateIsDirty = useMemo(() => {
+    if (!templateDraft || !templates) return false;
+    const original = templates[templateDraft.newsletterType];
+    if (!original) return true;
+    return (
+      original.subjectTemplate !== templateDraft.subjectTemplate ||
+      original.htmlTemplate !== templateDraft.htmlTemplate ||
+      original.textTemplate !== templateDraft.textTemplate
+    );
+  }, [templateDraft, templates]);
 
   const setStatusMessage = (value: string) => {
     setMessage(value);
@@ -109,12 +285,19 @@ export function NewsletterStudio() {
 
   const handleTemplateTypeChange = (nextType: NewsletterType) => {
     setActiveTemplateType(nextType);
-    if (templates) {
-      setTemplateDraft(templates[nextType]);
-    } else {
-      setTemplateDraft(null);
-    }
+    if (templates) setTemplateDraft(templates[nextType] || null);
+    else setTemplateDraft(null);
     setTemplatePreview(null);
+    setTemplatePreviewTab("html");
+  };
+
+  const setStudioMode = (next: Mode) => {
+    setMode(next);
+
+    if (next === "templates") {
+      setTemplatePreview(null);
+      setTemplatePreviewTab("html");
+    }
   };
 
   const createCampaign = async () => {
@@ -137,9 +320,7 @@ export function NewsletterStudio() {
         subject: campaignForm.subject,
         previewText: campaignForm.previewText || undefined,
         periodDays: campaignForm.periodDays,
-        scheduledAt: campaignForm.scheduledAtLocal
-          ? new Date(campaignForm.scheduledAtLocal).toISOString()
-          : undefined,
+        scheduledAt: campaignForm.scheduledAtLocal ? new Date(campaignForm.scheduledAtLocal).toISOString() : undefined,
         createdBy: "admin-news-studio",
       }),
     });
@@ -152,8 +333,9 @@ export function NewsletterStudio() {
     }
 
     setCampaignForm((current) => ({ ...current, subject: "", previewText: "", scheduledAtLocal: "" }));
-    setStatusMessage("Campaign issue created");
+    setStatusMessage("Draft created");
     await refreshData();
+    setMode("queue");
   };
 
   const autoCreateWeekly = async () => {
@@ -183,11 +365,12 @@ export function NewsletterStudio() {
 
     setStatusMessage(
       result.data.created
-        ? `Created weekly issue for ${result.data.periodStart} to ${result.data.periodEnd}`
-        : `Weekly issue already exists for ${result.data.periodStart} to ${result.data.periodEnd}`
+        ? `Created weekly draft for ${result.data.periodStart} to ${result.data.periodEnd}`
+        : `Weekly draft already exists for ${result.data.periodStart} to ${result.data.periodEnd}`
     );
 
     await refreshData();
+    setMode("queue");
   };
 
   const sendNow = async (campaignId: string) => {
@@ -206,7 +389,7 @@ export function NewsletterStudio() {
       return;
     }
 
-    setStatusMessage("Campaign send started");
+    setStatusMessage("Send started");
     await refreshData();
   };
 
@@ -236,7 +419,7 @@ export function NewsletterStudio() {
       return;
     }
 
-    setStatusMessage("Campaign scheduled");
+    setStatusMessage("Scheduled");
     await refreshData();
   };
 
@@ -280,7 +463,8 @@ export function NewsletterStudio() {
       },
       body: JSON.stringify({
         newsletterType: templateDraft.newsletterType,
-        periodDays: campaignForm.periodDays,
+        periodDays: templatePreviewContext.periodDays,
+        campaignSubject: templatePreviewContext.campaignSubject,
         subjectTemplate: templateDraft.subjectTemplate,
         htmlTemplate: templateDraft.htmlTemplate,
         textTemplate: templateDraft.textTemplate,
@@ -297,274 +481,724 @@ export function NewsletterStudio() {
     setTemplatePreview(result.data);
   };
 
+  const insertPlaceholderIntoTemplate = (placeholder: string) => {
+    if (!templateDraft) return;
+    const token = `{{${placeholder}}}`;
+
+    const field: TemplateFieldKey = focusedTemplateField || "htmlTemplate";
+    const currentValue = templateDraft[field] || "";
+
+    const element: HTMLInputElement | HTMLTextAreaElement | null =
+      field === "subjectTemplate"
+        ? subjectTemplateRef.current
+        : field === "htmlTemplate"
+          ? htmlTemplateRef.current
+          : textTemplateRef.current;
+
+    const start = element?.selectionStart ?? currentValue.length;
+    const end = element?.selectionEnd ?? start;
+
+    const nextValue = currentValue.slice(0, start) + token + currentValue.slice(end);
+    setTemplateDraft({ ...templateDraft, [field]: nextValue });
+
+    requestAnimationFrame(() => {
+      if (!element) return;
+      element.focus();
+      try {
+        element.setSelectionRange(start + token.length, start + token.length);
+      } catch {
+        // ignore
+      }
+    });
+  };
+
+  const renderComposePreview = useCallback(async () => {
+    if (getAdminApiKey() === "") return;
+
+    setComposePreviewLoading(true);
+    const subject = campaignForm.subject.trim()
+      ? campaignForm.subject.trim()
+      : suggestedWeeklySubject(campaignForm.newsletterType, campaignForm.periodDays);
+
+    const result = await adminFetch<TemplatePreview>("/api/v1/newsletter/templates/preview", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": getAdminApiKey(),
+      },
+      body: JSON.stringify({
+        newsletterType: campaignForm.newsletterType,
+        periodDays: campaignForm.periodDays,
+        campaignSubject: subject,
+      }),
+    });
+
+    setComposePreviewLoading(false);
+
+    if (result.error || !result.data) {
+      setError(result.error || "Unable to render preview");
+      return;
+    }
+
+    setComposePreview(result.data);
+  }, [campaignForm.newsletterType, campaignForm.periodDays, campaignForm.subject]);
+
+  useEffect(() => {
+    if (mode !== "compose") return;
+
+    const handle = setTimeout(() => {
+      void renderComposePreview();
+    }, 280);
+
+    return () => clearTimeout(handle);
+  }, [mode, renderComposePreview]);
+
   if (loading) {
-    return <div className="rounded-xl border border-neutral-200 dark:border-neutral-800 p-6">Loading newsletter studio...</div>;
+    return (
+      <div className="rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
+        Loading newsletter studio...
+      </div>
+    );
   }
 
+  const studioChromeBg =
+    "bg-[radial-gradient(900px_circle_at_10%_-30%,rgba(79,70,229,0.12),transparent_45%),radial-gradient(800px_circle_at_90%_-20%,rgba(16,185,129,0.10),transparent_50%)]";
+
   return (
-    <div className="space-y-6">
-      {error && <ErrorAlert message={error} onRetry={() => { setError(null); refreshData(); }} />}
+    <div className="space-y-4">
+      {error && (
+        <ErrorAlert
+          message={error}
+          onRetry={() => {
+            setError(null);
+            refreshData();
+          }}
+        />
+      )}
+
       {message && (
-        <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-900/20 dark:text-emerald-300">
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800 dark:border-emerald-900/40 dark:bg-emerald-900/20 dark:text-emerald-200">
           {message}
         </div>
       )}
 
-      <section className="rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5 space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Issue Composer</h2>
-          <button
-            type="button"
-            onClick={autoCreateWeekly}
-            disabled={saving}
-            className="px-3 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium disabled:opacity-50"
-          >
-            Create This Week&apos;s Issue
-          </button>
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <label className="space-y-1">
-            <span className="text-sm font-medium">Newsletter Type</span>
-            <select
-              value={campaignForm.newsletterType}
-              onChange={(event) => setCampaignForm((current) => ({ ...current, newsletterType: event.target.value as NewsletterType }))}
-              className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
-            >
-              {NEWSLETTER_TYPES.map((type) => (
-                <option key={type} value={type}>{type}</option>
-              ))}
-            </select>
-          </label>
-
-          <label className="space-y-1">
-            <span className="text-sm font-medium">Period (days)</span>
-            <input
-              type="number"
-              min={1}
-              max={30}
-              value={campaignForm.periodDays}
-              onChange={(event) => setCampaignForm((current) => ({ ...current, periodDays: Number(event.target.value) || 7 }))}
-              className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
-            />
-          </label>
-
-          <label className="space-y-1 md:col-span-2">
-            <span className="text-sm font-medium">Subject</span>
-            <input
-              type="text"
-              value={campaignForm.subject}
-              onChange={(event) => setCampaignForm((current) => ({ ...current, subject: event.target.value }))}
-              placeholder="Weekly News Digest"
-              className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
-            />
-          </label>
-
-          <label className="space-y-1 md:col-span-2">
-            <span className="text-sm font-medium">Preview Text</span>
-            <input
-              type="text"
-              value={campaignForm.previewText}
-              onChange={(event) => setCampaignForm((current) => ({ ...current, previewText: event.target.value }))}
-              placeholder="Top updates from the last week"
-              className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
-            />
-          </label>
-
-          <label className="space-y-1 md:col-span-2">
-            <span className="text-sm font-medium">Schedule (optional)</span>
-            <input
-              type="datetime-local"
-              value={campaignForm.scheduledAtLocal}
-              onChange={(event) => setCampaignForm((current) => ({ ...current, scheduledAtLocal: event.target.value }))}
-              className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
-            />
-          </label>
-        </div>
-
-        <div>
-          <button
-            type="button"
-            onClick={createCampaign}
-            disabled={saving}
-            className="px-4 py-2 rounded-lg bg-neutral-900 hover:bg-neutral-700 dark:bg-neutral-100 dark:hover:bg-neutral-300 text-white dark:text-neutral-900 text-sm font-medium disabled:opacity-50"
-          >
-            Create Campaign Issue
-          </button>
-        </div>
-      </section>
-
-      <section className="rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5 space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Campaign Queue</h2>
-          <span className="text-sm text-neutral-500">{campaigns.length} campaigns</span>
-        </div>
-
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-neutral-200 dark:border-neutral-800 text-left">
-                <th className="py-2 pr-3">Type</th>
-                <th className="py-2 pr-3">Subject</th>
-                <th className="py-2 pr-3">Status</th>
-                <th className="py-2 pr-3">Created</th>
-                <th className="py-2 pr-3">Schedule</th>
-                <th className="py-2 text-right">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sortedCampaigns.map((campaign) => (
-                <tr key={campaign.id} className="border-b border-neutral-100 dark:border-neutral-800/60 align-top">
-                  <td className="py-3 pr-3 capitalize">{campaign.newsletterType}</td>
-                  <td className="py-3 pr-3 min-w-72">
-                    <div className="font-medium">{campaign.subject}</div>
-                    {campaign.previewText && <div className="text-neutral-500">{campaign.previewText}</div>}
-                    {campaign.failureReason && <div className="text-red-600 dark:text-red-400">{campaign.failureReason}</div>}
-                  </td>
-                  <td className="py-3 pr-3 capitalize">{campaign.status}</td>
-                  <td className="py-3 pr-3 whitespace-nowrap">{new Date(campaign.createdAt).toLocaleString()}</td>
-                  <td className="py-3 pr-3 min-w-64">
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="datetime-local"
-                        value={scheduleDrafts[campaign.id] || ""}
-                        onChange={(event) => {
-                          const value = event.target.value;
-                          setScheduleDrafts((current) => ({ ...current, [campaign.id]: value }));
-                        }}
-                        className="w-full px-2 py-1 rounded-md border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => scheduleCampaign(campaign.id)}
-                        disabled={saving}
-                        className="px-2 py-1 rounded-md border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-800"
-                      >
-                        Set
-                      </button>
-                    </div>
-                    {campaign.scheduledAt && (
-                      <div className="mt-1 text-neutral-500 text-xs">Current: {new Date(campaign.scheduledAt).toLocaleString()}</div>
-                    )}
-                  </td>
-                  <td className="py-3 text-right">
-                    <button
-                      type="button"
-                      onClick={() => sendNow(campaign.id)}
-                      disabled={saving || campaign.status === "sent" || campaign.status === "sending"}
-                      className="px-3 py-1.5 rounded-md bg-emerald-600 hover:bg-emerald-700 text-white disabled:opacity-50"
-                    >
-                      Send Now
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
-
-      <section className="rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5 space-y-4">
-        <div className="flex items-center justify-between gap-4">
-          <h2 className="text-lg font-semibold">Template Editor</h2>
-          <select
-            value={activeTemplateType}
-            onChange={(event) => handleTemplateTypeChange(event.target.value as NewsletterType)}
-            className="px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
-          >
-            {NEWSLETTER_TYPES.map((type) => (
-              <option key={type} value={type}>{type}</option>
-            ))}
-          </select>
-        </div>
-
-        {templateDraft && (
-          <div className="grid grid-cols-1 gap-4">
-            <label className="space-y-1">
-              <span className="text-sm font-medium">Subject Template</span>
-              <input
-                type="text"
-                value={templateDraft.subjectTemplate}
-                onChange={(event) => {
-                  const value = event.target.value;
-                  setTemplateDraft((current) => current ? { ...current, subjectTemplate: value } : current);
-                }}
-                className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
-              />
-            </label>
-
-            <label className="space-y-1">
-              <span className="text-sm font-medium">HTML Template</span>
-              <textarea
-                rows={7}
-                value={templateDraft.htmlTemplate}
-                onChange={(event) => {
-                  const value = event.target.value;
-                  setTemplateDraft((current) => current ? { ...current, htmlTemplate: value } : current);
-                }}
-                className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 font-mono text-xs"
-              />
-            </label>
-
-            <label className="space-y-1">
-              <span className="text-sm font-medium">Text Template</span>
-              <textarea
-                rows={7}
-                value={templateDraft.textTemplate}
-                onChange={(event) => {
-                  const value = event.target.value;
-                  setTemplateDraft((current) => current ? { ...current, textTemplate: value } : current);
-                }}
-                className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 font-mono text-xs"
-              />
-            </label>
-
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={saveTemplate}
-                disabled={saving}
-                className="px-4 py-2 rounded-lg bg-neutral-900 hover:bg-neutral-700 dark:bg-neutral-100 dark:hover:bg-neutral-300 text-white dark:text-neutral-900 text-sm font-medium disabled:opacity-50"
-              >
-                Save Template
-              </button>
-              <button
-                type="button"
-                onClick={renderTemplatePreview}
-                disabled={saving}
-                className="px-4 py-2 rounded-lg border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-800 text-sm font-medium disabled:opacity-50"
-              >
-                Render Preview
-              </button>
-            </div>
-          </div>
-        )}
-
-        {templatePreview && (
-          <div className="space-y-3 rounded-lg border border-neutral-200 dark:border-neutral-800 p-4">
-            <div>
-              <h3 className="font-medium">Rendered Subject</h3>
-              <p className="text-sm text-neutral-700 dark:text-neutral-300">{templatePreview.rendered.subject}</p>
+      <section className={cx("rounded-2xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900", studioChromeBg)}>
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-neutral-900 text-white shadow-sm dark:bg-neutral-50 dark:text-neutral-900">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path
+                  d="M4 6.5C4 5.11929 5.11929 4 6.5 4H18.5C19.8807 4 21 5.11929 21 6.5V17.5C21 18.8807 19.8807 20 18.5 20H6.5C5.11929 20 4 18.8807 4 17.5V6.5Z"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                />
+                <path d="M7 8H18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                <path d="M7 12H15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                <path d="M7 16H12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+              </svg>
             </div>
             <div>
-              <h3 className="font-medium">Rendered HTML</h3>
-              <div className="mt-2 rounded border border-neutral-200 dark:border-neutral-700 p-3 bg-white dark:bg-neutral-950" dangerouslySetInnerHTML={{ __html: templatePreview.rendered.html }} />
-            </div>
-            <div>
-              <h3 className="font-medium">Rendered Text</h3>
-              <pre className="mt-2 whitespace-pre-wrap rounded border border-neutral-200 dark:border-neutral-700 p-3 text-xs bg-white dark:bg-neutral-950">{templatePreview.rendered.text}</pre>
-            </div>
-            <div>
-              <h3 className="font-medium">Available Placeholders</h3>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {templatePreview.placeholders.map((placeholder) => (
-                  <code key={placeholder} className="px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 text-xs">{`{{${placeholder}}}`}</code>
-                ))}
+              <div className="text-base font-semibold text-neutral-900 dark:text-neutral-50">Studio</div>
+              <div className="text-sm text-neutral-600 dark:text-neutral-300">
+                Compose drafts, manage the queue, and evolve templates.
               </div>
             </div>
           </div>
-        )}
+
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-end">
+            <SegmentedControl<Mode>
+              value={mode}
+              onChange={(next) => setStudioMode(next)}
+              options={[
+                { value: "compose", label: "Compose", hint: "Create new campaign drafts" },
+                { value: "queue", label: "Queue", hint: "Schedule and send campaigns" },
+                { value: "templates", label: "Templates", hint: "Edit templates and preview rendering" },
+              ]}
+            />
+
+            <div className="flex items-center gap-2">
+              {mode === "compose" && (
+                <>
+                  <button
+                    type="button"
+                    onClick={autoCreateWeekly}
+                    disabled={saving || campaignForm.newsletterType !== "news"}
+                    className={cx(
+                      "inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold transition shadow-sm",
+                      campaignForm.newsletterType === "news"
+                        ? "bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
+                        : "bg-neutral-200 text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400 cursor-not-allowed"
+                    )}
+                    title={campaignForm.newsletterType === "news" ? "Auto-create weekly news draft" : "Auto-create currently supports only the news newsletter"}
+                  >
+                    Generate weekly draft
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void renderComposePreview()}
+                    disabled={composePreviewLoading || saving}
+                    className="inline-flex items-center gap-2 rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold text-neutral-900 shadow-sm transition hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:hover:bg-neutral-900"
+                  >
+                    Refresh preview
+                  </button>
+                </>
+              )}
+
+              {mode === "queue" && (
+                <button
+                  type="button"
+                  onClick={refreshData}
+                  disabled={saving}
+                  className="inline-flex items-center gap-2 rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold text-neutral-900 shadow-sm transition hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:hover:bg-neutral-900"
+                >
+                  Refresh
+                </button>
+              )}
+
+              {mode === "templates" && (
+                <>
+                  <button
+                    type="button"
+                    onClick={saveTemplate}
+                    disabled={saving || !templateDraft}
+                    className={cx(
+                      "inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold transition shadow-sm disabled:opacity-50",
+                      templateIsDirty ? "bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-white" : "bg-neutral-200 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300"
+                    )}
+                    title={templateIsDirty ? "Save template changes" : "No unsaved changes"}
+                  >
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    onClick={renderTemplatePreview}
+                    disabled={saving || !templateDraft}
+                    className="inline-flex items-center gap-2 rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold text-neutral-900 shadow-sm transition hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:hover:bg-neutral-900"
+                  >
+                    Preview
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
       </section>
+
+      {mode === "compose" && (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">Draft composer</h2>
+                <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                  Creates a campaign record. Content is rendered from the saved template at send time.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setCampaignForm((c) => ({ ...c, subject: suggestedWeeklySubject(c.newsletterType, c.periodDays) }))}
+                className="rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:hover:bg-neutral-900"
+              >
+                Use suggested subject
+              </button>
+            </div>
+
+            <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-2">
+              <label className="space-y-1">
+                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Newsletter type</span>
+                <select
+                  value={campaignForm.newsletterType}
+                  onChange={(event) => setCampaignForm((current) => ({ ...current, newsletterType: event.target.value as NewsletterType }))}
+                  className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                >
+                  {NEWSLETTER_TYPES.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="space-y-1">
+                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Period (days)</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={30}
+                  value={campaignForm.periodDays}
+                  onChange={(event) => setCampaignForm((current) => ({ ...current, periodDays: Number(event.target.value) || 7 }))}
+                  className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                />
+              </label>
+
+              <label className="space-y-1 md:col-span-2">
+                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Subject</span>
+                <input
+                  type="text"
+                  value={campaignForm.subject}
+                  onChange={(event) => setCampaignForm((current) => ({ ...current, subject: event.target.value }))}
+                  placeholder={suggestedWeeklySubject(campaignForm.newsletterType, campaignForm.periodDays)}
+                  className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                />
+              </label>
+
+              <label className="space-y-1 md:col-span-2">
+                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Preview text (optional)</span>
+                <input
+                  type="text"
+                  value={campaignForm.previewText}
+                  onChange={(event) => setCampaignForm((current) => ({ ...current, previewText: event.target.value }))}
+                  placeholder="Top updates from the last week"
+                  className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                />
+              </label>
+
+              <label className="space-y-1 md:col-span-2">
+                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Schedule (optional)</span>
+                <input
+                  type="datetime-local"
+                  value={campaignForm.scheduledAtLocal}
+                  onChange={(event) => setCampaignForm((current) => ({ ...current, scheduledAtLocal: event.target.value }))}
+                  className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                />
+                <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                  Stored as UTC when scheduled.
+                </p>
+              </label>
+            </div>
+
+            <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <button
+                type="button"
+                onClick={createCampaign}
+                disabled={saving}
+                className="inline-flex items-center justify-center rounded-xl bg-neutral-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-neutral-800 disabled:opacity-50 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-white"
+              >
+                Create draft
+              </button>
+              <div className="text-xs text-neutral-500 dark:text-neutral-400">
+                Tip: edit templates in the Templates tab, then come back to Compose.
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">Live preview</h2>
+                <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                  Uses the saved template for <span className="font-semibold">{campaignForm.newsletterType}</span> and the latest digest snapshot.
+                </p>
+              </div>
+              <SegmentedControl<PreviewTab>
+                value={composePreviewTab}
+                onChange={(v) => setComposePreviewTab(v)}
+                options={[
+                  { value: "html", label: "HTML" },
+                  { value: "text", label: "Text" },
+                  { value: "subject", label: "Subject" },
+                ]}
+              />
+            </div>
+
+            {composePreviewLoading && (
+              <div className="mt-4 rounded-xl border border-neutral-200 bg-neutral-50 p-4 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300">
+                Rendering preview...
+              </div>
+            )}
+
+            {!composePreviewLoading && !composePreview && (
+              <div className="mt-4 rounded-xl border border-neutral-200 bg-neutral-50 p-4 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300">
+                Preview will appear here.
+              </div>
+            )}
+
+            {composePreview && (
+              <div className="mt-4 space-y-3">
+                <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                    Digest context
+                  </div>
+                  <div className="mt-1 text-sm font-semibold text-neutral-900 dark:text-neutral-50">
+                    {composePreview.context.digest.heading}
+                  </div>
+                  <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                    {composePreview.context.digest.summary}
+                  </div>
+                </div>
+
+                {composePreviewTab === "subject" && (
+                  <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                      Rendered subject
+                    </div>
+                    <div className="mt-2 text-base font-semibold text-neutral-900 dark:text-neutral-50">
+                      {composePreview.rendered.subject}
+                    </div>
+                    {campaignForm.previewText.trim() && (
+                      <div className="mt-2 text-sm text-neutral-600 dark:text-neutral-300">
+                        <span className="font-semibold">Preview text:</span> {campaignForm.previewText.trim()}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {composePreviewTab === "html" && (
+                  <div className="space-y-2">
+                    {campaignForm.previewText.trim() && (
+                      <div className="rounded-xl border border-neutral-200 bg-white p-3 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
+                        <span className="font-semibold">Preview text:</span> {campaignForm.previewText.trim()}
+                      </div>
+                    )}
+                    <HtmlPreviewFrame html={composePreview.rendered.html} />
+                  </div>
+                )}
+
+                {composePreviewTab === "text" && (
+                  <pre className="max-h-[520px] overflow-auto whitespace-pre-wrap rounded-xl border border-neutral-200 bg-white p-4 text-xs text-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
+                    {composePreview.rendered.text}
+                  </pre>
+                )}
+              </div>
+            )}
+          </section>
+        </div>
+      )}
+
+      {mode === "queue" && (
+        <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">Campaign queue</h2>
+              <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                Schedule drafts, kick off sends, and monitor failures.
+              </p>
+            </div>
+            <div className="flex w-full flex-col gap-2 md:w-auto md:flex-row md:items-center">
+              <div className="flex items-center gap-2">
+                <SegmentedControl<typeof queueFilter>
+                  value={queueFilter}
+                  onChange={(v) => setQueueFilter(v)}
+                  options={[
+                    { value: "all", label: "All" },
+                    { value: "draft", label: "Draft" },
+                    { value: "scheduled", label: "Scheduled" },
+                    { value: "sending", label: "Sending" },
+                    { value: "sent", label: "Sent" },
+                    { value: "failed", label: "Failed" },
+                  ]}
+                />
+              </div>
+              <input
+                type="text"
+                value={queueSearch}
+                onChange={(e) => setQueueSearch(e.target.value)}
+                placeholder="Search subject..."
+                className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950 md:w-72"
+              />
+            </div>
+          </div>
+
+          {filteredCampaigns.length === 0 ? (
+            <div className="mt-5 rounded-2xl border border-neutral-200 bg-neutral-50 p-8 text-center dark:border-neutral-800 dark:bg-neutral-950">
+              <div className="text-sm font-semibold text-neutral-900 dark:text-neutral-50">No campaigns match this view.</div>
+              <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                Create a draft in Compose, then come back here to schedule or send.
+              </div>
+              <button
+                type="button"
+                onClick={() => setMode("compose")}
+                className="mt-4 inline-flex items-center justify-center rounded-xl bg-neutral-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-neutral-800 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-white"
+              >
+                Go to Compose
+              </button>
+            </div>
+          ) : (
+            <div className="mt-5 overflow-x-auto rounded-2xl border border-neutral-200 dark:border-neutral-800">
+              <table className="w-full min-w-[980px] text-sm">
+                <thead className="bg-neutral-50 dark:bg-neutral-950">
+                  <tr className="text-left text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                    <th className="px-4 py-3">Status</th>
+                    <th className="px-4 py-3">Type</th>
+                    <th className="px-4 py-3">Subject</th>
+                    <th className="px-4 py-3">Created</th>
+                    <th className="px-4 py-3">Schedule</th>
+                    <th className="px-4 py-3 text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredCampaigns.map((campaign) => (
+                    <tr key={campaign.id} className="border-t border-neutral-200 align-top dark:border-neutral-800">
+                      <td className="px-4 py-3">
+                        <StatusPill status={campaign.status} />
+                        {campaign.failureReason && (
+                          <div className="mt-2 text-xs text-red-700 dark:text-red-300">
+                            {campaign.failureReason}
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 capitalize text-neutral-700 dark:text-neutral-200">{campaign.newsletterType}</td>
+                      <td className="px-4 py-3">
+                        <div className="font-semibold text-neutral-900 dark:text-neutral-50">{campaign.subject}</div>
+                        {campaign.previewText && <div className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">{campaign.previewText}</div>}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-neutral-700 dark:text-neutral-200">
+                        {new Date(campaign.createdAt).toLocaleString()}
+                      </td>
+                      <td className="px-4 py-3 min-w-80">
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="datetime-local"
+                            value={scheduleDrafts[campaign.id] || ""}
+                            onChange={(event) => setScheduleDrafts((current) => ({ ...current, [campaign.id]: event.target.value }))}
+                            className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => scheduleCampaign(campaign.id)}
+                            disabled={saving}
+                            className="rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:hover:bg-neutral-900"
+                          >
+                            Set
+                          </button>
+                        </div>
+                        {campaign.scheduledAt && (
+                          <div className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+                            Current: {new Date(campaign.scheduledAt).toLocaleString()}
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <button
+                          type="button"
+                          onClick={() => sendNow(campaign.id)}
+                          disabled={saving || campaign.status === "sent" || campaign.status === "sending"}
+                          className="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-emerald-700 disabled:opacity-50"
+                        >
+                          Send now
+                        </button>
+                        {campaign.sentAt && (
+                          <div className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
+                            Sent: {new Date(campaign.sentAt).toLocaleString()}
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      )}
+
+      {mode === "templates" && (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <div className="flex items-center gap-2">
+                  <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">Template editor</h2>
+                  {templateIsDirty && (
+                    <span className="rounded-full bg-amber-50 px-2.5 py-1 text-xs font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
+                      Unsaved
+                    </span>
+                  )}
+                </div>
+                <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                  Templates render on send. Use placeholders like <code className="rounded bg-neutral-100 px-1 py-0.5 dark:bg-neutral-800">{`{{digest_heading}}`}</code>.
+                </p>
+              </div>
+
+              <select
+                value={activeTemplateType}
+                onChange={(event) => handleTemplateTypeChange(event.target.value as NewsletterType)}
+                className="rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold dark:border-neutral-700 dark:bg-neutral-950"
+              >
+                {NEWSLETTER_TYPES.map((type) => (
+                  <option key={type} value={type}>
+                    {type}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {!templateDraft ? (
+              <div className="mt-5 rounded-2xl border border-neutral-200 bg-neutral-50 p-6 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300">
+                No template loaded for <span className="font-semibold">{activeTemplateType}</span>.
+              </div>
+            ) : (
+              <>
+                <div className="mt-5 grid grid-cols-1 gap-4">
+                  <label className="space-y-1">
+                    <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Subject template</span>
+                    <input
+                      ref={subjectTemplateRef}
+                      type="text"
+                      value={templateDraft.subjectTemplate}
+                      onFocus={() => setFocusedTemplateField("subjectTemplate")}
+                      onChange={(event) => setTemplateDraft((current) => (current ? { ...current, subjectTemplate: event.target.value } : current))}
+                      className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                    />
+                  </label>
+
+                  <label className="space-y-1">
+                    <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">HTML template</span>
+                    <textarea
+                      ref={htmlTemplateRef}
+                      rows={10}
+                      value={templateDraft.htmlTemplate}
+                      onFocus={() => setFocusedTemplateField("htmlTemplate")}
+                      onChange={(event) => setTemplateDraft((current) => (current ? { ...current, htmlTemplate: event.target.value } : current))}
+                      className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-950"
+                    />
+                  </label>
+
+                  <label className="space-y-1">
+                    <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Text template</span>
+                    <textarea
+                      ref={textTemplateRef}
+                      rows={10}
+                      value={templateDraft.textTemplate}
+                      onFocus={() => setFocusedTemplateField("textTemplate")}
+                      onChange={(event) => setTemplateDraft((current) => (current ? { ...current, textTemplate: event.target.value } : current))}
+                      className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-950"
+                    />
+                  </label>
+                </div>
+
+                <div className="mt-5 rounded-2xl border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="text-sm font-semibold text-neutral-900 dark:text-neutral-50">Placeholders</div>
+                      <div className="mt-1 text-xs text-neutral-600 dark:text-neutral-300">
+                        Click to insert into the focused field.
+                      </div>
+                    </div>
+                    <div className="text-xs text-neutral-500 dark:text-neutral-400">
+                      Focus: <span className="font-semibold">{focusedTemplateField || "htmlTemplate"}</span>
+                    </div>
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {(templatePreview?.placeholders || [
+                      "campaign_subject",
+                      "campaign_type",
+                      "period_days",
+                      "digest_heading",
+                      "digest_summary",
+                      "total_views",
+                      "delta_views",
+                      "digest_items_html",
+                      "digest_items_text",
+                      "recent_news_html",
+                      "recent_news_text",
+                      "unsubscribe_url",
+                      "preferences_url",
+                      "default_html_body",
+                      "default_text_body",
+                      "generated_at_iso",
+                    ]).map((ph) => (
+                      <button
+                        key={ph}
+                        type="button"
+                        onClick={() => insertPlaceholderIntoTemplate(ph)}
+                        className="rounded-full border border-neutral-200 bg-white px-3 py-1.5 text-xs font-semibold text-neutral-800 transition hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200 dark:hover:bg-neutral-900"
+                      >
+                        {`{{${ph}}}`}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
+          </section>
+
+          <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">Preview</h2>
+                <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                  Render the current draft template with a real digest snapshot.
+                </p>
+              </div>
+              <SegmentedControl<PreviewTab>
+                value={templatePreviewTab}
+                onChange={(v) => setTemplatePreviewTab(v)}
+                options={[
+                  { value: "html", label: "HTML" },
+                  { value: "text", label: "Text" },
+                  { value: "subject", label: "Subject" },
+                ]}
+              />
+            </div>
+
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <label className="space-y-1">
+                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Preview subject</span>
+                <input
+                  type="text"
+                  value={templatePreviewContext.campaignSubject}
+                  onChange={(e) => setTemplatePreviewContext((c) => ({ ...c, campaignSubject: e.target.value }))}
+                  className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                />
+              </label>
+              <label className="space-y-1">
+                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Period (days)</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={30}
+                  value={templatePreviewContext.periodDays}
+                  onChange={(e) => setTemplatePreviewContext((c) => ({ ...c, periodDays: Number(e.target.value) || 7 }))}
+                  className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                />
+              </label>
+            </div>
+
+            {!templatePreview && (
+              <div className="mt-4 rounded-2xl border border-neutral-200 bg-neutral-50 p-6 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300">
+                Click <span className="font-semibold">Preview</span> in the top bar to render.
+              </div>
+            )}
+
+            {templatePreview && (
+              <div className="mt-4 space-y-3">
+                <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                    Context
+                  </div>
+                  <div className="mt-1 text-sm font-semibold text-neutral-900 dark:text-neutral-50">
+                    {templatePreview.context.digest.heading}
+                  </div>
+                  <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                    {templatePreview.context.digest.summary}
+                  </div>
+                </div>
+
+                {templatePreviewTab === "subject" && (
+                  <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                      Rendered subject
+                    </div>
+                    <div className="mt-2 text-base font-semibold text-neutral-900 dark:text-neutral-50">
+                      {templatePreview.rendered.subject}
+                    </div>
+                  </div>
+                )}
+
+                {templatePreviewTab === "html" && <HtmlPreviewFrame html={templatePreview.rendered.html} />}
+
+                {templatePreviewTab === "text" && (
+                  <pre className="max-h-[520px] overflow-auto whitespace-pre-wrap rounded-xl border border-neutral-200 bg-white p-4 text-xs text-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
+                    {templatePreview.rendered.text}
+                  </pre>
+                )}
+              </div>
+            )}
+          </section>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/admin/NewsletterStudio.tsx
+++ b/src/components/admin/NewsletterStudio.tsx
@@ -1,0 +1,570 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { adminFetch, getAdminApiKey } from "@/lib/admin-utils";
+import { ErrorAlert } from "@/components/admin/ActionButtons";
+
+interface NewsletterCampaign {
+  id: string;
+  newsletterType: "news" | "jobs" | "candidates";
+  subject: string;
+  previewText: string | null;
+  periodDays: number;
+  status: "draft" | "scheduled" | "sending" | "sent" | "failed";
+  scheduledAt: string | null;
+  sentAt: string | null;
+  failureReason: string | null;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+interface NewsletterTemplate {
+  newsletterType: "news" | "jobs" | "candidates";
+  subjectTemplate: string;
+  htmlTemplate: string;
+  textTemplate: string;
+}
+
+interface TemplatePreview {
+  placeholders: string[];
+  rendered: {
+    subject: string;
+    html: string;
+    text: string;
+  };
+}
+
+const NEWSLETTER_TYPES = ["news", "jobs", "candidates"] as const;
+
+type NewsletterType = (typeof NEWSLETTER_TYPES)[number];
+
+export function NewsletterStudio() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const [campaigns, setCampaigns] = useState<NewsletterCampaign[]>([]);
+  const [templates, setTemplates] = useState<Record<NewsletterType, NewsletterTemplate> | null>(null);
+  const [activeTemplateType, setActiveTemplateType] = useState<NewsletterType>("news");
+
+  const [campaignForm, setCampaignForm] = useState({
+    newsletterType: "news" as NewsletterType,
+    subject: "",
+    previewText: "",
+    periodDays: 7,
+    scheduledAtLocal: "",
+  });
+
+  const [scheduleDrafts, setScheduleDrafts] = useState<Record<string, string>>({});
+  const [templateDraft, setTemplateDraft] = useState<NewsletterTemplate | null>(null);
+  const [templatePreview, setTemplatePreview] = useState<TemplatePreview | null>(null);
+
+  const refreshData = useCallback(async () => {
+    setError(null);
+
+    const headers = { "x-api-key": getAdminApiKey() };
+    const [campaignsResult, templatesResult] = await Promise.all([
+      adminFetch<NewsletterCampaign[]>("/api/v1/newsletter/campaigns?limit=100", { headers }),
+      adminFetch<NewsletterTemplate[]>("/api/v1/newsletter/templates", { headers }),
+    ]);
+
+    if (campaignsResult.error) {
+      setError(campaignsResult.error);
+    } else {
+      setCampaigns(campaignsResult.data || []);
+    }
+
+    if (templatesResult.error) {
+      setError((prev) => prev || templatesResult.error);
+    } else {
+      const byType = Object.fromEntries(
+        (templatesResult.data || []).map((item) => [item.newsletterType, item])
+      ) as Record<NewsletterType, NewsletterTemplate>;
+      setTemplates(byType);
+      setTemplateDraft(byType[activeTemplateType]);
+    }
+  }, [activeTemplateType]);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      await refreshData();
+      setLoading(false);
+    };
+
+    load();
+  }, [refreshData]);
+
+  const sortedCampaigns = useMemo(() => {
+    return [...campaigns].sort((a, b) => {
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+  }, [campaigns]);
+
+  const setStatusMessage = (value: string) => {
+    setMessage(value);
+    setTimeout(() => setMessage(null), 4000);
+  };
+
+  const handleTemplateTypeChange = (nextType: NewsletterType) => {
+    setActiveTemplateType(nextType);
+    if (templates) {
+      setTemplateDraft(templates[nextType]);
+    } else {
+      setTemplateDraft(null);
+    }
+    setTemplatePreview(null);
+  };
+
+  const createCampaign = async () => {
+    if (!campaignForm.subject.trim()) {
+      setError("Subject is required");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    const { error: createError } = await adminFetch("/api/v1/newsletter/campaigns", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": getAdminApiKey(),
+      },
+      body: JSON.stringify({
+        newsletterType: campaignForm.newsletterType,
+        subject: campaignForm.subject,
+        previewText: campaignForm.previewText || undefined,
+        periodDays: campaignForm.periodDays,
+        scheduledAt: campaignForm.scheduledAtLocal
+          ? new Date(campaignForm.scheduledAtLocal).toISOString()
+          : undefined,
+        createdBy: "admin-news-studio",
+      }),
+    });
+
+    setSaving(false);
+
+    if (createError) {
+      setError(createError);
+      return;
+    }
+
+    setCampaignForm((current) => ({ ...current, subject: "", previewText: "", scheduledAtLocal: "" }));
+    setStatusMessage("Campaign issue created");
+    await refreshData();
+  };
+
+  const autoCreateWeekly = async () => {
+    setSaving(true);
+    setError(null);
+
+    const result = await adminFetch<{
+      created: boolean;
+      periodStart: string;
+      periodEnd: string;
+      campaign: NewsletterCampaign;
+    }>("/api/v1/newsletter/campaigns/auto-create-weekly", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": getAdminApiKey(),
+      },
+      body: JSON.stringify({ periodDays: 7, createdBy: "admin-news-studio:auto" }),
+    });
+
+    setSaving(false);
+
+    if (result.error || !result.data) {
+      setError(result.error || "Unable to auto-create weekly issue");
+      return;
+    }
+
+    setStatusMessage(
+      result.data.created
+        ? `Created weekly issue for ${result.data.periodStart} to ${result.data.periodEnd}`
+        : `Weekly issue already exists for ${result.data.periodStart} to ${result.data.periodEnd}`
+    );
+
+    await refreshData();
+  };
+
+  const sendNow = async (campaignId: string) => {
+    setSaving(true);
+    setError(null);
+
+    const { error: sendError } = await adminFetch(`/api/v1/newsletter/campaigns/${campaignId}/send`, {
+      method: "POST",
+      headers: { "x-api-key": getAdminApiKey() },
+    });
+
+    setSaving(false);
+
+    if (sendError) {
+      setError(sendError);
+      return;
+    }
+
+    setStatusMessage("Campaign send started");
+    await refreshData();
+  };
+
+  const scheduleCampaign = async (campaignId: string) => {
+    const localValue = scheduleDrafts[campaignId];
+    if (!localValue) {
+      setError("Pick a schedule date/time first");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    const { error: scheduleError } = await adminFetch(`/api/v1/newsletter/campaigns/${campaignId}/schedule`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": getAdminApiKey(),
+      },
+      body: JSON.stringify({ scheduledAt: new Date(localValue).toISOString() }),
+    });
+
+    setSaving(false);
+
+    if (scheduleError) {
+      setError(scheduleError);
+      return;
+    }
+
+    setStatusMessage("Campaign scheduled");
+    await refreshData();
+  };
+
+  const saveTemplate = async () => {
+    if (!templateDraft) return;
+
+    setSaving(true);
+    setError(null);
+
+    const { error: saveError } = await adminFetch("/api/v1/newsletter/templates", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": getAdminApiKey(),
+      },
+      body: JSON.stringify(templateDraft),
+    });
+
+    setSaving(false);
+
+    if (saveError) {
+      setError(saveError);
+      return;
+    }
+
+    setStatusMessage("Template saved");
+    await refreshData();
+  };
+
+  const renderTemplatePreview = async () => {
+    if (!templateDraft) return;
+
+    setSaving(true);
+    setError(null);
+
+    const result = await adminFetch<TemplatePreview>("/api/v1/newsletter/templates/preview", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": getAdminApiKey(),
+      },
+      body: JSON.stringify({
+        newsletterType: templateDraft.newsletterType,
+        periodDays: campaignForm.periodDays,
+        subjectTemplate: templateDraft.subjectTemplate,
+        htmlTemplate: templateDraft.htmlTemplate,
+        textTemplate: templateDraft.textTemplate,
+      }),
+    });
+
+    setSaving(false);
+
+    if (result.error || !result.data) {
+      setError(result.error || "Unable to render preview");
+      return;
+    }
+
+    setTemplatePreview(result.data);
+  };
+
+  if (loading) {
+    return <div className="rounded-xl border border-neutral-200 dark:border-neutral-800 p-6">Loading newsletter studio...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {error && <ErrorAlert message={error} onRetry={() => { setError(null); refreshData(); }} />}
+      {message && (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-900/20 dark:text-emerald-300">
+          {message}
+        </div>
+      )}
+
+      <section className="rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Issue Composer</h2>
+          <button
+            type="button"
+            onClick={autoCreateWeekly}
+            disabled={saving}
+            className="px-3 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium disabled:opacity-50"
+          >
+            Create This Week&apos;s Issue
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <label className="space-y-1">
+            <span className="text-sm font-medium">Newsletter Type</span>
+            <select
+              value={campaignForm.newsletterType}
+              onChange={(event) => setCampaignForm((current) => ({ ...current, newsletterType: event.target.value as NewsletterType }))}
+              className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
+            >
+              {NEWSLETTER_TYPES.map((type) => (
+                <option key={type} value={type}>{type}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="space-y-1">
+            <span className="text-sm font-medium">Period (days)</span>
+            <input
+              type="number"
+              min={1}
+              max={30}
+              value={campaignForm.periodDays}
+              onChange={(event) => setCampaignForm((current) => ({ ...current, periodDays: Number(event.target.value) || 7 }))}
+              className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
+            />
+          </label>
+
+          <label className="space-y-1 md:col-span-2">
+            <span className="text-sm font-medium">Subject</span>
+            <input
+              type="text"
+              value={campaignForm.subject}
+              onChange={(event) => setCampaignForm((current) => ({ ...current, subject: event.target.value }))}
+              placeholder="Weekly News Digest"
+              className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
+            />
+          </label>
+
+          <label className="space-y-1 md:col-span-2">
+            <span className="text-sm font-medium">Preview Text</span>
+            <input
+              type="text"
+              value={campaignForm.previewText}
+              onChange={(event) => setCampaignForm((current) => ({ ...current, previewText: event.target.value }))}
+              placeholder="Top updates from the last week"
+              className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
+            />
+          </label>
+
+          <label className="space-y-1 md:col-span-2">
+            <span className="text-sm font-medium">Schedule (optional)</span>
+            <input
+              type="datetime-local"
+              value={campaignForm.scheduledAtLocal}
+              onChange={(event) => setCampaignForm((current) => ({ ...current, scheduledAtLocal: event.target.value }))}
+              className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
+            />
+          </label>
+        </div>
+
+        <div>
+          <button
+            type="button"
+            onClick={createCampaign}
+            disabled={saving}
+            className="px-4 py-2 rounded-lg bg-neutral-900 hover:bg-neutral-700 dark:bg-neutral-100 dark:hover:bg-neutral-300 text-white dark:text-neutral-900 text-sm font-medium disabled:opacity-50"
+          >
+            Create Campaign Issue
+          </button>
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Campaign Queue</h2>
+          <span className="text-sm text-neutral-500">{campaigns.length} campaigns</span>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-neutral-200 dark:border-neutral-800 text-left">
+                <th className="py-2 pr-3">Type</th>
+                <th className="py-2 pr-3">Subject</th>
+                <th className="py-2 pr-3">Status</th>
+                <th className="py-2 pr-3">Created</th>
+                <th className="py-2 pr-3">Schedule</th>
+                <th className="py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedCampaigns.map((campaign) => (
+                <tr key={campaign.id} className="border-b border-neutral-100 dark:border-neutral-800/60 align-top">
+                  <td className="py-3 pr-3 capitalize">{campaign.newsletterType}</td>
+                  <td className="py-3 pr-3 min-w-72">
+                    <div className="font-medium">{campaign.subject}</div>
+                    {campaign.previewText && <div className="text-neutral-500">{campaign.previewText}</div>}
+                    {campaign.failureReason && <div className="text-red-600 dark:text-red-400">{campaign.failureReason}</div>}
+                  </td>
+                  <td className="py-3 pr-3 capitalize">{campaign.status}</td>
+                  <td className="py-3 pr-3 whitespace-nowrap">{new Date(campaign.createdAt).toLocaleString()}</td>
+                  <td className="py-3 pr-3 min-w-64">
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="datetime-local"
+                        value={scheduleDrafts[campaign.id] || ""}
+                        onChange={(event) => {
+                          const value = event.target.value;
+                          setScheduleDrafts((current) => ({ ...current, [campaign.id]: value }));
+                        }}
+                        className="w-full px-2 py-1 rounded-md border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => scheduleCampaign(campaign.id)}
+                        disabled={saving}
+                        className="px-2 py-1 rounded-md border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-800"
+                      >
+                        Set
+                      </button>
+                    </div>
+                    {campaign.scheduledAt && (
+                      <div className="mt-1 text-neutral-500 text-xs">Current: {new Date(campaign.scheduledAt).toLocaleString()}</div>
+                    )}
+                  </td>
+                  <td className="py-3 text-right">
+                    <button
+                      type="button"
+                      onClick={() => sendNow(campaign.id)}
+                      disabled={saving || campaign.status === "sent" || campaign.status === "sending"}
+                      className="px-3 py-1.5 rounded-md bg-emerald-600 hover:bg-emerald-700 text-white disabled:opacity-50"
+                    >
+                      Send Now
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5 space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <h2 className="text-lg font-semibold">Template Editor</h2>
+          <select
+            value={activeTemplateType}
+            onChange={(event) => handleTemplateTypeChange(event.target.value as NewsletterType)}
+            className="px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
+          >
+            {NEWSLETTER_TYPES.map((type) => (
+              <option key={type} value={type}>{type}</option>
+            ))}
+          </select>
+        </div>
+
+        {templateDraft && (
+          <div className="grid grid-cols-1 gap-4">
+            <label className="space-y-1">
+              <span className="text-sm font-medium">Subject Template</span>
+              <input
+                type="text"
+                value={templateDraft.subjectTemplate}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setTemplateDraft((current) => current ? { ...current, subjectTemplate: value } : current);
+                }}
+                className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800"
+              />
+            </label>
+
+            <label className="space-y-1">
+              <span className="text-sm font-medium">HTML Template</span>
+              <textarea
+                rows={7}
+                value={templateDraft.htmlTemplate}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setTemplateDraft((current) => current ? { ...current, htmlTemplate: value } : current);
+                }}
+                className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 font-mono text-xs"
+              />
+            </label>
+
+            <label className="space-y-1">
+              <span className="text-sm font-medium">Text Template</span>
+              <textarea
+                rows={7}
+                value={templateDraft.textTemplate}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setTemplateDraft((current) => current ? { ...current, textTemplate: value } : current);
+                }}
+                className="w-full px-3 py-2 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 font-mono text-xs"
+              />
+            </label>
+
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={saveTemplate}
+                disabled={saving}
+                className="px-4 py-2 rounded-lg bg-neutral-900 hover:bg-neutral-700 dark:bg-neutral-100 dark:hover:bg-neutral-300 text-white dark:text-neutral-900 text-sm font-medium disabled:opacity-50"
+              >
+                Save Template
+              </button>
+              <button
+                type="button"
+                onClick={renderTemplatePreview}
+                disabled={saving}
+                className="px-4 py-2 rounded-lg border border-neutral-300 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-800 text-sm font-medium disabled:opacity-50"
+              >
+                Render Preview
+              </button>
+            </div>
+          </div>
+        )}
+
+        {templatePreview && (
+          <div className="space-y-3 rounded-lg border border-neutral-200 dark:border-neutral-800 p-4">
+            <div>
+              <h3 className="font-medium">Rendered Subject</h3>
+              <p className="text-sm text-neutral-700 dark:text-neutral-300">{templatePreview.rendered.subject}</p>
+            </div>
+            <div>
+              <h3 className="font-medium">Rendered HTML</h3>
+              <div className="mt-2 rounded border border-neutral-200 dark:border-neutral-700 p-3 bg-white dark:bg-neutral-950" dangerouslySetInnerHTML={{ __html: templatePreview.rendered.html }} />
+            </div>
+            <div>
+              <h3 className="font-medium">Rendered Text</h3>
+              <pre className="mt-2 whitespace-pre-wrap rounded border border-neutral-200 dark:border-neutral-700 p-3 text-xs bg-white dark:bg-neutral-950">{templatePreview.rendered.text}</pre>
+            </div>
+            <div>
+              <h3 className="font-medium">Available Placeholders</h3>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {templatePreview.placeholders.map((placeholder) => (
+                  <code key={placeholder} className="px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 text-xs">{`{{${placeholder}}}`}</code>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/admin/NewsletterStudio.tsx
+++ b/src/components/admin/NewsletterStudio.tsx
@@ -79,6 +79,8 @@ interface SubscriberRow {
   unsubscribedAt: string | null;
   createdAt: string;
   preferences: Array<{ type: string; enabled: boolean }>;
+  clicks7d?: number;
+  lastClickedLink?: string | null;
 }
 
 const NEWSLETTER_TYPES = ["news", "jobs", "candidates"] as const;
@@ -1346,12 +1348,14 @@ export function NewsletterStudio() {
             </div>
           ) : (
             <div className="mt-5 overflow-x-auto rounded-2xl border border-neutral-200 dark:border-neutral-800">
-              <table className="w-full min-w-[820px] text-sm">
+              <table className="w-full min-w-[1060px] text-sm">
                 <thead className="bg-neutral-50 dark:bg-neutral-950">
                   <tr className="text-left text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
                     <th className="px-4 py-3">Email</th>
                     <th className="px-4 py-3">Status</th>
                     <th className="px-4 py-3">Preferences</th>
+                    <th className="px-4 py-3">Clicks (7d)</th>
+                    <th className="px-4 py-3">Last Clicked</th>
                     <th className="px-4 py-3">Subscribed</th>
                     <th className="px-4 py-3">Source</th>
                   </tr>
@@ -1392,6 +1396,32 @@ export function NewsletterStudio() {
                             <span className="text-xs text-neutral-400 dark:text-neutral-500">None</span>
                           )}
                         </div>
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        {sub.clicks7d && sub.clicks7d > 0 ? (
+                          <span className="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 dark:bg-blue-500/15 dark:text-blue-200">
+                            {sub.clicks7d}
+                          </span>
+                        ) : (
+                          <span className="text-xs text-neutral-400 dark:text-neutral-500">0</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-neutral-700 dark:text-neutral-200">
+                        {sub.lastClickedLink ? (
+                          <a
+                            href={sub.lastClickedLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title={sub.lastClickedLink}
+                            className="text-xs text-blue-600 underline decoration-blue-300 underline-offset-2 hover:text-blue-800 dark:text-blue-400 dark:decoration-blue-600 dark:hover:text-blue-300"
+                          >
+                            {sub.lastClickedLink.length > 40
+                              ? sub.lastClickedLink.slice(0, 40) + "\u2026"
+                              : sub.lastClickedLink}
+                          </a>
+                        ) : (
+                          <span className="text-xs text-neutral-400 dark:text-neutral-500">--</span>
+                        )}
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap text-neutral-700 dark:text-neutral-200">
                         {new Date(sub.createdAt).toLocaleDateString()}

--- a/src/components/admin/NewsletterStudio.tsx
+++ b/src/components/admin/NewsletterStudio.tsx
@@ -31,6 +31,13 @@ interface TemplatePreviewContextDigestItem {
   url?: string;
   currentViews?: number;
   delta?: number;
+  category?: string;
+}
+
+interface TemplatePreviewContextDigestGroup {
+  category: string;
+  label: string;
+  items: TemplatePreviewContextDigestItem[];
 }
 
 interface TemplatePreviewContext {
@@ -41,6 +48,7 @@ interface TemplatePreviewContext {
     totalViews?: number;
     deltaViews?: number;
     items: TemplatePreviewContextDigestItem[];
+    groups?: TemplatePreviewContextDigestGroup[];
   };
   recentNews: Array<{
     title: string;
@@ -874,6 +882,28 @@ export function NewsletterStudio() {
                   <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
                     {composePreview.context.digest.summary}
                   </div>
+                  {composePreview.context.digest.groups && composePreview.context.digest.groups.length > 0 ? (
+                    <div className="mt-3 space-y-2">
+                      {composePreview.context.digest.groups.map((group) => (
+                        <div key={group.category}>
+                          <div className="text-xs font-semibold text-neutral-500 dark:text-neutral-400">
+                            {group.label} ({group.items.length})
+                          </div>
+                          <ul className="mt-1 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
+                            {group.items.map((item, i) => (
+                              <li key={i}>{item.title}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      ))}
+                    </div>
+                  ) : composePreview.context.digest.items.length > 0 ? (
+                    <ul className="mt-3 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
+                      {composePreview.context.digest.items.map((item, i) => (
+                        <li key={i}>{item.title}</li>
+                      ))}
+                    </ul>
+                  ) : null}
                 </div>
 
                 {composePreviewTab === "subject" && (
@@ -1223,6 +1253,28 @@ export function NewsletterStudio() {
                   <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
                     {templatePreview.context.digest.summary}
                   </div>
+                  {templatePreview.context.digest.groups && templatePreview.context.digest.groups.length > 0 ? (
+                    <div className="mt-3 space-y-2">
+                      {templatePreview.context.digest.groups.map((group) => (
+                        <div key={group.category}>
+                          <div className="text-xs font-semibold text-neutral-500 dark:text-neutral-400">
+                            {group.label} ({group.items.length})
+                          </div>
+                          <ul className="mt-1 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
+                            {group.items.map((item, i) => (
+                              <li key={i}>{item.title}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      ))}
+                    </div>
+                  ) : templatePreview.context.digest.items.length > 0 ? (
+                    <ul className="mt-3 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
+                      {templatePreview.context.digest.items.map((item, i) => (
+                        <li key={i}>{item.title}</li>
+                      ))}
+                    </ul>
+                  ) : null}
                 </div>
 
                 {templatePreviewTab === "subject" && (

--- a/src/components/admin/NewsletterStudio.tsx
+++ b/src/components/admin/NewsletterStudio.tsx
@@ -62,10 +62,21 @@ interface TemplatePreview {
   context: TemplatePreviewContext;
 }
 
+interface SubscriberRow {
+  id: string;
+  email: string;
+  status: string;
+  source: string;
+  confirmedAt: string | null;
+  unsubscribedAt: string | null;
+  createdAt: string;
+  preferences: Array<{ type: string; enabled: boolean }>;
+}
+
 const NEWSLETTER_TYPES = ["news", "jobs", "candidates"] as const;
 type NewsletterType = (typeof NEWSLETTER_TYPES)[number];
 
-type Mode = "compose" | "queue" | "templates";
+type Mode = "compose" | "queue" | "templates" | "subscribers";
 
 type PreviewTab = "html" | "text" | "subject";
 type TemplateFieldKey = "subjectTemplate" | "htmlTemplate" | "textTemplate";
@@ -216,6 +227,10 @@ export function NewsletterStudio() {
   const [composePreviewTab, setComposePreviewTab] = useState<PreviewTab>("html");
   const [composePreviewLoading, setComposePreviewLoading] = useState(false);
 
+  const [subscribers, setSubscribers] = useState<SubscriberRow[]>([]);
+  const [subscriberTotal, setSubscriberTotal] = useState(0);
+  const [subscriberLoading, setSubscriberLoading] = useState(false);
+
   const refreshData = useCallback(async () => {
     setError(null);
 
@@ -253,6 +268,28 @@ export function NewsletterStudio() {
 
     load();
   }, [refreshData]);
+
+  async function loadSubscribers() {
+    setSubscriberLoading(true);
+    try {
+      const res = await fetch("/api/v1/newsletter/subscribers?limit=200", {
+        headers: { "x-api-key": getAdminApiKey() },
+      });
+      if (res.ok) {
+        const json = await res.json();
+        setSubscribers(json.data);
+        setSubscriberTotal(json.total);
+      }
+    } finally {
+      setSubscriberLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (mode === "subscribers") {
+      loadSubscribers();
+    }
+  }, [mode]);
 
   const sortedCampaigns = useMemo(() => {
     return [...campaigns].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
@@ -613,6 +650,7 @@ export function NewsletterStudio() {
                 { value: "compose", label: "Compose", hint: "Create new campaign drafts" },
                 { value: "queue", label: "Queue", hint: "Schedule and send campaigns" },
                 { value: "templates", label: "Templates", hint: "Edit templates and preview rendering" },
+                { value: "subscribers", label: "Subscribers", hint: "View and manage subscribers" },
               ]}
             />
 
@@ -678,6 +716,17 @@ export function NewsletterStudio() {
                     Preview
                   </button>
                 </>
+              )}
+
+              {mode === "subscribers" && (
+                <button
+                  type="button"
+                  onClick={() => void loadSubscribers()}
+                  disabled={subscriberLoading}
+                  className="inline-flex items-center gap-2 rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold text-neutral-900 shadow-sm transition hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:hover:bg-neutral-900"
+                >
+                  Refresh
+                </button>
               )}
             </div>
           </div>
@@ -1198,6 +1247,113 @@ export function NewsletterStudio() {
             )}
           </section>
         </div>
+      )}
+
+      {mode === "subscribers" && (
+        <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">
+                Subscribers{" "}
+                {subscriberTotal > 0 && (
+                  <span className="ml-1 text-sm font-normal text-neutral-500 dark:text-neutral-400">
+                    ({subscriberTotal} total)
+                  </span>
+                )}
+              </h2>
+              <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                View subscriber status, preferences, and history.
+              </p>
+            </div>
+
+            {subscribers.length > 0 && (
+              <div className="flex items-center gap-3 text-sm">
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-2.5 py-1 text-xs font-semibold text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                  {subscribers.filter((s) => s.status === "active").length} active
+                </span>
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                  {subscribers.filter((s) => s.status === "pending").length} pending
+                </span>
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-semibold text-neutral-700 dark:bg-neutral-800 dark:text-neutral-400">
+                  {subscribers.filter((s) => s.status === "unsubscribed").length} unsubscribed
+                </span>
+              </div>
+            )}
+          </div>
+
+          {subscriberLoading ? (
+            <div className="mt-5 flex items-center justify-center py-12">
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-neutral-300 border-t-neutral-900 dark:border-neutral-600 dark:border-t-neutral-100" />
+            </div>
+          ) : subscribers.length === 0 ? (
+            <div className="mt-5 rounded-2xl border border-neutral-200 bg-neutral-50 p-8 text-center dark:border-neutral-800 dark:bg-neutral-950">
+              <div className="text-sm font-semibold text-neutral-900 dark:text-neutral-50">No subscribers found.</div>
+              <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                Subscribers will appear here once people sign up for newsletters.
+              </div>
+            </div>
+          ) : (
+            <div className="mt-5 overflow-x-auto rounded-2xl border border-neutral-200 dark:border-neutral-800">
+              <table className="w-full min-w-[820px] text-sm">
+                <thead className="bg-neutral-50 dark:bg-neutral-950">
+                  <tr className="text-left text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                    <th className="px-4 py-3">Email</th>
+                    <th className="px-4 py-3">Status</th>
+                    <th className="px-4 py-3">Preferences</th>
+                    <th className="px-4 py-3">Subscribed</th>
+                    <th className="px-4 py-3">Source</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {subscribers.map((sub) => (
+                    <tr key={sub.id} className="border-t border-neutral-200 align-top dark:border-neutral-800">
+                      <td className="px-4 py-3">
+                        <span className="font-semibold text-neutral-900 dark:text-neutral-50">{sub.email}</span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={cx(
+                            "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold",
+                            sub.status === "active"
+                              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                              : sub.status === "pending"
+                                ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+                                : "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-400"
+                          )}
+                        >
+                          {sub.status.charAt(0).toUpperCase() + sub.status.slice(1)}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex flex-wrap gap-1">
+                          {sub.preferences
+                            .filter((p) => p.enabled)
+                            .map((p) => (
+                              <span
+                                key={p.type}
+                                className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-500/15 dark:text-indigo-200"
+                              >
+                                {p.type}
+                              </span>
+                            ))}
+                          {sub.preferences.filter((p) => p.enabled).length === 0 && (
+                            <span className="text-xs text-neutral-400 dark:text-neutral-500">None</span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-neutral-700 dark:text-neutral-200">
+                        {new Date(sub.createdAt).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-3 text-neutral-700 dark:text-neutral-200">
+                        {sub.source || <span className="text-neutral-400 dark:text-neutral-500">--</span>}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
       )}
     </div>
   );

--- a/src/components/admin/NewsletterStudio.tsx
+++ b/src/components/admin/NewsletterStudio.tsx
@@ -874,39 +874,41 @@ export function NewsletterStudio() {
 
             {composePreview && (
               <div className="mt-4 space-y-3">
-                <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950">
-                  <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                <details className="rounded-xl border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
+                  <summary className="cursor-pointer px-4 py-3 text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
                     Digest context
-                  </div>
-                  <div className="mt-1 text-sm font-semibold text-neutral-900 dark:text-neutral-50">
-                    {composePreview.context.digest.heading}
-                  </div>
-                  <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-                    {composePreview.context.digest.summary}
-                  </div>
-                  {composePreview.context.digest.groups && composePreview.context.digest.groups.length > 0 ? (
-                    <div className="mt-3 space-y-2">
-                      {composePreview.context.digest.groups.map((group) => (
-                        <div key={group.category}>
-                          <div className="text-xs font-semibold text-neutral-500 dark:text-neutral-400">
-                            {group.label} ({group.items.length})
-                          </div>
-                          <ul className="mt-1 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
-                            {group.items.map((item, i) => (
-                              <li key={i}>{item.title}</li>
-                            ))}
-                          </ul>
-                        </div>
-                      ))}
+                  </summary>
+                  <div className="px-4 pb-4">
+                    <div className="text-sm font-semibold text-neutral-900 dark:text-neutral-50">
+                      {composePreview.context.digest.heading}
                     </div>
-                  ) : composePreview.context.digest.items.length > 0 ? (
-                    <ul className="mt-3 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
-                      {composePreview.context.digest.items.map((item, i) => (
-                        <li key={i}>{item.title}</li>
-                      ))}
-                    </ul>
-                  ) : null}
-                </div>
+                    <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                      {composePreview.context.digest.summary}
+                    </div>
+                    {composePreview.context.digest.groups && composePreview.context.digest.groups.length > 0 ? (
+                      <div className="mt-3 space-y-2">
+                        {composePreview.context.digest.groups.map((group) => (
+                          <div key={group.category}>
+                            <div className="text-xs font-semibold text-neutral-500 dark:text-neutral-400">
+                              {group.label} ({group.items.length})
+                            </div>
+                            <ul className="mt-1 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
+                              {group.items.map((item, i) => (
+                                <li key={i}>{item.title}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        ))}
+                      </div>
+                    ) : composePreview.context.digest.items.length > 0 ? (
+                      <ul className="mt-3 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
+                        {composePreview.context.digest.items.map((item, i) => (
+                          <li key={i}>{item.title}</li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </div>
+                </details>
 
                 {composePreviewTab === "subject" && (
                   <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950">
@@ -1245,39 +1247,41 @@ export function NewsletterStudio() {
 
             {templatePreview && (
               <div className="mt-4 space-y-3">
-                <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950">
-                  <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                <details className="rounded-xl border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
+                  <summary className="cursor-pointer px-4 py-3 text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
                     Context
-                  </div>
-                  <div className="mt-1 text-sm font-semibold text-neutral-900 dark:text-neutral-50">
-                    {templatePreview.context.digest.heading}
-                  </div>
-                  <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-                    {templatePreview.context.digest.summary}
-                  </div>
-                  {templatePreview.context.digest.groups && templatePreview.context.digest.groups.length > 0 ? (
-                    <div className="mt-3 space-y-2">
-                      {templatePreview.context.digest.groups.map((group) => (
-                        <div key={group.category}>
-                          <div className="text-xs font-semibold text-neutral-500 dark:text-neutral-400">
-                            {group.label} ({group.items.length})
-                          </div>
-                          <ul className="mt-1 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
-                            {group.items.map((item, i) => (
-                              <li key={i}>{item.title}</li>
-                            ))}
-                          </ul>
-                        </div>
-                      ))}
+                  </summary>
+                  <div className="px-4 pb-4">
+                    <div className="text-sm font-semibold text-neutral-900 dark:text-neutral-50">
+                      {templatePreview.context.digest.heading}
                     </div>
-                  ) : templatePreview.context.digest.items.length > 0 ? (
-                    <ul className="mt-3 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
-                      {templatePreview.context.digest.items.map((item, i) => (
-                        <li key={i}>{item.title}</li>
-                      ))}
-                    </ul>
-                  ) : null}
-                </div>
+                    <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                      {templatePreview.context.digest.summary}
+                    </div>
+                    {templatePreview.context.digest.groups && templatePreview.context.digest.groups.length > 0 ? (
+                      <div className="mt-3 space-y-2">
+                        {templatePreview.context.digest.groups.map((group) => (
+                          <div key={group.category}>
+                            <div className="text-xs font-semibold text-neutral-500 dark:text-neutral-400">
+                              {group.label} ({group.items.length})
+                            </div>
+                            <ul className="mt-1 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
+                              {group.items.map((item, i) => (
+                                <li key={i}>{item.title}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        ))}
+                      </div>
+                    ) : templatePreview.context.digest.items.length > 0 ? (
+                      <ul className="mt-3 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
+                        {templatePreview.context.digest.items.map((item, i) => (
+                          <li key={i}>{item.title}</li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </div>
+                </details>
 
                 {templatePreviewTab === "subject" && (
                   <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950">

--- a/src/components/admin/NewsletterStudio.tsx
+++ b/src/components/admin/NewsletterStudio.tsx
@@ -13,7 +13,10 @@ import {
   type NewsletterSubscriberPreference,
   type NewsletterSubscriberRowDraft,
 } from "@/lib/newsletter-subscribers";
-import { canAutoRenderComposePreview } from "@/lib/newsletter-studio";
+import {
+  canAutoRenderComposePreview,
+  shouldLoadSubscribersOnModeChange,
+} from "@/lib/newsletter-studio";
 
 type NewsletterType = "news" | "jobs" | "candidates";
 type NewsletterContentMode = "template" | "markdown" | "manual";
@@ -595,10 +598,18 @@ export function NewsletterStudio() {
     load();
   }, [refreshData]);
 
-  useEffect(() => {
-    if (mode !== "subscribers" || subscribersLoaded || subscribersLoading) return;
-    void refreshSubscribers();
-  }, [mode, refreshSubscribers, subscribersLoaded, subscribersLoading]);
+  const handleModeChange = useCallback((next: Mode) => {
+    setMode(next);
+    if (
+      shouldLoadSubscribersOnModeChange({
+        nextMode: next,
+        subscribersLoaded,
+        subscribersLoading,
+      })
+    ) {
+      void refreshSubscribers();
+    }
+  }, [refreshSubscribers, subscribersLoaded, subscribersLoading]);
 
   const sortedCampaigns = useMemo(() => {
     return [...campaigns].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
@@ -724,7 +735,7 @@ export function NewsletterStudio() {
     }, 250);
 
     return () => clearTimeout(handle);
-  }, [loading, mode, renderComposePreview]);
+  }, [composeForm, loading, mode, renderComposePreview]);
 
   const closeEditPanel = useCallback(
     (force = false) => {
@@ -1499,7 +1510,7 @@ export function NewsletterStudio() {
             <div className="flex items-center gap-2">
               <SegmentedControl<Mode>
                 value={mode}
-                onChange={(next) => setMode(next)}
+                onChange={handleModeChange}
                 options={[
                   { value: "compose", label: "Compose" },
                   { value: "queue", label: "Queue" },

--- a/src/components/admin/NewsletterStudio.tsx
+++ b/src/components/admin/NewsletterStudio.tsx
@@ -1,54 +1,36 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { adminFetch, getAdminApiKey } from "@/lib/admin-utils";
+import ReactMarkdown from "react-markdown";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { ErrorAlert } from "@/components/admin/ActionButtons";
+import { adminFetch, getAdminApiKey } from "@/lib/admin-utils";
 
-interface NewsletterCampaign {
-  id: string;
-  newsletterType: "news" | "jobs" | "candidates";
-  subject: string;
-  previewText: string | null;
-  periodDays: number;
-  status: "draft" | "scheduled" | "sending" | "sent" | "failed";
-  scheduledAt: string | null;
-  sentAt: string | null;
-  failureReason: string | null;
-  createdBy: string | null;
-  createdAt: string;
-}
+type NewsletterType = "news" | "jobs" | "candidates";
+type NewsletterContentMode = "template" | "markdown" | "manual";
+type CampaignStatus = "draft" | "scheduled" | "sending" | "sent" | "failed";
+type WorkspaceView = "editor" | "split" | "preview";
 
-interface NewsletterTemplate {
-  newsletterType: "news" | "jobs" | "candidates";
-  subjectTemplate: string;
-  htmlTemplate: string;
-  textTemplate: string;
-}
+type Mode = "compose" | "queue" | "templates";
+type PreviewTab = "subject" | "html" | "text" | "starter";
+type TemplateFieldKey = "subjectTemplate" | "htmlTemplate" | "textTemplate" | "markdownTemplate";
+type ComposeFieldKey = "markdownContent" | "manualHtml" | "manualText";
 
-interface TemplatePreviewContextDigestItem {
+type DigestItem = {
   title: string;
   subtitle?: string;
   url?: string;
   currentViews?: number;
   delta?: number;
-  category?: string;
-}
+};
 
-interface TemplatePreviewContextDigestGroup {
-  category: string;
-  label: string;
-  items: TemplatePreviewContextDigestItem[];
-}
-
-interface TemplatePreviewContext {
+type PreviewContext = {
   digest: {
     heading: string;
     summary: string;
     periodDays: number;
     totalViews?: number;
     deltaViews?: number;
-    items: TemplatePreviewContextDigestItem[];
-    groups?: TemplatePreviewContextDigestGroup[];
+    items: DigestItem[];
   };
   recentNews: Array<{
     title: string;
@@ -57,59 +39,213 @@ interface TemplatePreviewContext {
     type: string;
     source: string;
   }>;
-}
+};
 
-interface TemplatePreview {
+type RenderedPayload = {
+  subject: string;
+  html: string;
+  text: string;
+};
+
+type CampaignPreviewResult = {
+  rendered: RenderedPayload;
+  starter: { markdown: string };
   placeholders: string[];
+  context: PreviewContext;
+};
+
+type TemplatePreviewResult = CampaignPreviewResult & {
   template: NewsletterTemplate;
-  rendered: {
-    subject: string;
-    html: string;
-    text: string;
-  };
-  context: TemplatePreviewContext;
-}
+};
 
-interface SubscriberRow {
+interface NewsletterCampaign {
   id: string;
-  email: string;
-  status: string;
-  source: string;
-  confirmedAt: string | null;
-  unsubscribedAt: string | null;
+  newsletterType: NewsletterType;
+  subject: string;
+  previewText: string | null;
+  contentMode: NewsletterContentMode;
+  markdownContent: string | null;
+  manualHtml: string | null;
+  manualText: string | null;
+  periodDays: number;
+  status: CampaignStatus;
+  scheduledAt: string | null;
+  sentAt: string | null;
+  failureReason: string | null;
+  createdBy: string | null;
   createdAt: string;
-  preferences: Array<{ type: string; enabled: boolean }>;
-  clicks7d?: number;
-  lastClickedLink?: string | null;
 }
 
-const NEWSLETTER_TYPES = ["news", "jobs", "candidates"] as const;
-type NewsletterType = (typeof NEWSLETTER_TYPES)[number];
+interface NewsletterTemplate {
+  newsletterType: NewsletterType;
+  subjectTemplate: string;
+  htmlTemplate: string;
+  textTemplate: string;
+  markdownTemplate: string;
+}
 
-type Mode = "compose" | "queue" | "templates" | "subscribers";
+type CampaignDraft = {
+  newsletterType: NewsletterType;
+  subject: string;
+  previewText: string;
+  contentMode: NewsletterContentMode;
+  markdownContent: string;
+  manualHtml: string;
+  manualText: string;
+  periodDays: number;
+  scheduledAtLocal: string;
+};
 
-type PreviewTab = "html" | "text" | "subject";
-type TemplateFieldKey = "subjectTemplate" | "htmlTemplate" | "textTemplate";
+const NEWSLETTER_TYPES: NewsletterType[] = ["news", "jobs", "candidates"];
+const MUTABLE_STATUSES = new Set<CampaignStatus>(["draft", "scheduled"]);
+type MarkdownFormatKind = "h2" | "bold" | "italic" | "link" | "list" | "quote" | "code" | "divider";
+
+const MARKDOWN_TOOLBAR_ACTIONS: Array<{ id: MarkdownFormatKind; label: string }> = [
+  { id: "h2", label: "H2" },
+  { id: "bold", label: "Bold" },
+  { id: "italic", label: "Italic" },
+  { id: "link", label: "Link" },
+  { id: "list", label: "List" },
+  { id: "quote", label: "Quote" },
+  { id: "code", label: "Code" },
+  { id: "divider", label: "Divider" },
+];
+
+const SUBSTACK_SANS_FONT_STACK = "'SF Pro Display', -apple-system, system-ui, BlinkMacSystemFont, 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'";
+
+const FALLBACK_PLACEHOLDERS = [
+  "campaign_subject",
+  "campaign_type",
+  "period_days",
+  "digest_heading",
+  "digest_summary",
+  "total_views",
+  "delta_views",
+  "digest_items_text",
+  "digest_items_markdown",
+  "recent_news_text",
+  "recent_news_markdown",
+  "unsubscribe_url",
+  "preferences_url",
+  "default_text_body",
+  "default_markdown_body",
+  "generated_at_iso",
+] as const;
+
+const PLACEHOLDER_ORDER = [
+  "campaign_subject",
+  "digest_heading",
+  "digest_summary",
+  "digest_items_markdown",
+  "recent_news_markdown",
+  "total_views",
+  "delta_views",
+  "campaign_type",
+  "period_days",
+  "digest_items_text",
+  "recent_news_text",
+  "default_markdown_body",
+  "default_text_body",
+  "preferences_url",
+  "unsubscribe_url",
+  "generated_at_iso",
+] as const;
+
+const MINIMAL_WRITING_PLACEHOLDERS = new Set([
+  "campaign_subject",
+  "campaign_type",
+  "period_days",
+  "digest_heading",
+  "digest_summary",
+  "total_views",
+  "delta_views",
+  "preferences_url",
+  "unsubscribe_url",
+  "generated_at_iso",
+]);
+
+const MARKDOWN_WRITING_PLACEHOLDERS = new Set([
+  ...MINIMAL_WRITING_PLACEHOLDERS,
+  "digest_items_markdown",
+  "recent_news_markdown",
+  "default_markdown_body",
+]);
+
+const TEXT_WRITING_PLACEHOLDERS = new Set([
+  ...MINIMAL_WRITING_PLACEHOLDERS,
+  "digest_items_text",
+  "recent_news_text",
+  "default_text_body",
+]);
+
+const SUBJECT_WRITING_PLACEHOLDERS = new Set([
+  "campaign_subject",
+  "campaign_type",
+  "period_days",
+  "digest_heading",
+  "generated_at_iso",
+]);
+
+function isHtmlPlaceholderToken(placeholder: string) {
+  return placeholder.endsWith("_html") || placeholder === "default_html_body";
+}
+
+function orderPlaceholders(placeholders: string[]): string[] {
+  const indexByName = new Map<string, number>(PLACEHOLDER_ORDER.map((name, index) => [name, index]));
+  return [...new Set(placeholders)].sort((a, b) => {
+    const aIdx = indexByName.get(a);
+    const bIdx = indexByName.get(b);
+    if (aIdx === undefined && bIdx === undefined) return a.localeCompare(b);
+    if (aIdx === undefined) return 1;
+    if (bIdx === undefined) return -1;
+    return aIdx - bIdx;
+  });
+}
+
+function filterRelevantPlaceholders(placeholders: string[], allowed: ReadonlySet<string>) {
+  const filtered = placeholders.filter((placeholder) => allowed.has(placeholder));
+  return filtered.length > 0 ? filtered : placeholders;
+}
 
 function cx(...parts: Array<string | false | null | undefined>) {
   return parts.filter(Boolean).join(" ");
 }
 
-function formatStatus(status: NewsletterCampaign["status"]) {
+function serializeCampaignDraft(draft: CampaignDraft | null) {
+  if (!draft) return null;
+  return JSON.stringify(draft);
+}
+
+function formatStatus(status: CampaignStatus) {
   return status === "sending" ? "Sending" : status.charAt(0).toUpperCase() + status.slice(1);
 }
 
-function StatusPill({ status }: { status: NewsletterCampaign["status"] }) {
+function formatLocalInputFromIso(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const min = String(d.getMinutes()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}T${hh}:${min}`;
+}
+
+function StatusPill({ status }: { status: CampaignStatus }) {
   const styles = {
     draft: "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200",
-    scheduled: "bg-indigo-50 text-indigo-700 border border-indigo-100 dark:bg-indigo-500/15 dark:text-indigo-200 dark:border-indigo-500/25",
-    sending: "bg-amber-50 text-amber-800 border border-amber-100 dark:bg-amber-500/15 dark:text-amber-200 dark:border-amber-500/25",
-    sent: "bg-emerald-50 text-emerald-800 border border-emerald-100 dark:bg-emerald-500/15 dark:text-emerald-200 dark:border-emerald-500/25",
-    failed: "bg-red-50 text-red-700 border border-red-100 dark:bg-red-500/15 dark:text-red-200 dark:border-red-500/25",
+    scheduled:
+      "border border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-500/25 dark:bg-indigo-500/15 dark:text-indigo-200",
+    sending:
+      "border border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-500/25 dark:bg-amber-500/15 dark:text-amber-200",
+    sent: "border border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/25 dark:bg-emerald-500/15 dark:text-emerald-200",
+    failed: "border border-red-200 bg-red-50 text-red-700 dark:border-red-500/25 dark:bg-red-500/15 dark:text-red-200",
   }[status];
 
   return (
-    <span className={cx("inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold", styles)}>
+    <span className={cx("inline-flex rounded-full px-2.5 py-1 text-xs font-semibold", styles)}>
       {formatStatus(status)}
     </span>
   );
@@ -129,13 +265,13 @@ function SegmentedControl<T extends string>(props: {
             key={opt.value}
             type="button"
             onClick={() => props.onChange(opt.value)}
+            title={opt.hint}
             className={cx(
-              "relative rounded-full px-3 py-1.5 text-sm font-semibold transition",
+              "rounded-full px-3 py-1.5 text-sm font-semibold transition",
               active
                 ? "bg-white text-neutral-900 shadow-sm ring-1 ring-neutral-200 dark:bg-neutral-950 dark:text-neutral-50 dark:ring-neutral-800"
                 : "text-neutral-600 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-white"
             )}
-            title={opt.hint}
           >
             {opt.label}
           </button>
@@ -145,7 +281,7 @@ function SegmentedControl<T extends string>(props: {
   );
 }
 
-function HtmlPreviewFrame({ html }: { html: string }) {
+function HtmlPreviewFrame({ html, className }: { html: string; className?: string }) {
   const srcDoc = `<!doctype html>
 <html>
   <head>
@@ -153,16 +289,17 @@ function HtmlPreviewFrame({ html }: { html: string }) {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <base target="_blank" />
     <style>
-      :root { color-scheme: light; }
+      :root { color-scheme: only light; }
       body {
         margin: 0;
         padding: 18px;
-        font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
-        line-height: 1.45;
+        font-family: ${SUBSTACK_SANS_FONT_STACK};
+        line-height: 1.6;
       }
       img { max-width: 100%; height: auto; }
       hr { border: none; border-top: 1px solid #e5e7eb; margin: 18px 0; }
-      a { color: #4338ca; }
+      h1, h2, h3, h4, h5, h6 { font-family: ${SUBSTACK_SANS_FONT_STACK}; color: #111111; }
+      a { color: #111111; text-decoration: underline; text-underline-offset: 2px; text-decoration-thickness: 1px; }
       pre, code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
     </style>
   </head>
@@ -174,7 +311,10 @@ function HtmlPreviewFrame({ html }: { html: string }) {
       title="Newsletter HTML Preview"
       sandbox="allow-popups allow-popups-to-escape-sandbox"
       referrerPolicy="no-referrer"
-      className="h-[520px] w-full rounded-xl border border-neutral-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-950"
+      className={cx(
+        "w-full rounded-xl border border-neutral-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-950",
+        className || "h-[620px]"
+      )}
       srcDoc={srcDoc}
     />
   );
@@ -192,11 +332,68 @@ function isoDay(date: Date) {
   return date.toISOString().slice(0, 10);
 }
 
-function suggestedWeeklySubject(type: NewsletterType, periodDays: number) {
+function suggestedSubject(type: NewsletterType, periodDays: number) {
   const now = new Date();
   const { start, end } = computeUtcWindow(periodDays, now);
   const label = type === "news" ? "Weekly News Digest" : `${type[0].toUpperCase()}${type.slice(1)} Digest`;
   return `${label} (${isoDay(start)} to ${isoDay(end)})`;
+}
+
+function withSelectionWrap(
+  ref: HTMLTextAreaElement | null,
+  value: string,
+  before: string,
+  after: string,
+  fallback: string
+) {
+  if (!ref) {
+    return `${value}${before}${fallback}${after}`;
+  }
+
+  const start = ref.selectionStart ?? value.length;
+  const end = ref.selectionEnd ?? start;
+  const selected = value.slice(start, end) || fallback;
+  return `${value.slice(0, start)}${before}${selected}${after}${value.slice(end)}`;
+}
+
+function withSelectionPrefix(ref: HTMLTextAreaElement | null, value: string, prefix: string, fallback: string) {
+  if (!ref) return `${value}\n${prefix}${fallback}`;
+
+  const start = ref.selectionStart ?? value.length;
+  const end = ref.selectionEnd ?? start;
+  const selected = value.slice(start, end) || fallback;
+  const transformed = selected
+    .split("\n")
+    .map((line) => `${prefix}${line}`)
+    .join("\n");
+
+  return `${value.slice(0, start)}${transformed}${value.slice(end)}`;
+}
+
+function countWords(value: string): number {
+  const trimmed = value.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+function MarkdownToolbar(props: {
+  onApply: (kind: MarkdownFormatKind) => void;
+  className?: string;
+}) {
+  return (
+    <div className={cx("flex flex-wrap gap-2", props.className)}>
+      {MARKDOWN_TOOLBAR_ACTIONS.map((action) => (
+        <button
+          key={action.id}
+          type="button"
+          onClick={() => props.onApply(action.id)}
+          className="rounded-md border px-2 py-1 text-xs"
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 export function NewsletterStudio() {
@@ -210,121 +407,60 @@ export function NewsletterStudio() {
   const [campaigns, setCampaigns] = useState<NewsletterCampaign[]>([]);
   const [templates, setTemplates] = useState<Record<NewsletterType, NewsletterTemplate> | null>(null);
 
-  const [campaignForm, setCampaignForm] = useState({
-    newsletterType: "news" as NewsletterType,
+  const [composeForm, setComposeForm] = useState<CampaignDraft>({
+    newsletterType: "news",
     subject: "",
     previewText: "",
+    contentMode: "template",
+    markdownContent: "",
+    manualHtml: "",
+    manualText: "",
     periodDays: 7,
     scheduledAtLocal: "",
   });
+  const [composePreview, setComposePreview] = useState<CampaignPreviewResult | null>(null);
+  const [composePreviewTab, setComposePreviewTab] = useState<PreviewTab>("html");
+  const [composeWorkspaceView, setComposeWorkspaceView] = useState<WorkspaceView>("split");
+  const [composePreviewLoading, setComposePreviewLoading] = useState(false);
+  const [composeFocusedField, setComposeFocusedField] = useState<ComposeFieldKey | null>(null);
 
-  const [queueFilter, setQueueFilter] = useState<NewsletterCampaign["status"] | "all">("all");
+  const [queueFilter, setQueueFilter] = useState<CampaignStatus | "all">("all");
   const [queueSearch, setQueueSearch] = useState("");
   const [scheduleDrafts, setScheduleDrafts] = useState<Record<string, string>>({});
 
+  const [editingCampaignId, setEditingCampaignId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<CampaignDraft | null>(null);
+  const [editPreview, setEditPreview] = useState<CampaignPreviewResult | null>(null);
+  const [editPreviewTab, setEditPreviewTab] = useState<PreviewTab>("html");
+  const [editPreviewLoading, setEditPreviewLoading] = useState(false);
+  const [editFocusedField, setEditFocusedField] = useState<ComposeFieldKey | null>(null);
+  const [editWorkspaceView, setEditWorkspaceView] = useState<WorkspaceView>("split");
+
   const [activeTemplateType, setActiveTemplateType] = useState<NewsletterType>("news");
   const [templateDraft, setTemplateDraft] = useState<NewsletterTemplate | null>(null);
-  const [templatePreview, setTemplatePreview] = useState<TemplatePreview | null>(null);
+  const [templatePreview, setTemplatePreview] = useState<TemplatePreviewResult | null>(null);
   const [templatePreviewTab, setTemplatePreviewTab] = useState<PreviewTab>("html");
-  const [templatePreviewContext, setTemplatePreviewContext] = useState({ periodDays: 7, campaignSubject: "Weekly News Digest" });
+  const [templatePreviewContext, setTemplatePreviewContext] = useState({
+    periodDays: 7,
+    campaignSubject: "Weekly News Digest",
+  });
   const [focusedTemplateField, setFocusedTemplateField] = useState<TemplateFieldKey | null>(null);
 
-  const subjectTemplateRef = useRef<HTMLInputElement | null>(null);
-  const htmlTemplateRef = useRef<HTMLTextAreaElement | null>(null);
-  const textTemplateRef = useRef<HTMLTextAreaElement | null>(null);
+  const composeMarkdownRef = useRef<HTMLTextAreaElement | null>(null);
+  const composeManualHtmlRef = useRef<HTMLTextAreaElement | null>(null);
+  const composeManualTextRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const templateSubjectRef = useRef<HTMLInputElement | null>(null);
+  const templateHtmlRef = useRef<HTMLTextAreaElement | null>(null);
+  const templateTextRef = useRef<HTMLTextAreaElement | null>(null);
+  const templateMarkdownRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const editMarkdownRef = useRef<HTMLTextAreaElement | null>(null);
+  const editManualHtmlRef = useRef<HTMLTextAreaElement | null>(null);
+  const editManualTextRef = useRef<HTMLTextAreaElement | null>(null);
+  const [editInitialSnapshot, setEditInitialSnapshot] = useState<string | null>(null);
+
   const statusMessageTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const [composePreview, setComposePreview] = useState<TemplatePreview | null>(null);
-  const [composePreviewTab, setComposePreviewTab] = useState<PreviewTab>("html");
-  const [composePreviewLoading, setComposePreviewLoading] = useState(false);
-
-  const [subscribers, setSubscribers] = useState<SubscriberRow[]>([]);
-  const [subscriberTotal, setSubscriberTotal] = useState(0);
-  const [subscriberLoading, setSubscriberLoading] = useState(false);
-
-  const refreshData = useCallback(async () => {
-    setError(null);
-
-    const headers = { "x-api-key": getAdminApiKey() };
-    const [campaignsResult, templatesResult] = await Promise.all([
-      adminFetch<NewsletterCampaign[]>("/api/v1/newsletter/campaigns?limit=100", { headers }),
-      adminFetch<NewsletterTemplate[]>("/api/v1/newsletter/templates", { headers }),
-    ]);
-
-    if (campaignsResult.error) {
-      setError(campaignsResult.error);
-    } else {
-      setCampaigns(campaignsResult.data || []);
-    }
-
-    if (templatesResult.error) {
-      setError((prev) => prev || templatesResult.error);
-    } else {
-      const byType = Object.fromEntries(
-        (templatesResult.data || []).map((item) => [item.newsletterType, item])
-      ) as Record<NewsletterType, NewsletterTemplate>;
-      setTemplates(byType);
-
-      const current = byType[activeTemplateType];
-      setTemplateDraft(current || null);
-    }
-  }, [activeTemplateType]);
-
-  useEffect(() => {
-    const load = async () => {
-      setLoading(true);
-      await refreshData();
-      setLoading(false);
-    };
-
-    load();
-  }, [refreshData]);
-
-  async function loadSubscribers() {
-    setSubscriberLoading(true);
-    try {
-      const res = await fetch("/api/v1/newsletter/subscribers?limit=200", {
-        headers: { "x-api-key": getAdminApiKey() },
-      });
-      if (res.ok) {
-        const json = await res.json();
-        setSubscribers(json.data);
-        setSubscriberTotal(json.total);
-      }
-    } finally {
-      setSubscriberLoading(false);
-    }
-  }
-
-  useEffect(() => {
-    if (mode === "subscribers") {
-      loadSubscribers();
-    }
-  }, [mode]);
-
-  const sortedCampaigns = useMemo(() => {
-    return [...campaigns].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-  }, [campaigns]);
-
-  const filteredCampaigns = useMemo(() => {
-    const q = queueSearch.trim().toLowerCase();
-    return sortedCampaigns.filter((c) => {
-      if (queueFilter !== "all" && c.status !== queueFilter) return false;
-      if (!q) return true;
-      return c.subject.toLowerCase().includes(q) || c.newsletterType.toLowerCase().includes(q);
-    });
-  }, [queueFilter, queueSearch, sortedCampaigns]);
-
-  const templateIsDirty = useMemo(() => {
-    if (!templateDraft || !templates) return false;
-    const original = templates[templateDraft.newsletterType];
-    if (!original) return true;
-    return (
-      original.subjectTemplate !== templateDraft.subjectTemplate ||
-      original.htmlTemplate !== templateDraft.htmlTemplate ||
-      original.textTemplate !== templateDraft.textTemplate
-    );
-  }, [templateDraft, templates]);
 
   const setStatusMessage = (value: string) => {
     setMessage(value);
@@ -345,25 +481,187 @@ export function NewsletterStudio() {
     };
   }, []);
 
-  const handleTemplateTypeChange = (nextType: NewsletterType) => {
-    setActiveTemplateType(nextType);
-    if (templates) setTemplateDraft(templates[nextType] || null);
-    else setTemplateDraft(null);
-    setTemplatePreview(null);
-    setTemplatePreviewTab("html");
-  };
+  const refreshData = useCallback(async () => {
+    setError(null);
 
-  const setStudioMode = (next: Mode) => {
-    setMode(next);
+    const headers = { "x-api-key": getAdminApiKey() };
+    const [campaignsResult, templatesResult] = await Promise.all([
+      adminFetch<NewsletterCampaign[]>("/api/v1/newsletter/campaigns?limit=100", { headers }),
+      adminFetch<NewsletterTemplate[]>("/api/v1/newsletter/templates", { headers }),
+    ]);
 
-    if (next === "templates") {
-      setTemplatePreview(null);
-      setTemplatePreviewTab("html");
+    if (campaignsResult.error) {
+      setError(campaignsResult.error);
+    } else {
+      setCampaigns(campaignsResult.data || []);
     }
-  };
+
+    if (templatesResult.error) {
+      setError((prev) => prev || templatesResult.error);
+    } else {
+      const byType = Object.fromEntries((templatesResult.data || []).map((x) => [x.newsletterType, x])) as Record<
+        NewsletterType,
+        NewsletterTemplate
+      >;
+      setTemplates(byType);
+      setTemplateDraft(byType[activeTemplateType] || null);
+    }
+  }, [activeTemplateType]);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      await refreshData();
+      setLoading(false);
+    };
+    load();
+  }, [refreshData]);
+
+  const sortedCampaigns = useMemo(() => {
+    return [...campaigns].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }, [campaigns]);
+
+  const filteredCampaigns = useMemo(() => {
+    const q = queueSearch.trim().toLowerCase();
+    return sortedCampaigns.filter((item) => {
+      if (queueFilter !== "all" && item.status !== queueFilter) return false;
+      if (!q) return true;
+      return item.subject.toLowerCase().includes(q) || item.newsletterType.toLowerCase().includes(q);
+    });
+  }, [queueFilter, queueSearch, sortedCampaigns]);
+
+  const templateIsDirty = useMemo(() => {
+    if (!templateDraft || !templates) return false;
+    const base = templates[templateDraft.newsletterType];
+    if (!base) return true;
+    return (
+      base.subjectTemplate !== templateDraft.subjectTemplate ||
+      base.htmlTemplate !== templateDraft.htmlTemplate ||
+      base.textTemplate !== templateDraft.textTemplate ||
+      base.markdownTemplate !== templateDraft.markdownTemplate
+    );
+  }, [templateDraft, templates]);
+
+  const isEditDirty = useMemo(() => {
+    const currentSnapshot = serializeCampaignDraft(editForm);
+    if (!currentSnapshot || !editInitialSnapshot) return false;
+    return currentSnapshot !== editInitialSnapshot;
+  }, [editForm, editInitialSnapshot]);
+
+  const resolvedPlaceholders = useMemo(() => {
+    const source = composePreview?.placeholders?.length
+      ? composePreview.placeholders
+      : templatePreview?.placeholders?.length
+        ? templatePreview.placeholders
+        : [...FALLBACK_PLACEHOLDERS];
+    return orderPlaceholders(source.filter((placeholder) => !isHtmlPlaceholderToken(placeholder)));
+  }, [composePreview, templatePreview]);
+
+  const composeInsertablePlaceholders = useMemo(() => {
+    if (composeForm.contentMode === "markdown") {
+      return filterRelevantPlaceholders(resolvedPlaceholders, MARKDOWN_WRITING_PLACEHOLDERS);
+    }
+
+    if (composeFocusedField === "manualHtml") {
+      return filterRelevantPlaceholders(resolvedPlaceholders, MINIMAL_WRITING_PLACEHOLDERS);
+    }
+
+    return filterRelevantPlaceholders(resolvedPlaceholders, TEXT_WRITING_PLACEHOLDERS);
+  }, [composeForm.contentMode, composeFocusedField, resolvedPlaceholders]);
+
+  const editInsertablePlaceholders = useMemo(() => {
+    if (!editForm) return resolvedPlaceholders;
+    if (editForm.contentMode === "markdown") {
+      return filterRelevantPlaceholders(resolvedPlaceholders, MARKDOWN_WRITING_PLACEHOLDERS);
+    }
+
+    if (editFocusedField === "manualHtml") {
+      return filterRelevantPlaceholders(resolvedPlaceholders, MINIMAL_WRITING_PLACEHOLDERS);
+    }
+
+    return filterRelevantPlaceholders(resolvedPlaceholders, TEXT_WRITING_PLACEHOLDERS);
+  }, [editForm, editFocusedField, resolvedPlaceholders]);
+
+  const templateInsertablePlaceholders = useMemo(() => {
+    const field = focusedTemplateField || "markdownTemplate";
+    if (field === "subjectTemplate") {
+      return filterRelevantPlaceholders(resolvedPlaceholders, SUBJECT_WRITING_PLACEHOLDERS);
+    }
+    if (field === "markdownTemplate") {
+      return filterRelevantPlaceholders(resolvedPlaceholders, MARKDOWN_WRITING_PLACEHOLDERS);
+    }
+    if (field === "textTemplate") {
+      return filterRelevantPlaceholders(resolvedPlaceholders, TEXT_WRITING_PLACEHOLDERS);
+    }
+    return filterRelevantPlaceholders(resolvedPlaceholders, MINIMAL_WRITING_PLACEHOLDERS);
+  }, [focusedTemplateField, resolvedPlaceholders]);
+
+  const requestCampaignPreview = useCallback(
+    async (draft: CampaignDraft) => {
+      const payload = {
+        newsletterType: draft.newsletterType,
+        subject: draft.subject.trim() || suggestedSubject(draft.newsletterType, draft.periodDays),
+        periodDays: draft.periodDays,
+        contentMode: draft.contentMode,
+        markdownContent: draft.contentMode === "markdown" ? draft.markdownContent : undefined,
+        manualHtml: draft.contentMode === "manual" ? draft.manualHtml : undefined,
+        manualText: draft.contentMode === "manual" ? draft.manualText : undefined,
+      };
+
+      return adminFetch<CampaignPreviewResult>("/api/v1/newsletter/campaigns/preview", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": getAdminApiKey(),
+        },
+        body: JSON.stringify(payload),
+      });
+    },
+    []
+  );
+
+  const renderComposePreview = useCallback(async () => {
+    setComposePreviewLoading(true);
+    const result = await requestCampaignPreview(composeForm);
+    setComposePreviewLoading(false);
+
+    if (result.error || !result.data) {
+      setError(result.error || "Unable to render preview");
+      return;
+    }
+
+    setComposePreview(result.data);
+  }, [composeForm, requestCampaignPreview]);
+
+  useEffect(() => {
+    if (mode !== "compose") return;
+
+    const handle = setTimeout(() => {
+      void renderComposePreview();
+    }, 250);
+
+    return () => clearTimeout(handle);
+  }, [mode, renderComposePreview]);
+
+  const closeEditPanel = useCallback(
+    (force = false) => {
+      if (!force && isEditDirty) {
+        const confirmed = confirm("Discard unsaved campaign edits?");
+        if (!confirmed) return false;
+      }
+
+      setEditingCampaignId(null);
+      setEditForm(null);
+      setEditPreview(null);
+      setEditPreviewLoading(false);
+      setEditInitialSnapshot(null);
+      return true;
+    },
+    [isEditDirty]
+  );
 
   const createCampaign = async () => {
-    if (!campaignForm.subject.trim()) {
+    if (!composeForm.subject.trim()) {
       setError("Subject is required");
       return;
     }
@@ -378,12 +676,16 @@ export function NewsletterStudio() {
         "x-api-key": getAdminApiKey(),
       },
       body: JSON.stringify({
-        newsletterType: campaignForm.newsletterType,
-        subject: campaignForm.subject,
-        previewText: campaignForm.previewText || undefined,
-        periodDays: campaignForm.periodDays,
-        scheduledAt: campaignForm.scheduledAtLocal ? new Date(campaignForm.scheduledAtLocal).toISOString() : undefined,
+        newsletterType: composeForm.newsletterType,
+        subject: composeForm.subject,
+        previewText: composeForm.previewText || undefined,
+        periodDays: composeForm.periodDays,
+        scheduledAt: composeForm.scheduledAtLocal ? new Date(composeForm.scheduledAtLocal).toISOString() : undefined,
         createdBy: "admin-news-studio",
+        contentMode: composeForm.contentMode,
+        markdownContent: composeForm.contentMode === "markdown" ? composeForm.markdownContent : undefined,
+        manualHtml: composeForm.contentMode === "manual" ? composeForm.manualHtml : undefined,
+        manualText: composeForm.contentMode === "manual" ? composeForm.manualText : undefined,
       }),
     });
 
@@ -394,8 +696,17 @@ export function NewsletterStudio() {
       return;
     }
 
-    setCampaignForm((current) => ({ ...current, subject: "", previewText: "", scheduledAtLocal: "" }));
     setStatusMessage("Draft created");
+    setComposeForm((current) => ({
+      ...current,
+      subject: "",
+      previewText: "",
+      scheduledAtLocal: "",
+      markdownContent: current.contentMode === "markdown" ? current.markdownContent : "",
+      manualHtml: current.contentMode === "manual" ? current.manualHtml : "",
+      manualText: current.contentMode === "manual" ? current.manualText : "",
+    }));
+
     await refreshData();
     setMode("queue");
   };
@@ -408,7 +719,6 @@ export function NewsletterStudio() {
       created: boolean;
       periodStart: string;
       periodEnd: string;
-      campaign: NewsletterCampaign;
     }>("/api/v1/newsletter/campaigns/auto-create-weekly", {
       method: "POST",
       headers: {
@@ -433,26 +743,6 @@ export function NewsletterStudio() {
 
     await refreshData();
     setMode("queue");
-  };
-
-  const sendNow = async (campaignId: string) => {
-    setSaving(true);
-    setError(null);
-
-    const { error: sendError } = await adminFetch(`/api/v1/newsletter/campaigns/${campaignId}/send`, {
-      method: "POST",
-      headers: { "x-api-key": getAdminApiKey() },
-    });
-
-    setSaving(false);
-
-    if (sendError) {
-      setError(sendError);
-      return;
-    }
-
-    setStatusMessage("Send started");
-    await refreshData();
   };
 
   const scheduleCampaign = async (campaignId: string) => {
@@ -481,9 +771,160 @@ export function NewsletterStudio() {
       return;
     }
 
-    setStatusMessage("Scheduled");
+    setStatusMessage("Campaign scheduled");
     await refreshData();
   };
+
+  const sendNow = async (campaignId: string) => {
+    setSaving(true);
+    setError(null);
+
+    const { error: sendError } = await adminFetch(`/api/v1/newsletter/campaigns/${campaignId}/send`, {
+      method: "POST",
+      headers: { "x-api-key": getAdminApiKey() },
+    });
+
+    setSaving(false);
+
+    if (sendError) {
+      setError(sendError);
+      return;
+    }
+
+    setStatusMessage("Campaign send started");
+    await refreshData();
+  };
+
+  const deleteCampaign = async (campaign: NewsletterCampaign) => {
+    if (!MUTABLE_STATUSES.has(campaign.status)) return;
+    const ok = confirm(`Delete draft \"${campaign.subject}\"? This cannot be undone.`);
+    if (!ok) return;
+
+    setSaving(true);
+    setError(null);
+
+    const { error: deleteError } = await adminFetch(`/api/v1/newsletter/campaigns/${campaign.id}`, {
+      method: "DELETE",
+      headers: { "x-api-key": getAdminApiKey() },
+    });
+
+    setSaving(false);
+
+    if (deleteError) {
+      setError(deleteError);
+      return;
+    }
+
+    if (editingCampaignId === campaign.id) {
+      closeEditPanel(true);
+    }
+
+    setStatusMessage("Campaign deleted");
+    await refreshData();
+  };
+
+  const openCampaignEditor = async (campaignId: string) => {
+    if (editingCampaignId && isEditDirty) {
+      const confirmed = confirm("You have unsaved campaign edits. Continue and discard them?");
+      if (!confirmed) return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    const result = await adminFetch<NewsletterCampaign>(`/api/v1/newsletter/campaigns/${campaignId}`, {
+      headers: { "x-api-key": getAdminApiKey() },
+    });
+
+    setSaving(false);
+
+    if (result.error || !result.data) {
+      setError(result.error || "Unable to load campaign");
+      return;
+    }
+
+    const campaign = result.data;
+    const draft: CampaignDraft = {
+      newsletterType: campaign.newsletterType,
+      subject: campaign.subject,
+      previewText: campaign.previewText || "",
+      contentMode: campaign.contentMode,
+      markdownContent: campaign.markdownContent || "",
+      manualHtml: campaign.manualHtml || "",
+      manualText: campaign.manualText || "",
+      periodDays: campaign.periodDays,
+      scheduledAtLocal: formatLocalInputFromIso(campaign.scheduledAt),
+    };
+
+    setEditingCampaignId(campaign.id);
+    setEditForm(draft);
+    setEditInitialSnapshot(serializeCampaignDraft(draft));
+    setEditPreview(null);
+    setEditPreviewTab("html");
+  };
+
+  const saveCampaignEdit = async () => {
+    if (!editingCampaignId || !editForm) return;
+
+    setSaving(true);
+    setError(null);
+
+    const { error: updateError } = await adminFetch(`/api/v1/newsletter/campaigns/${editingCampaignId}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": getAdminApiKey(),
+      },
+      body: JSON.stringify({
+        newsletterType: editForm.newsletterType,
+        subject: editForm.subject,
+        previewText: editForm.previewText,
+        periodDays: editForm.periodDays,
+        scheduledAt: editForm.scheduledAtLocal ? new Date(editForm.scheduledAtLocal).toISOString() : null,
+        contentMode: editForm.contentMode,
+        markdownContent: editForm.contentMode === "markdown" ? editForm.markdownContent : null,
+        manualHtml: editForm.contentMode === "manual" ? editForm.manualHtml : null,
+        manualText: editForm.contentMode === "manual" ? editForm.manualText : null,
+      }),
+    });
+
+    setSaving(false);
+
+    if (updateError) {
+      setError(updateError);
+      return;
+    }
+
+    setStatusMessage("Campaign updated");
+    setEditInitialSnapshot(serializeCampaignDraft(editForm));
+    await refreshData();
+  };
+
+  const renderEditPreview = useCallback(async () => {
+    if (!editForm) return;
+    setEditPreviewLoading(true);
+
+    const result = await requestCampaignPreview(editForm);
+
+    setEditPreviewLoading(false);
+
+    if (result.error || !result.data) {
+      setError(result.error || "Unable to render preview");
+      return;
+    }
+
+    setEditPreview(result.data);
+  }, [editForm, requestCampaignPreview]);
+
+  useEffect(() => {
+    if (mode !== "queue" || !editForm) return;
+
+    const handle = setTimeout(() => {
+      void renderEditPreview();
+    }, 250);
+
+    return () => clearTimeout(handle);
+  }, [mode, editForm, renderEditPreview]);
 
   const saveTemplate = async () => {
     if (!templateDraft) return;
@@ -517,7 +958,7 @@ export function NewsletterStudio() {
     setSaving(true);
     setError(null);
 
-    const result = await adminFetch<TemplatePreview>("/api/v1/newsletter/templates/preview", {
+    const result = await adminFetch<TemplatePreviewResult>("/api/v1/newsletter/templates/preview", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -530,90 +971,322 @@ export function NewsletterStudio() {
         subjectTemplate: templateDraft.subjectTemplate,
         htmlTemplate: templateDraft.htmlTemplate,
         textTemplate: templateDraft.textTemplate,
+        markdownTemplate: templateDraft.markdownTemplate,
       }),
     });
 
     setSaving(false);
 
     if (result.error || !result.data) {
-      setError(result.error || "Unable to render preview");
+      setError(result.error || "Unable to render template preview");
       return;
     }
 
     setTemplatePreview(result.data);
   };
 
-  const insertPlaceholderIntoTemplate = (placeholder: string) => {
-    if (!templateDraft) return;
+  const insertComposeToken = (placeholder: string) => {
     const token = `{{${placeholder}}}`;
+    const field = composeFocusedField || (composeForm.contentMode === "manual" ? "manualText" : "markdownContent");
 
-    const field: TemplateFieldKey = focusedTemplateField || "htmlTemplate";
-    const currentValue = templateDraft[field] || "";
-
-    const element: HTMLInputElement | HTMLTextAreaElement | null =
-      field === "subjectTemplate"
-        ? subjectTemplateRef.current
-        : field === "htmlTemplate"
-          ? htmlTemplateRef.current
-          : textTemplateRef.current;
-
-    const start = element?.selectionStart ?? currentValue.length;
-    const end = element?.selectionEnd ?? start;
-
-    const nextValue = currentValue.slice(0, start) + token + currentValue.slice(end);
-    setTemplateDraft({ ...templateDraft, [field]: nextValue });
-
-    requestAnimationFrame(() => {
-      if (!element) return;
-      element.focus();
-      try {
-        element.setSelectionRange(start + token.length, start + token.length);
-      } catch {
-        // ignore
-      }
-    });
-  };
-
-  const renderComposePreview = useCallback(async () => {
-    if (getAdminApiKey() === "") return;
-
-    setComposePreviewLoading(true);
-    const subject = campaignForm.subject.trim()
-      ? campaignForm.subject.trim()
-      : suggestedWeeklySubject(campaignForm.newsletterType, campaignForm.periodDays);
-
-    const result = await adminFetch<TemplatePreview>("/api/v1/newsletter/templates/preview", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": getAdminApiKey(),
-      },
-      body: JSON.stringify({
-        newsletterType: campaignForm.newsletterType,
-        periodDays: campaignForm.periodDays,
-        campaignSubject: subject,
-      }),
-    });
-
-    setComposePreviewLoading(false);
-
-    if (result.error || !result.data) {
-      setError(result.error || "Unable to render preview");
+    if (field === "markdownContent") {
+      const el = composeMarkdownRef.current;
+      const value = composeForm.markdownContent;
+      const start = el?.selectionStart ?? value.length;
+      const end = el?.selectionEnd ?? start;
+      setComposeForm((current) => ({
+        ...current,
+        markdownContent: `${value.slice(0, start)}${token}${value.slice(end)}`,
+      }));
       return;
     }
 
+    if (field === "manualHtml") {
+      const el = composeManualHtmlRef.current;
+      const value = composeForm.manualHtml;
+      const start = el?.selectionStart ?? value.length;
+      const end = el?.selectionEnd ?? start;
+      setComposeForm((current) => ({
+        ...current,
+        manualHtml: `${value.slice(0, start)}${token}${value.slice(end)}`,
+      }));
+      return;
+    }
+
+    const el = composeManualTextRef.current;
+    const value = composeForm.manualText;
+    const start = el?.selectionStart ?? value.length;
+    const end = el?.selectionEnd ?? start;
+    setComposeForm((current) => ({
+      ...current,
+      manualText: `${value.slice(0, start)}${token}${value.slice(end)}`,
+    }));
+  };
+
+  const insertEditToken = (placeholder: string) => {
+    if (!editForm) return;
+
+    const token = `{{${placeholder}}}`;
+    const field = editFocusedField || (editForm.contentMode === "manual" ? "manualText" : "markdownContent");
+
+    if (field === "markdownContent") {
+      const el = editMarkdownRef.current;
+      const value = editForm.markdownContent;
+      const start = el?.selectionStart ?? value.length;
+      const end = el?.selectionEnd ?? start;
+      setEditForm((current) =>
+        current ? { ...current, markdownContent: `${value.slice(0, start)}${token}${value.slice(end)}` } : current
+      );
+      return;
+    }
+
+    if (field === "manualHtml") {
+      const el = editManualHtmlRef.current;
+      const value = editForm.manualHtml;
+      const start = el?.selectionStart ?? value.length;
+      const end = el?.selectionEnd ?? start;
+      setEditForm((current) =>
+        current ? { ...current, manualHtml: `${value.slice(0, start)}${token}${value.slice(end)}` } : current
+      );
+      return;
+    }
+
+    const el = editManualTextRef.current;
+    const value = editForm.manualText;
+    const start = el?.selectionStart ?? value.length;
+    const end = el?.selectionEnd ?? start;
+    setEditForm((current) =>
+      current ? { ...current, manualText: `${value.slice(0, start)}${token}${value.slice(end)}` } : current
+    );
+  };
+
+  const insertTemplateToken = (placeholder: string) => {
+    if (!templateDraft) return;
+    const token = `{{${placeholder}}}`;
+    const field = focusedTemplateField || "markdownTemplate";
+
+    const refs: Record<TemplateFieldKey, HTMLInputElement | HTMLTextAreaElement | null> = {
+      subjectTemplate: templateSubjectRef.current,
+      htmlTemplate: templateHtmlRef.current,
+      textTemplate: templateTextRef.current,
+      markdownTemplate: templateMarkdownRef.current,
+    };
+
+    const ref = refs[field];
+    const value = templateDraft[field];
+    const start = ref?.selectionStart ?? value.length;
+    const end = ref?.selectionEnd ?? start;
+
+    setTemplateDraft({
+      ...templateDraft,
+      [field]: `${value.slice(0, start)}${token}${value.slice(end)}`,
+    });
+  };
+
+  const applyMarkdownFormat = (
+    value: string,
+    ref: HTMLTextAreaElement | null,
+    kind: MarkdownFormatKind
+  ) => {
+    let next = value;
+    if (kind === "h2") next = withSelectionPrefix(ref, value, "## ", "Heading");
+    if (kind === "bold") next = withSelectionWrap(ref, value, "**", "**", "bold text");
+    if (kind === "italic") next = withSelectionWrap(ref, value, "*", "*", "italic text");
+    if (kind === "link") next = withSelectionWrap(ref, value, "[", "](https://)", "link text");
+    if (kind === "list") next = withSelectionPrefix(ref, value, "- ", "List item");
+    if (kind === "quote") next = withSelectionPrefix(ref, value, "> ", "Quote");
+    if (kind === "code") next = withSelectionWrap(ref, value, "```\n", "\n```", "code");
+    if (kind === "divider") next = `${value}\n\n---\n\n`;
+    return next;
+  };
+
+  const handleMarkdownHotkeys = (
+    event: KeyboardEvent<HTMLTextAreaElement>,
+    onApply: (kind: MarkdownFormatKind) => void
+  ) => {
+    if (!(event.metaKey || event.ctrlKey)) return;
+
+    const key = event.key.toLowerCase();
+    if (key === "b") {
+      event.preventDefault();
+      onApply("bold");
+      return;
+    }
+    if (key === "i") {
+      event.preventDefault();
+      onApply("italic");
+      return;
+    }
+    if (key === "k") {
+      event.preventDefault();
+      onApply("link");
+    }
+  };
+
+  const applyComposeMarkdownFormat = (kind: MarkdownFormatKind) => {
+    const ref = composeMarkdownRef.current;
+    const value = composeForm.markdownContent;
+    const next = applyMarkdownFormat(value, ref, kind);
+    setComposeForm((current) => ({ ...current, markdownContent: next }));
+  };
+
+  const applyEditMarkdownFormat = (kind: MarkdownFormatKind) => {
+    if (!editForm) return;
+
+    const ref = editMarkdownRef.current;
+    const value = editForm.markdownContent;
+    const next = applyMarkdownFormat(value, ref, kind);
+
+    setEditForm((current) => (current ? { ...current, markdownContent: next } : current));
+  };
+
+  const autofillComposeMarkdown = async (forceOverride: boolean) => {
+    if (composeForm.contentMode !== "markdown") return;
+
+    if (composeForm.markdownContent.trim()) {
+      const ok = confirm(
+        forceOverride
+          ? "This will overwrite existing markdown content. Continue?"
+          : "Markdown already has content. Replace with template starter?"
+      );
+      if (!ok) return;
+    }
+
+    setSaving(true);
+    setError(null);
+    const result = await requestCampaignPreview({
+      ...composeForm,
+      contentMode: "template",
+      markdownContent: "",
+      manualHtml: "",
+      manualText: "",
+    });
+    setSaving(false);
+
+    if (result.error || !result.data) {
+      setError(result.error || "Unable to generate starter markdown");
+      return;
+    }
+
+    setComposeForm((current) => ({ ...current, markdownContent: result.data!.starter.markdown }));
     setComposePreview(result.data);
-  }, [campaignForm.newsletterType, campaignForm.periodDays, campaignForm.subject]);
+  };
 
-  useEffect(() => {
-    if (mode !== "compose") return;
+  const autofillComposeManual = async (forceOverride: boolean) => {
+    if (composeForm.contentMode !== "manual") return;
 
-    const handle = setTimeout(() => {
-      void renderComposePreview();
-    }, 280);
+    if (composeForm.manualHtml.trim() || composeForm.manualText.trim()) {
+      const ok = confirm(
+        forceOverride
+          ? "This will overwrite existing manual HTML/Text content. Continue?"
+          : "Manual HTML/Text already has content. Replace with template output?"
+      );
+      if (!ok) return;
+    }
 
-    return () => clearTimeout(handle);
-  }, [mode, renderComposePreview]);
+    setSaving(true);
+    setError(null);
+    const result = await requestCampaignPreview({
+      ...composeForm,
+      contentMode: "template",
+      markdownContent: "",
+      manualHtml: "",
+      manualText: "",
+    });
+    setSaving(false);
+
+    if (result.error || !result.data) {
+      setError(result.error || "Unable to generate manual content from template");
+      return;
+    }
+
+    setComposeForm((current) => ({
+      ...current,
+      manualHtml: result.data!.rendered.html,
+      manualText: result.data!.rendered.text,
+    }));
+    setComposePreview(result.data);
+  };
+
+  const autofillEditMarkdown = async (forceOverride: boolean) => {
+    if (!editForm || editForm.contentMode !== "markdown") return;
+
+    if (editForm.markdownContent.trim()) {
+      const ok = confirm(
+        forceOverride
+          ? "This will overwrite existing markdown content in this draft. Continue?"
+          : "Markdown already has content. Replace with template starter?"
+      );
+      if (!ok) return;
+    }
+
+    setSaving(true);
+    setError(null);
+    const result = await requestCampaignPreview({
+      ...editForm,
+      contentMode: "template",
+      markdownContent: "",
+      manualHtml: "",
+      manualText: "",
+    });
+    setSaving(false);
+
+    if (result.error || !result.data) {
+      setError(result.error || "Unable to generate starter markdown");
+      return;
+    }
+
+    setEditForm((current) => (current ? { ...current, markdownContent: result.data!.starter.markdown } : current));
+    setEditPreview(result.data);
+  };
+
+  const autofillEditManual = async (forceOverride: boolean) => {
+    if (!editForm || editForm.contentMode !== "manual") return;
+
+    if (editForm.manualHtml.trim() || editForm.manualText.trim()) {
+      const ok = confirm(
+        forceOverride
+          ? "This will overwrite existing manual HTML/Text content in this draft. Continue?"
+          : "Manual HTML/Text already has content. Replace with template output?"
+      );
+      if (!ok) return;
+    }
+
+    setSaving(true);
+    setError(null);
+    const result = await requestCampaignPreview({
+      ...editForm,
+      contentMode: "template",
+      markdownContent: "",
+      manualHtml: "",
+      manualText: "",
+    });
+    setSaving(false);
+
+    if (result.error || !result.data) {
+      setError(result.error || "Unable to generate manual content from template");
+      return;
+    }
+
+    setEditForm((current) =>
+      current
+        ? {
+          ...current,
+          manualHtml: result.data!.rendered.html,
+          manualText: result.data!.rendered.text,
+        }
+        : current
+    );
+    setEditPreview(result.data);
+  };
+
+  const setComposeContentMode = (next: NewsletterContentMode) => {
+    setComposeForm((current) => ({ ...current, contentMode: next }));
+  };
+
+  const setEditContentMode = (next: NewsletterContentMode) => {
+    setEditForm((current) => (current ? { ...current, contentMode: next } : current));
+  };
 
   if (loading) {
     return (
@@ -622,9 +1295,6 @@ export function NewsletterStudio() {
       </div>
     );
   }
-
-  const studioChromeBg =
-    "bg-[radial-gradient(900px_circle_at_10%_-30%,rgba(79,70,229,0.12),transparent_45%),radial-gradient(800px_circle_at_90%_-20%,rgba(16,185,129,0.10),transparent_50%)]";
 
   return (
     <div className="space-y-4">
@@ -644,145 +1314,69 @@ export function NewsletterStudio() {
         </div>
       )}
 
-      <section className={cx("rounded-2xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900", studioChromeBg)}>
+      <section className="rounded-2xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-neutral-900 text-white shadow-sm dark:bg-neutral-50 dark:text-neutral-900">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path
-                  d="M4 6.5C4 5.11929 5.11929 4 6.5 4H18.5C19.8807 4 21 5.11929 21 6.5V17.5C21 18.8807 19.8807 20 18.5 20H6.5C5.11929 20 4 18.8807 4 17.5V6.5Z"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                />
-                <path d="M7 8H18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                <path d="M7 12H15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                <path d="M7 16H12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-              </svg>
-            </div>
-            <div>
-              <div className="text-base font-semibold text-neutral-900 dark:text-neutral-50">Studio</div>
-              <div className="text-sm text-neutral-600 dark:text-neutral-300">
-                Compose drafts, manage the queue, and evolve templates.
-              </div>
+          <div>
+            <div className="text-base font-semibold text-neutral-900 dark:text-neutral-50">Newsletter Studio</div>
+            <div className="text-sm text-neutral-600 dark:text-neutral-300">
+              Full campaign authoring, queue operations, and template controls.
             </div>
           </div>
-
-          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-end">
-            <SegmentedControl<Mode>
-              value={mode}
-              onChange={(next) => setStudioMode(next)}
-              options={[
-                { value: "compose", label: "Compose", hint: "Create new campaign drafts" },
-                { value: "queue", label: "Queue", hint: "Schedule and send campaigns" },
-                { value: "templates", label: "Templates", hint: "Edit templates and preview rendering" },
-                { value: "subscribers", label: "Subscribers", hint: "View and manage subscribers" },
-              ]}
-            />
-
+          <div className="flex flex-col gap-2 md:items-end">
             <div className="flex items-center gap-2">
+              <SegmentedControl<Mode>
+                value={mode}
+                onChange={(next) => setMode(next)}
+                options={[
+                  { value: "compose", label: "Compose" },
+                  { value: "queue", label: "Queue" },
+                  { value: "templates", label: "Templates" },
+                ]}
+              />
+
               {mode === "compose" && (
-                <>
-                  <button
-                    type="button"
-                    onClick={autoCreateWeekly}
-                    disabled={saving || campaignForm.newsletterType !== "news"}
-                    className={cx(
-                      "inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold transition shadow-sm",
-                      campaignForm.newsletterType === "news"
-                        ? "bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
-                        : "bg-neutral-200 text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400 cursor-not-allowed"
-                    )}
-                    title={campaignForm.newsletterType === "news" ? "Auto-create weekly news draft" : "Auto-create currently supports only the news newsletter"}
-                  >
-                    Generate weekly draft
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void renderComposePreview()}
-                    disabled={composePreviewLoading || saving}
-                    className="inline-flex items-center gap-2 rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold text-neutral-900 shadow-sm transition hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:hover:bg-neutral-900"
-                  >
-                    Refresh preview
-                  </button>
-                </>
-              )}
-
-              {mode === "queue" && (
                 <button
                   type="button"
-                  onClick={refreshData}
-                  disabled={saving}
-                  className="inline-flex items-center gap-2 rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold text-neutral-900 shadow-sm transition hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:hover:bg-neutral-900"
+                  onClick={autoCreateWeekly}
+                  disabled={saving || composeForm.newsletterType !== "news"}
+                  className="rounded-xl bg-indigo-600 px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50"
                 >
-                  Refresh
-                </button>
-              )}
-
-              {mode === "templates" && (
-                <>
-                  <button
-                    type="button"
-                    onClick={saveTemplate}
-                    disabled={saving || !templateDraft}
-                    className={cx(
-                      "inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold transition shadow-sm disabled:opacity-50",
-                      templateIsDirty ? "bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-white" : "bg-neutral-200 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300"
-                    )}
-                    title={templateIsDirty ? "Save template changes" : "No unsaved changes"}
-                  >
-                    Save
-                  </button>
-                  <button
-                    type="button"
-                    onClick={renderTemplatePreview}
-                    disabled={saving || !templateDraft}
-                    className="inline-flex items-center gap-2 rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold text-neutral-900 shadow-sm transition hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:hover:bg-neutral-900"
-                  >
-                    Preview
-                  </button>
-                </>
-              )}
-
-              {mode === "subscribers" && (
-                <button
-                  type="button"
-                  onClick={() => void loadSubscribers()}
-                  disabled={subscriberLoading}
-                  className="inline-flex items-center gap-2 rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold text-neutral-900 shadow-sm transition hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:hover:bg-neutral-900"
-                >
-                  Refresh
+                  Generate weekly draft
                 </button>
               )}
             </div>
+
           </div>
         </div>
       </section>
 
       {mode === "compose" && (
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="space-y-4">
           <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
             <div className="flex items-start justify-between gap-3">
               <div>
-                <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">Draft composer</h2>
+                <h2 className="text-lg font-semibold">Compose draft</h2>
                 <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-                  Creates a campaign record. Content is rendered from the saved template at send time.
+                  Configure campaign metadata and delivery settings.
                 </p>
               </div>
               <button
                 type="button"
-                onClick={() => setCampaignForm((c) => ({ ...c, subject: suggestedWeeklySubject(c.newsletterType, c.periodDays) }))}
-                className="rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:hover:bg-neutral-900"
+                onClick={() => setComposeForm((c) => ({ ...c, subject: suggestedSubject(c.newsletterType, c.periodDays) }))}
+                className="rounded-xl border px-3 py-2 text-sm font-semibold"
               >
                 Use suggested subject
               </button>
             </div>
 
-            <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
               <label className="space-y-1">
-                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Newsletter type</span>
+                <span className="text-sm font-semibold">Newsletter type</span>
                 <select
-                  value={campaignForm.newsletterType}
-                  onChange={(event) => setCampaignForm((current) => ({ ...current, newsletterType: event.target.value as NewsletterType }))}
+                  value={composeForm.newsletterType}
+                  onChange={(event) =>
+                    setComposeForm((current) => ({ ...current, newsletterType: event.target.value as NewsletterType }))
+                  }
                   className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
                 >
                   {NEWSLETTER_TYPES.map((type) => (
@@ -794,171 +1388,304 @@ export function NewsletterStudio() {
               </label>
 
               <label className="space-y-1">
-                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Period (days)</span>
+                <span className="text-sm font-semibold">Period (days)</span>
                 <input
                   type="number"
                   min={1}
                   max={30}
-                  value={campaignForm.periodDays}
-                  onChange={(event) => setCampaignForm((current) => ({ ...current, periodDays: Number(event.target.value) || 7 }))}
+                  value={composeForm.periodDays}
+                  onChange={(event) =>
+                    setComposeForm((current) => ({ ...current, periodDays: Number(event.target.value) || 7 }))
+                  }
                   className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
                 />
               </label>
 
               <label className="space-y-1 md:col-span-2">
-                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Subject</span>
+                <span className="text-sm font-semibold">Subject</span>
                 <input
                   type="text"
-                  value={campaignForm.subject}
-                  onChange={(event) => setCampaignForm((current) => ({ ...current, subject: event.target.value }))}
-                  placeholder={suggestedWeeklySubject(campaignForm.newsletterType, campaignForm.periodDays)}
+                  value={composeForm.subject}
+                  onChange={(event) => setComposeForm((current) => ({ ...current, subject: event.target.value }))}
+                  placeholder={suggestedSubject(composeForm.newsletterType, composeForm.periodDays)}
                   className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
                 />
               </label>
 
               <label className="space-y-1 md:col-span-2">
-                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Preview text (optional)</span>
+                <span className="text-sm font-semibold">Preview text (optional)</span>
                 <input
                   type="text"
-                  value={campaignForm.previewText}
-                  onChange={(event) => setCampaignForm((current) => ({ ...current, previewText: event.target.value }))}
+                  value={composeForm.previewText}
+                  onChange={(event) => setComposeForm((current) => ({ ...current, previewText: event.target.value }))}
                   placeholder="Top updates from the last week"
                   className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
                 />
               </label>
 
               <label className="space-y-1 md:col-span-2">
-                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Schedule (optional)</span>
+                <span className="text-sm font-semibold">Schedule (optional)</span>
                 <input
                   type="datetime-local"
-                  value={campaignForm.scheduledAtLocal}
-                  onChange={(event) => setCampaignForm((current) => ({ ...current, scheduledAtLocal: event.target.value }))}
+                  value={composeForm.scheduledAtLocal}
+                  onChange={(event) =>
+                    setComposeForm((current) => ({ ...current, scheduledAtLocal: event.target.value }))
+                  }
                   className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
                 />
-                <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                  Stored as UTC when scheduled.
-                </p>
               </label>
             </div>
 
-            <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="mt-5">
               <button
                 type="button"
                 onClick={createCampaign}
                 disabled={saving}
-                className="inline-flex items-center justify-center rounded-xl bg-neutral-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-neutral-800 disabled:opacity-50 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-white"
+                className="rounded-xl bg-neutral-900 px-4 py-2.5 text-sm font-semibold text-white hover:bg-neutral-800 disabled:opacity-50 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-white"
               >
                 Create draft
               </button>
-              <div className="text-xs text-neutral-500 dark:text-neutral-400">
-                Tip: edit templates in the Templates tab, then come back to Compose.
-              </div>
             </div>
           </section>
 
           <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div>
-                <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">Live preview</h2>
+                <h2 className="text-lg font-semibold">Content Workspace</h2>
                 <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-                  Uses the saved template for <span className="font-semibold">{campaignForm.newsletterType}</span> and the latest digest snapshot.
+                  Switch between editor, preview, or split view.
                 </p>
               </div>
-              <SegmentedControl<PreviewTab>
-                value={composePreviewTab}
-                onChange={(v) => setComposePreviewTab(v)}
+              <div className="flex flex-col gap-2 sm:items-end">
+                <SegmentedControl<WorkspaceView>
+                  value={composeWorkspaceView}
+                  onChange={setComposeWorkspaceView}
+                  options={[
+                    { value: "editor", label: "Editor" },
+                    { value: "split", label: "Split" },
+                    { value: "preview", label: "Preview" },
+                  ]}
+                />
+                <SegmentedControl<PreviewTab>
+                  value={composePreviewTab}
+                  onChange={setComposePreviewTab}
+                  options={[
+                    { value: "subject", label: "Subject" },
+                    { value: "html", label: "HTML" },
+                    { value: "text", label: "Text" },
+                    { value: "starter", label: "Starter" },
+                  ]}
+                />
+              </div>
+            </div>
+
+            <div className="mt-4 mb-3 flex flex-wrap items-center gap-3">
+              <span className="text-sm font-semibold">Content mode</span>
+              <SegmentedControl<NewsletterContentMode>
+                value={composeForm.contentMode}
+                onChange={setComposeContentMode}
                 options={[
-                  { value: "html", label: "HTML" },
-                  { value: "text", label: "Text" },
-                  { value: "subject", label: "Subject" },
+                  { value: "template", label: "Template" },
+                  { value: "markdown", label: "Markdown" },
+                  { value: "manual", label: "Manual" },
                 ]}
               />
             </div>
 
-            {composePreviewLoading && (
-              <div className="mt-4 rounded-xl border border-neutral-200 bg-neutral-50 p-4 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300">
-                Rendering preview...
-              </div>
-            )}
-
-            {!composePreviewLoading && !composePreview && (
-              <div className="mt-4 rounded-xl border border-neutral-200 bg-neutral-50 p-4 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300">
-                Preview will appear here.
-              </div>
-            )}
-
-            {composePreview && (
-              <div className="mt-4 space-y-3">
-                <details className="rounded-xl border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
-                  <summary className="cursor-pointer px-4 py-3 text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
-                    Digest context
-                  </summary>
-                  <div className="px-4 pb-4">
-                    <div className="text-sm font-semibold text-neutral-900 dark:text-neutral-50">
-                      {composePreview.context.digest.heading}
-                    </div>
-                    <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-                      {composePreview.context.digest.summary}
-                    </div>
-                    {composePreview.context.digest.groups && composePreview.context.digest.groups.length > 0 ? (
-                      <div className="mt-3 space-y-2">
-                        {composePreview.context.digest.groups.map((group) => (
-                          <div key={group.category}>
-                            <div className="text-xs font-semibold text-neutral-500 dark:text-neutral-400">
-                              {group.label} ({group.items.length})
-                            </div>
-                            <ul className="mt-1 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
-                              {group.items.map((item, i) => (
-                                <li key={i}>{item.title}</li>
-                              ))}
-                            </ul>
-                          </div>
-                        ))}
-                      </div>
-                    ) : composePreview.context.digest.items.length > 0 ? (
-                      <ul className="mt-3 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
-                        {composePreview.context.digest.items.map((item, i) => (
-                          <li key={i}>{item.title}</li>
-                        ))}
-                      </ul>
-                    ) : null}
+            <div className={cx("mt-4 grid grid-cols-1 gap-4", composeWorkspaceView === "split" && "lg:grid-cols-2")}>
+              {composeWorkspaceView !== "preview" && (
+              <div className={cx("min-h-[72vh] rounded-xl border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950", composeWorkspaceView === "editor" && "min-h-[78vh]")}>
+                <div className="mb-3 flex items-center justify-between">
+                  <div className="text-sm font-semibold">Editor</div>
+                  <div className="text-xs uppercase tracking-wide text-neutral-500">
+                    mode: {composeForm.contentMode}
                   </div>
-                </details>
+                </div>
 
-                {composePreviewTab === "subject" && (
-                  <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950">
-                    <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
-                      Rendered subject
+                {composeForm.contentMode === "template" && (
+                  <div className="rounded-xl border border-neutral-200 bg-white p-4 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300">
+                    Template mode has no direct body editor. Switch to Markdown or Manual to edit content directly.
+                  </div>
+                )}
+
+                {composeForm.contentMode === "markdown" && (
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap gap-2">
+                      <MarkdownToolbar onApply={applyComposeMarkdownFormat} />
+                      <button
+                        type="button"
+                        onClick={() => void autofillComposeMarkdown(false)}
+                        className="rounded-md border px-2 py-1 text-xs"
+                      >
+                        Autofill from template
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void autofillComposeMarkdown(true)}
+                        className="rounded-md border px-2 py-1 text-xs"
+                      >
+                        Regenerate starter
+                      </button>
                     </div>
-                    <div className="mt-2 text-base font-semibold text-neutral-900 dark:text-neutral-50">
-                      {composePreview.rendered.subject}
+
+                    <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-neutral-500 dark:text-neutral-400">
+                      <span>Shortcuts: Cmd/Ctrl+B (bold), I (italic), K (link)</span>
+                      <span>{countWords(composeForm.markdownContent)} words · {composeForm.markdownContent.length} chars</span>
                     </div>
-                    {campaignForm.previewText.trim() && (
-                      <div className="mt-2 text-sm text-neutral-600 dark:text-neutral-300">
-                        <span className="font-semibold">Preview text:</span> {campaignForm.previewText.trim()}
+                    <textarea
+                      ref={composeMarkdownRef}
+                      rows={composeWorkspaceView === "split" ? 22 : 30}
+                      value={composeForm.markdownContent}
+                      onFocus={() => setComposeFocusedField("markdownContent")}
+                      onKeyDown={(event) => handleMarkdownHotkeys(event, applyComposeMarkdownFormat)}
+                      onChange={(event) =>
+                        setComposeForm((current) => ({ ...current, markdownContent: event.target.value }))
+                      }
+                      className="min-h-[56vh] w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-sm leading-6 dark:border-neutral-700 dark:bg-neutral-950"
+                      placeholder="Write markdown newsletter content..."
+                    />
+
+                    <div className="flex flex-wrap gap-2">
+                      {composeInsertablePlaceholders.map((placeholder) => (
+                        <button
+                          key={placeholder}
+                          type="button"
+                          onClick={() => insertComposeToken(placeholder)}
+                          className="rounded-full border px-3 py-1 text-xs"
+                        >
+                          {`{{${placeholder}}}`}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {composeForm.contentMode === "manual" && (
+                  <div className="space-y-3">
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => void autofillComposeManual(false)}
+                        className="rounded-md border px-2 py-1 text-xs"
+                      >
+                        Autofill from template
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void autofillComposeManual(true)}
+                        className="rounded-md border px-2 py-1 text-xs"
+                      >
+                        Regenerate starter
+                      </button>
+                    </div>
+
+                    <label className="space-y-1">
+                      <span className="text-sm font-semibold">Manual HTML</span>
+                      <textarea
+                        ref={composeManualHtmlRef}
+                        rows={composeWorkspaceView === "split" ? 12 : 16}
+                        value={composeForm.manualHtml}
+                        onFocus={() => setComposeFocusedField("manualHtml")}
+                        onChange={(event) =>
+                          setComposeForm((current) => ({ ...current, manualHtml: event.target.value }))
+                        }
+                        className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-sm leading-6 dark:border-neutral-700 dark:bg-neutral-950"
+                      />
+                    </label>
+
+                    <label className="space-y-1">
+                      <span className="text-sm font-semibold">Manual text</span>
+                      <textarea
+                        ref={composeManualTextRef}
+                        rows={composeWorkspaceView === "split" ? 12 : 16}
+                        value={composeForm.manualText}
+                        onFocus={() => setComposeFocusedField("manualText")}
+                        onChange={(event) =>
+                          setComposeForm((current) => ({ ...current, manualText: event.target.value }))
+                        }
+                        className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-sm leading-6 dark:border-neutral-700 dark:bg-neutral-950"
+                      />
+                    </label>
+
+                    <div className="flex flex-wrap gap-2">
+                      {composeInsertablePlaceholders.map((placeholder) => (
+                        <button
+                          key={placeholder}
+                          type="button"
+                          onClick={() => insertComposeToken(placeholder)}
+                          className="rounded-full border px-3 py-1 text-xs"
+                        >
+                          {`{{${placeholder}}}`}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+              )}
+
+              {composeWorkspaceView !== "editor" && (
+              <div className={cx("min-h-[72vh] rounded-xl border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950", composeWorkspaceView === "preview" && "min-h-[78vh]")}>
+                <div className="mb-3 text-sm font-semibold">Live preview</div>
+
+                {composePreviewLoading && (
+                  <div className="rounded-xl border border-neutral-200 bg-white p-4 text-sm dark:border-neutral-800 dark:bg-neutral-900">
+                    Rendering preview...
+                  </div>
+                )}
+
+                {!composePreviewLoading && !composePreview && (
+                  <div className="rounded-xl border border-neutral-200 bg-white p-4 text-sm dark:border-neutral-800 dark:bg-neutral-900">
+                    Preview will appear here.
+                  </div>
+                )}
+
+                {composePreview && (
+                  <div className="space-y-3">
+                    <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+                      <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Digest context</div>
+                      <div className="mt-1 text-sm font-semibold">{composePreview.context.digest.heading}</div>
+                      <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">{composePreview.context.digest.summary}</div>
+                    </div>
+
+                    {composePreviewTab === "subject" && (
+                      <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+                        <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Rendered subject</div>
+                        <div className="mt-2 text-base font-semibold">{composePreview.rendered.subject}</div>
+                      </div>
+                    )}
+
+                    {composePreviewTab === "html" && (
+                      <HtmlPreviewFrame
+                        html={composePreview.rendered.html}
+                        className={composeWorkspaceView === "preview" ? "h-[78vh]" : "h-[70vh]"}
+                      />
+                    )}
+
+                    {composePreviewTab === "text" && (
+                      <pre className={cx(
+                        "overflow-auto whitespace-pre-wrap rounded-xl border border-neutral-200 bg-white p-4 text-xs dark:border-neutral-800 dark:bg-neutral-900",
+                        composeWorkspaceView === "preview" ? "max-h-[78vh]" : "max-h-[70vh]"
+                      )}>
+                        {composePreview.rendered.text}
+                      </pre>
+                    )}
+
+                    {composePreviewTab === "starter" && (
+                      <div className="grid grid-cols-1 gap-3">
+                        <pre className={cx(
+                          "overflow-auto whitespace-pre-wrap rounded-xl border border-neutral-200 bg-white p-4 text-xs dark:border-neutral-800 dark:bg-neutral-900",
+                          composeWorkspaceView === "preview" ? "max-h-[78vh]" : "max-h-[70vh]"
+                        )}>
+                          {composePreview.starter.markdown}
+                        </pre>
                       </div>
                     )}
                   </div>
                 )}
-
-                {composePreviewTab === "html" && (
-                  <div className="space-y-2">
-                    {campaignForm.previewText.trim() && (
-                      <div className="rounded-xl border border-neutral-200 bg-white p-3 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
-                        <span className="font-semibold">Preview text:</span> {campaignForm.previewText.trim()}
-                      </div>
-                    )}
-                    <HtmlPreviewFrame html={composePreview.rendered.html} />
-                  </div>
-                )}
-
-                {composePreviewTab === "text" && (
-                  <pre className="max-h-[520px] overflow-auto whitespace-pre-wrap rounded-xl border border-neutral-200 bg-white p-4 text-xs text-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
-                    {composePreview.rendered.text}
-                  </pre>
-                )}
               </div>
-            )}
+              )}
+            </div>
           </section>
         </div>
       )}
@@ -967,30 +1694,28 @@ export function NewsletterStudio() {
         <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div>
-              <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">Campaign queue</h2>
+              <h2 className="text-lg font-semibold">Campaign queue</h2>
               <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-                Schedule drafts, kick off sends, and monitor failures.
+                Edit, schedule, send, and delete unsent campaigns.
               </p>
             </div>
-            <div className="flex w-full flex-col gap-2 md:w-auto md:flex-row md:items-center">
-              <div className="flex items-center gap-2">
-                <SegmentedControl<typeof queueFilter>
-                  value={queueFilter}
-                  onChange={(v) => setQueueFilter(v)}
-                  options={[
-                    { value: "all", label: "All" },
-                    { value: "draft", label: "Draft" },
-                    { value: "scheduled", label: "Scheduled" },
-                    { value: "sending", label: "Sending" },
-                    { value: "sent", label: "Sent" },
-                    { value: "failed", label: "Failed" },
-                  ]}
-                />
-              </div>
+            <div className="flex flex-col gap-2 md:flex-row md:items-center">
+              <SegmentedControl<CampaignStatus | "all">
+                value={queueFilter}
+                onChange={setQueueFilter}
+                options={[
+                  { value: "all", label: "All" },
+                  { value: "draft", label: "Draft" },
+                  { value: "scheduled", label: "Scheduled" },
+                  { value: "sending", label: "Sending" },
+                  { value: "sent", label: "Sent" },
+                  { value: "failed", label: "Failed" },
+                ]}
+              />
               <input
                 type="text"
                 value={queueSearch}
-                onChange={(e) => setQueueSearch(e.target.value)}
+                onChange={(event) => setQueueSearch(event.target.value)}
                 placeholder="Search subject..."
                 className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950 md:w-72"
               />
@@ -998,24 +1723,14 @@ export function NewsletterStudio() {
           </div>
 
           {filteredCampaigns.length === 0 ? (
-            <div className="mt-5 rounded-2xl border border-neutral-200 bg-neutral-50 p-8 text-center dark:border-neutral-800 dark:bg-neutral-950">
-              <div className="text-sm font-semibold text-neutral-900 dark:text-neutral-50">No campaigns match this view.</div>
-              <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-                Create a draft in Compose, then come back here to schedule or send.
-              </div>
-              <button
-                type="button"
-                onClick={() => setMode("compose")}
-                className="mt-4 inline-flex items-center justify-center rounded-xl bg-neutral-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-neutral-800 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-white"
-              >
-                Go to Compose
-              </button>
+            <div className="mt-5 rounded-xl border border-neutral-200 bg-neutral-50 p-6 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300">
+              No campaigns match this view.
             </div>
           ) : (
-            <div className="mt-5 overflow-x-auto rounded-2xl border border-neutral-200 dark:border-neutral-800">
-              <table className="w-full min-w-[980px] text-sm">
+            <div className="mt-5 overflow-x-auto rounded-xl border border-neutral-200 dark:border-neutral-800">
+              <table className="w-full min-w-[1050px] text-sm">
                 <thead className="bg-neutral-50 dark:bg-neutral-950">
-                  <tr className="text-left text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                  <tr className="text-left text-xs font-semibold uppercase tracking-wide text-neutral-500">
                     <th className="px-4 py-3">Status</th>
                     <th className="px-4 py-3">Type</th>
                     <th className="px-4 py-3">Subject</th>
@@ -1025,66 +1740,407 @@ export function NewsletterStudio() {
                   </tr>
                 </thead>
                 <tbody>
-                  {filteredCampaigns.map((campaign) => (
-                    <tr key={campaign.id} className="border-t border-neutral-200 align-top dark:border-neutral-800">
-                      <td className="px-4 py-3">
-                        <StatusPill status={campaign.status} />
-                        {campaign.failureReason && (
-                          <div className="mt-2 text-xs text-red-700 dark:text-red-300">
-                            {campaign.failureReason}
+                  {filteredCampaigns.map((campaign) => {
+                    const mutable = MUTABLE_STATUSES.has(campaign.status);
+                    return (
+                      <tr key={campaign.id} className="border-t border-neutral-200 align-top dark:border-neutral-800">
+                        <td className="px-4 py-3">
+                          <StatusPill status={campaign.status} />
+                          {campaign.failureReason && (
+                            <div className="mt-2 text-xs text-red-700 dark:text-red-300">{campaign.failureReason}</div>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 capitalize">{campaign.newsletterType}</td>
+                        <td className="px-4 py-3">
+                          <div className="font-semibold">{campaign.subject}</div>
+                          {campaign.previewText && <div className="mt-1 text-xs text-neutral-500">{campaign.previewText}</div>}
+                          <div className="mt-1 text-xs text-neutral-500">mode: {campaign.contentMode}</div>
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">{new Date(campaign.createdAt).toLocaleString()}</td>
+                        <td className="px-4 py-3 min-w-80">
+                          <div className="flex items-center gap-2">
+                            <input
+                              type="datetime-local"
+                              value={scheduleDrafts[campaign.id] || ""}
+                              onChange={(event) =>
+                                setScheduleDrafts((current) => ({ ...current, [campaign.id]: event.target.value }))
+                              }
+                              className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                            />
+                            <button
+                              type="button"
+                              onClick={() => scheduleCampaign(campaign.id)}
+                              disabled={saving || !mutable}
+                              className="rounded-xl border px-3 py-2 text-sm font-semibold disabled:opacity-50"
+                            >
+                              Set
+                            </button>
                           </div>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 capitalize text-neutral-700 dark:text-neutral-200">{campaign.newsletterType}</td>
-                      <td className="px-4 py-3">
-                        <div className="font-semibold text-neutral-900 dark:text-neutral-50">{campaign.subject}</div>
-                        {campaign.previewText && <div className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">{campaign.previewText}</div>}
-                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-neutral-700 dark:text-neutral-200">
-                        {new Date(campaign.createdAt).toLocaleString()}
-                      </td>
-                      <td className="px-4 py-3 min-w-80">
-                        <div className="flex items-center gap-2">
-                          <input
-                            type="datetime-local"
-                            value={scheduleDrafts[campaign.id] || ""}
-                            onChange={(event) => setScheduleDrafts((current) => ({ ...current, [campaign.id]: event.target.value }))}
-                            className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
-                          />
-                          <button
-                            type="button"
-                            onClick={() => scheduleCampaign(campaign.id)}
-                            disabled={saving}
-                            className="rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold text-neutral-900 transition hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50 dark:hover:bg-neutral-900"
-                          >
-                            Set
-                          </button>
-                        </div>
-                        {campaign.scheduledAt && (
-                          <div className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
-                            Current: {new Date(campaign.scheduledAt).toLocaleString()}
+                          {campaign.scheduledAt && (
+                            <div className="mt-2 text-xs text-neutral-500">Current: {new Date(campaign.scheduledAt).toLocaleString()}</div>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          <div className="flex justify-end gap-2">
+                            <button
+                              type="button"
+                              onClick={() => openCampaignEditor(campaign.id)}
+                              disabled={saving || !mutable}
+                              className="rounded-xl border px-3 py-2 text-xs font-semibold disabled:opacity-50"
+                            >
+                              Edit
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => deleteCampaign(campaign)}
+                              disabled={saving || !mutable}
+                              className="rounded-xl border border-red-300 px-3 py-2 text-xs font-semibold text-red-700 disabled:opacity-50 dark:border-red-500/30 dark:text-red-300"
+                            >
+                              Delete
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => sendNow(campaign.id)}
+                              disabled={saving || campaign.status === "sent" || campaign.status === "sending"}
+                              className="rounded-xl bg-emerald-600 px-3 py-2 text-xs font-semibold text-white disabled:opacity-50"
+                            >
+                              Send now
+                            </button>
                           </div>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        <button
-                          type="button"
-                          onClick={() => sendNow(campaign.id)}
-                          disabled={saving || campaign.status === "sent" || campaign.status === "sending"}
-                          className="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-emerald-700 disabled:opacity-50"
-                        >
-                          Send now
-                        </button>
-                        {campaign.sentAt && (
-                          <div className="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
-                            Sent: {new Date(campaign.sentAt).toLocaleString()}
-                          </div>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
+            </div>
+          )}
+
+          {editingCampaignId && editForm && (
+            <div className="mt-6 space-y-4 rounded-2xl border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-base font-semibold">Edit Campaign</h3>
+                  {isEditDirty && (
+                    <span className="rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+                      Unsaved
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <SegmentedControl<WorkspaceView>
+                    value={editWorkspaceView}
+                    onChange={setEditWorkspaceView}
+                    options={[
+                      { value: "editor", label: "Editor" },
+                      { value: "split", label: "Split" },
+                      { value: "preview", label: "Preview" },
+                    ]}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => closeEditPanel()}
+                    className="rounded-lg border px-3 py-1.5 text-sm"
+                  >
+                    Close
+                  </button>
+                </div>
+              </div>
+
+              <div className={cx("grid grid-cols-1 gap-4", editWorkspaceView === "split" && "xl:grid-cols-2")}>
+                {editWorkspaceView !== "preview" && (
+                  <div className={cx("space-y-3", editWorkspaceView === "editor" && "min-h-[68vh]")}>
+                  <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                    <label className="space-y-1">
+                      <span className="text-sm font-semibold">Type</span>
+                      <select
+                        value={editForm.newsletterType}
+                        onChange={(event) =>
+                          setEditForm((current) =>
+                            current ? { ...current, newsletterType: event.target.value as NewsletterType } : current
+                          )
+                        }
+                        className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                      >
+                        {NEWSLETTER_TYPES.map((type) => (
+                          <option key={type} value={type}>
+                            {type}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+
+                    <label className="space-y-1">
+                      <span className="text-sm font-semibold">Period (days)</span>
+                      <input
+                        type="number"
+                        min={1}
+                        max={30}
+                        value={editForm.periodDays}
+                        onChange={(event) =>
+                          setEditForm((current) =>
+                            current ? { ...current, periodDays: Number(event.target.value) || 7 } : current
+                          )
+                        }
+                        className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                      />
+                    </label>
+                  </div>
+
+                  <label className="space-y-1">
+                    <span className="text-sm font-semibold">Subject</span>
+                    <input
+                      type="text"
+                      value={editForm.subject}
+                      onChange={(event) =>
+                        setEditForm((current) => (current ? { ...current, subject: event.target.value } : current))
+                      }
+                      className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                    />
+                  </label>
+
+                  <label className="space-y-1">
+                    <span className="text-sm font-semibold">Preview text</span>
+                    <input
+                      type="text"
+                      value={editForm.previewText}
+                      onChange={(event) =>
+                        setEditForm((current) => (current ? { ...current, previewText: event.target.value } : current))
+                      }
+                      className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                    />
+                  </label>
+
+                  <label className="space-y-1">
+                    <span className="text-sm font-semibold">Schedule</span>
+                    <input
+                      type="datetime-local"
+                      value={editForm.scheduledAtLocal}
+                      onChange={(event) =>
+                        setEditForm((current) =>
+                          current ? { ...current, scheduledAtLocal: event.target.value } : current
+                        )
+                      }
+                      className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                    />
+                  </label>
+
+                  <div className="space-y-2">
+                    <div className="text-sm font-semibold">Content mode</div>
+                    <SegmentedControl<NewsletterContentMode>
+                      value={editForm.contentMode}
+                      onChange={setEditContentMode}
+                      options={[
+                        { value: "template", label: "Template" },
+                        { value: "markdown", label: "Markdown" },
+                        { value: "manual", label: "Manual" },
+                      ]}
+                    />
+                  </div>
+
+                  {editForm.contentMode === "markdown" && (
+                    <div className="space-y-2">
+                      <div className="flex flex-wrap gap-2">
+                        <MarkdownToolbar onApply={applyEditMarkdownFormat} />
+                        <button
+                          type="button"
+                          onClick={() => void autofillEditMarkdown(false)}
+                          className="rounded-md border px-2 py-1 text-xs"
+                        >
+                          Autofill from template
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void autofillEditMarkdown(true)}
+                          className="rounded-md border px-2 py-1 text-xs"
+                        >
+                          Regenerate starter
+                        </button>
+                      </div>
+
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-neutral-500 dark:text-neutral-400">
+                          <span>Shortcuts: Cmd/Ctrl+B (bold), I (italic), K (link)</span>
+                          <span>{countWords(editForm.markdownContent)} words · {editForm.markdownContent.length} chars</span>
+                        </div>
+                        <textarea
+                          ref={editMarkdownRef}
+                          rows={editWorkspaceView === "split" ? 16 : 24}
+                          value={editForm.markdownContent}
+                          onFocus={() => setEditFocusedField("markdownContent")}
+                          onKeyDown={(event) => handleMarkdownHotkeys(event, applyEditMarkdownFormat)}
+                          onChange={(event) =>
+                            setEditForm((current) =>
+                              current ? { ...current, markdownContent: event.target.value } : current
+                            )
+                          }
+                          className="min-h-[46vh] w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-sm leading-6 dark:border-neutral-700 dark:bg-neutral-950"
+                        />
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        {editInsertablePlaceholders.map((placeholder) => (
+                          <button
+                            key={placeholder}
+                            type="button"
+                            onClick={() => insertEditToken(placeholder)}
+                            className="rounded-full border px-3 py-1 text-xs"
+                          >
+                            {`{{${placeholder}}}`}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {editForm.contentMode === "manual" && (
+                    <div className="space-y-2">
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          onClick={() => void autofillEditManual(false)}
+                          className="rounded-md border px-2 py-1 text-xs"
+                        >
+                          Autofill from template
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void autofillEditManual(true)}
+                          className="rounded-md border px-2 py-1 text-xs"
+                        >
+                          Regenerate starter
+                        </button>
+                      </div>
+                      <textarea
+                        ref={editManualHtmlRef}
+                        rows={editWorkspaceView === "split" ? 9 : 14}
+                        value={editForm.manualHtml}
+                        onFocus={() => setEditFocusedField("manualHtml")}
+                        onChange={(event) =>
+                          setEditForm((current) => (current ? { ...current, manualHtml: event.target.value } : current))
+                        }
+                        className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-sm leading-6 dark:border-neutral-700 dark:bg-neutral-950"
+                        placeholder="Manual HTML"
+                      />
+                      <textarea
+                        ref={editManualTextRef}
+                        rows={editWorkspaceView === "split" ? 9 : 14}
+                        value={editForm.manualText}
+                        onFocus={() => setEditFocusedField("manualText")}
+                        onChange={(event) =>
+                          setEditForm((current) => (current ? { ...current, manualText: event.target.value } : current))
+                        }
+                        className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-sm leading-6 dark:border-neutral-700 dark:bg-neutral-950"
+                        placeholder="Manual text"
+                      />
+
+                      <div className="flex flex-wrap gap-2">
+                        {editInsertablePlaceholders.map((placeholder) => (
+                          <button
+                            key={placeholder}
+                            type="button"
+                            onClick={() => insertEditToken(placeholder)}
+                            className="rounded-full border px-3 py-1 text-xs"
+                          >
+                            {`{{${placeholder}}}`}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {editForm.contentMode === "template" && (
+                    <div className="rounded-xl border border-neutral-200 bg-white p-3 text-sm dark:border-neutral-800 dark:bg-neutral-900">
+                      Campaign uses saved templates only.
+                    </div>
+                  )}
+
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={saveCampaignEdit}
+                      disabled={saving}
+                      className="rounded-xl bg-neutral-900 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50 dark:bg-neutral-50 dark:text-neutral-900"
+                    >
+                      Save changes
+                    </button>
+                    <button
+                      type="button"
+                      onClick={renderEditPreview}
+                      disabled={saving || editPreviewLoading}
+                      className="rounded-xl border px-4 py-2 text-sm font-semibold disabled:opacity-50"
+                    >
+                      {editPreviewLoading ? "Rendering..." : "Preview"}
+                    </button>
+                  </div>
+                  </div>
+                )}
+
+                {editWorkspaceView !== "editor" && (
+                  <div className={cx("space-y-3", editWorkspaceView === "preview" && "min-h-[68vh]")}>
+                  <div className="flex items-center justify-between">
+                    <div className="text-sm font-semibold">Edit preview</div>
+                    <SegmentedControl<PreviewTab>
+                      value={editPreviewTab}
+                      onChange={setEditPreviewTab}
+                      options={[
+                        { value: "subject", label: "Subject" },
+                        { value: "html", label: "HTML" },
+                        { value: "text", label: "Text" },
+                        { value: "starter", label: "Starter" },
+                      ]}
+                    />
+                  </div>
+
+                  {editPreviewLoading && (
+                    <div className="rounded-xl border border-neutral-200 bg-white p-4 text-sm dark:border-neutral-800 dark:bg-neutral-900">
+                      Rendering preview...
+                    </div>
+                  )}
+
+                  {!editPreviewLoading && !editPreview && (
+                    <div className="rounded-xl border border-neutral-200 bg-white p-4 text-sm dark:border-neutral-800 dark:bg-neutral-900">
+                      Live preview will appear as you edit.
+                    </div>
+                  )}
+
+                  {editPreview && editPreviewTab === "subject" && (
+                    <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+                      <div className="text-sm font-semibold">{editPreview.rendered.subject}</div>
+                    </div>
+                  )}
+
+                  {editPreview && editPreviewTab === "html" && (
+                    <HtmlPreviewFrame
+                      html={editPreview.rendered.html}
+                      className={editWorkspaceView === "preview" ? "h-[74vh]" : "h-[560px]"}
+                    />
+                  )}
+
+                  {editPreview && editPreviewTab === "text" && (
+                    <pre
+                      className={cx(
+                        "overflow-auto whitespace-pre-wrap rounded-xl border border-neutral-200 bg-white p-4 text-xs dark:border-neutral-800 dark:bg-neutral-900",
+                        editWorkspaceView === "preview" ? "max-h-[72vh]" : "max-h-[480px]"
+                      )}
+                    >
+                      {editPreview.rendered.text}
+                    </pre>
+                  )}
+
+                  {editPreview && editPreviewTab === "starter" && (
+                    <pre
+                      className={cx(
+                        "overflow-auto whitespace-pre-wrap rounded-xl border border-neutral-200 bg-white p-4 text-xs dark:border-neutral-800 dark:bg-neutral-900",
+                        editWorkspaceView === "preview" ? "max-h-[72vh]" : "max-h-[480px]"
+                      )}
+                    >
+                      {editPreview.starter.markdown}
+                    </pre>
+                  )}
+                  </div>
+                )}
+              </div>
             </div>
           )}
         </section>
@@ -1093,24 +2149,22 @@ export function NewsletterStudio() {
       {mode === "templates" && (
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
-            <div className="flex items-start justify-between gap-4">
+            <div className="flex items-center justify-between gap-4">
               <div>
-                <div className="flex items-center gap-2">
-                  <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">Template editor</h2>
-                  {templateIsDirty && (
-                    <span className="rounded-full bg-amber-50 px-2.5 py-1 text-xs font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
-                      Unsaved
-                    </span>
-                  )}
-                </div>
+                <h2 className="text-lg font-semibold">Template editor</h2>
                 <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-                  Templates render on send. Use placeholders like <code className="rounded bg-neutral-100 px-1 py-0.5 dark:bg-neutral-800">{`{{digest_heading}}`}</code>.
+                  Subject, html, text, and markdown starter templates.
                 </p>
               </div>
-
               <select
                 value={activeTemplateType}
-                onChange={(event) => handleTemplateTypeChange(event.target.value as NewsletterType)}
+                onChange={(event) => {
+                  const next = event.target.value as NewsletterType;
+                  setActiveTemplateType(next);
+                  if (templates) setTemplateDraft(templates[next] || null);
+                  else setTemplateDraft(null);
+                  setTemplatePreview(null);
+                }}
                 className="rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm font-semibold dark:border-neutral-700 dark:bg-neutral-950"
               >
                 {NEWSLETTER_TYPES.map((type) => (
@@ -1121,340 +2175,174 @@ export function NewsletterStudio() {
               </select>
             </div>
 
-            {!templateDraft ? (
-              <div className="mt-5 rounded-2xl border border-neutral-200 bg-neutral-50 p-6 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300">
-                No template loaded for <span className="font-semibold">{activeTemplateType}</span>.
+            {templateDraft && (
+              <div className="mt-4 space-y-3">
+                <label className="space-y-1">
+                  <span className="text-sm font-semibold">Subject template</span>
+                  <input
+                    ref={templateSubjectRef}
+                    value={templateDraft.subjectTemplate}
+                    onFocus={() => setFocusedTemplateField("subjectTemplate")}
+                    onChange={(event) =>
+                      setTemplateDraft((current) => (current ? { ...current, subjectTemplate: event.target.value } : current))
+                    }
+                    className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                  />
+                </label>
+
+                <label className="space-y-1">
+                  <span className="text-sm font-semibold">HTML template</span>
+                  <textarea
+                    ref={templateHtmlRef}
+                    rows={7}
+                    value={templateDraft.htmlTemplate}
+                    onFocus={() => setFocusedTemplateField("htmlTemplate")}
+                    onChange={(event) =>
+                      setTemplateDraft((current) => (current ? { ...current, htmlTemplate: event.target.value } : current))
+                    }
+                    className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-950"
+                  />
+                </label>
+
+                <label className="space-y-1">
+                  <span className="text-sm font-semibold">Text template</span>
+                  <textarea
+                    ref={templateTextRef}
+                    rows={7}
+                    value={templateDraft.textTemplate}
+                    onFocus={() => setFocusedTemplateField("textTemplate")}
+                    onChange={(event) =>
+                      setTemplateDraft((current) => (current ? { ...current, textTemplate: event.target.value } : current))
+                    }
+                    className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-950"
+                  />
+                </label>
+
+                <label className="space-y-1">
+                  <span className="text-sm font-semibold">Markdown template</span>
+                  <textarea
+                    ref={templateMarkdownRef}
+                    rows={10}
+                    value={templateDraft.markdownTemplate}
+                    onFocus={() => setFocusedTemplateField("markdownTemplate")}
+                    onChange={(event) =>
+                      setTemplateDraft((current) => (current ? { ...current, markdownTemplate: event.target.value } : current))
+                    }
+                    className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-950"
+                  />
+                </label>
+
+                <div className="flex flex-wrap gap-2">
+                  {templateInsertablePlaceholders.map((placeholder) => (
+                    <button
+                      key={placeholder}
+                      type="button"
+                      onClick={() => insertTemplateToken(placeholder)}
+                      className="rounded-full border px-3 py-1 text-xs"
+                    >
+                      {`{{${placeholder}}}`}
+                    </button>
+                  ))}
+                </div>
+
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={saveTemplate}
+                    disabled={saving || !templateIsDirty}
+                    className="rounded-xl bg-neutral-900 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50 dark:bg-neutral-50 dark:text-neutral-900"
+                  >
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    onClick={renderTemplatePreview}
+                    disabled={saving}
+                    className="rounded-xl border px-4 py-2 text-sm font-semibold disabled:opacity-50"
+                  >
+                    Preview
+                  </button>
+                </div>
               </div>
-            ) : (
-              <>
-                <div className="mt-5 grid grid-cols-1 gap-4">
-                  <label className="space-y-1">
-                    <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Subject template</span>
-                    <input
-                      ref={subjectTemplateRef}
-                      type="text"
-                      value={templateDraft.subjectTemplate}
-                      onFocus={() => setFocusedTemplateField("subjectTemplate")}
-                      onChange={(event) => setTemplateDraft((current) => (current ? { ...current, subjectTemplate: event.target.value } : current))}
-                      className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
-                    />
-                  </label>
-
-                  <label className="space-y-1">
-                    <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">HTML template</span>
-                    <textarea
-                      ref={htmlTemplateRef}
-                      rows={10}
-                      value={templateDraft.htmlTemplate}
-                      onFocus={() => setFocusedTemplateField("htmlTemplate")}
-                      onChange={(event) => setTemplateDraft((current) => (current ? { ...current, htmlTemplate: event.target.value } : current))}
-                      className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-950"
-                    />
-                  </label>
-
-                  <label className="space-y-1">
-                    <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Text template</span>
-                    <textarea
-                      ref={textTemplateRef}
-                      rows={10}
-                      value={templateDraft.textTemplate}
-                      onFocus={() => setFocusedTemplateField("textTemplate")}
-                      onChange={(event) => setTemplateDraft((current) => (current ? { ...current, textTemplate: event.target.value } : current))}
-                      className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 font-mono text-xs dark:border-neutral-700 dark:bg-neutral-950"
-                    />
-                  </label>
-                </div>
-
-                <div className="mt-5 rounded-2xl border border-neutral-200 bg-neutral-50 p-4 dark:border-neutral-800 dark:bg-neutral-950">
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <div className="text-sm font-semibold text-neutral-900 dark:text-neutral-50">Placeholders</div>
-                      <div className="mt-1 text-xs text-neutral-600 dark:text-neutral-300">
-                        Click to insert into the focused field.
-                      </div>
-                    </div>
-                    <div className="text-xs text-neutral-500 dark:text-neutral-400">
-                      Focus: <span className="font-semibold">{focusedTemplateField || "htmlTemplate"}</span>
-                    </div>
-                  </div>
-
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {(templatePreview?.placeholders || [
-                      "campaign_subject",
-                      "campaign_type",
-                      "period_days",
-                      "digest_heading",
-                      "digest_summary",
-                      "total_views",
-                      "delta_views",
-                      "digest_items_html",
-                      "digest_items_text",
-                      "recent_news_html",
-                      "recent_news_text",
-                      "unsubscribe_url",
-                      "preferences_url",
-                      "default_html_body",
-                      "default_text_body",
-                      "generated_at_iso",
-                    ]).map((ph) => (
-                      <button
-                        key={ph}
-                        type="button"
-                        onClick={() => insertPlaceholderIntoTemplate(ph)}
-                        className="rounded-full border border-neutral-200 bg-white px-3 py-1.5 text-xs font-semibold text-neutral-800 transition hover:bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200 dark:hover:bg-neutral-900"
-                      >
-                        {`{{${ph}}}`}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              </>
             )}
           </section>
 
           <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div>
-                <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">Preview</h2>
-                <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-                  Render the current draft template with a real digest snapshot.
-                </p>
-              </div>
-              <SegmentedControl<PreviewTab>
-                value={templatePreviewTab}
-                onChange={(v) => setTemplatePreviewTab(v)}
-                options={[
-                  { value: "html", label: "HTML" },
-                  { value: "text", label: "Text" },
-                  { value: "subject", label: "Subject" },
-                ]}
-              />
-            </div>
-
-            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
-              <label className="space-y-1">
-                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Preview subject</span>
-                <input
-                  type="text"
-                  value={templatePreviewContext.campaignSubject}
-                  onChange={(e) => setTemplatePreviewContext((c) => ({ ...c, campaignSubject: e.target.value }))}
-                  className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold">Template preview</h2>
+                <SegmentedControl<PreviewTab>
+                  value={templatePreviewTab}
+                  onChange={setTemplatePreviewTab}
+                  options={[
+                    { value: "subject", label: "Subject" },
+                    { value: "html", label: "HTML" },
+                    { value: "text", label: "Text" },
+                    { value: "starter", label: "Starter" },
+                  ]}
                 />
-              </label>
-              <label className="space-y-1">
-                <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Period (days)</span>
-                <input
-                  type="number"
-                  min={1}
-                  max={30}
-                  value={templatePreviewContext.periodDays}
-                  onChange={(e) => setTemplatePreviewContext((c) => ({ ...c, periodDays: Number(e.target.value) || 7 }))}
-                  className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
-                />
-              </label>
-            </div>
-
-            {!templatePreview && (
-              <div className="mt-4 rounded-2xl border border-neutral-200 bg-neutral-50 p-6 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300">
-                Click <span className="font-semibold">Preview</span> in the top bar to render.
               </div>
-            )}
 
-            {templatePreview && (
-              <div className="mt-4 space-y-3">
-                <details className="rounded-xl border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
-                  <summary className="cursor-pointer px-4 py-3 text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
-                    Context
-                  </summary>
-                  <div className="px-4 pb-4">
-                    <div className="text-sm font-semibold text-neutral-900 dark:text-neutral-50">
-                      {templatePreview.context.digest.heading}
-                    </div>
-                    <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-                      {templatePreview.context.digest.summary}
-                    </div>
-                    {templatePreview.context.digest.groups && templatePreview.context.digest.groups.length > 0 ? (
-                      <div className="mt-3 space-y-2">
-                        {templatePreview.context.digest.groups.map((group) => (
-                          <div key={group.category}>
-                            <div className="text-xs font-semibold text-neutral-500 dark:text-neutral-400">
-                              {group.label} ({group.items.length})
-                            </div>
-                            <ul className="mt-1 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
-                              {group.items.map((item, i) => (
-                                <li key={i}>{item.title}</li>
-                              ))}
-                            </ul>
-                          </div>
-                        ))}
-                      </div>
-                    ) : templatePreview.context.digest.items.length > 0 ? (
-                      <ul className="mt-3 list-inside list-disc text-xs text-neutral-600 dark:text-neutral-300">
-                        {templatePreview.context.digest.items.map((item, i) => (
-                          <li key={i}>{item.title}</li>
-                        ))}
-                      </ul>
-                    ) : null}
-                  </div>
-                </details>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <label className="space-y-1">
+                  <span className="text-sm font-semibold">Preview subject</span>
+                  <input
+                    type="text"
+                    value={templatePreviewContext.campaignSubject}
+                    onChange={(event) =>
+                      setTemplatePreviewContext((current) => ({ ...current, campaignSubject: event.target.value }))
+                    }
+                    className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                  />
+                </label>
+                <label className="space-y-1">
+                  <span className="text-sm font-semibold">Period (days)</span>
+                  <input
+                    type="number"
+                    min={1}
+                    max={30}
+                    value={templatePreviewContext.periodDays}
+                    onChange={(event) =>
+                      setTemplatePreviewContext((current) => ({ ...current, periodDays: Number(event.target.value) || 7 }))
+                    }
+                    className="w-full rounded-xl border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                  />
+                </label>
+              </div>
 
-                {templatePreviewTab === "subject" && (
-                  <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950">
-                    <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
-                      Rendered subject
-                    </div>
-                    <div className="mt-2 text-base font-semibold text-neutral-900 dark:text-neutral-50">
-                      {templatePreview.rendered.subject}
-                    </div>
-                  </div>
-                )}
+              {!templatePreview && (
+                <div className="rounded-xl border border-neutral-200 bg-neutral-50 p-4 text-sm dark:border-neutral-800 dark:bg-neutral-950">
+                  Render a preview to inspect template output.
+                </div>
+              )}
 
-                {templatePreviewTab === "html" && <HtmlPreviewFrame html={templatePreview.rendered.html} />}
+              {templatePreview && templatePreviewTab === "subject" && (
+                <div className="rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950">
+                  <div className="text-sm font-semibold">{templatePreview.rendered.subject}</div>
+                </div>
+              )}
 
-                {templatePreviewTab === "text" && (
-                  <pre className="max-h-[520px] overflow-auto whitespace-pre-wrap rounded-xl border border-neutral-200 bg-white p-4 text-xs text-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
-                    {templatePreview.rendered.text}
+              {templatePreview && templatePreviewTab === "html" && <HtmlPreviewFrame html={templatePreview.rendered.html} />}
+
+              {templatePreview && templatePreviewTab === "text" && (
+                <pre className="max-h-[480px] overflow-auto whitespace-pre-wrap rounded-xl border border-neutral-200 bg-white p-4 text-xs dark:border-neutral-800 dark:bg-neutral-950">
+                  {templatePreview.rendered.text}
+                </pre>
+              )}
+
+              {templatePreview && templatePreviewTab === "starter" && (
+                <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                  <pre className="max-h-[480px] overflow-auto whitespace-pre-wrap rounded-xl border border-neutral-200 bg-white p-4 text-xs dark:border-neutral-800 dark:bg-neutral-950">
+                    {templatePreview.starter.markdown}
                   </pre>
-                )}
-              </div>
-            )}
+                  <div className="prose prose-sm max-w-none rounded-xl border border-neutral-200 bg-white p-4 dark:prose-invert dark:border-neutral-800 dark:bg-neutral-950">
+                    <ReactMarkdown>{templatePreview.starter.markdown}</ReactMarkdown>
+                  </div>
+                </div>
+              )}
+            </div>
           </section>
         </div>
-      )}
-
-      {mode === "subscribers" && (
-        <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
-          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-50">
-                Subscribers{" "}
-                {subscriberTotal > 0 && (
-                  <span className="ml-1 text-sm font-normal text-neutral-500 dark:text-neutral-400">
-                    ({subscriberTotal} total)
-                  </span>
-                )}
-              </h2>
-              <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-                View subscriber status, preferences, and history.
-              </p>
-            </div>
-
-            {subscribers.length > 0 && (
-              <div className="flex items-center gap-3 text-sm">
-                <span className="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-2.5 py-1 text-xs font-semibold text-green-700 dark:bg-green-900/30 dark:text-green-400">
-                  {subscribers.filter((s) => s.status === "active").length} active
-                </span>
-                <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
-                  {subscribers.filter((s) => s.status === "pending").length} pending
-                </span>
-                <span className="inline-flex items-center gap-1.5 rounded-full bg-neutral-100 px-2.5 py-1 text-xs font-semibold text-neutral-700 dark:bg-neutral-800 dark:text-neutral-400">
-                  {subscribers.filter((s) => s.status === "unsubscribed").length} unsubscribed
-                </span>
-              </div>
-            )}
-          </div>
-
-          {subscriberLoading ? (
-            <div className="mt-5 flex items-center justify-center py-12">
-              <div className="h-6 w-6 animate-spin rounded-full border-2 border-neutral-300 border-t-neutral-900 dark:border-neutral-600 dark:border-t-neutral-100" />
-            </div>
-          ) : subscribers.length === 0 ? (
-            <div className="mt-5 rounded-2xl border border-neutral-200 bg-neutral-50 p-8 text-center dark:border-neutral-800 dark:bg-neutral-950">
-              <div className="text-sm font-semibold text-neutral-900 dark:text-neutral-50">No subscribers found.</div>
-              <div className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
-                Subscribers will appear here once people sign up for newsletters.
-              </div>
-            </div>
-          ) : (
-            <div className="mt-5 overflow-x-auto rounded-2xl border border-neutral-200 dark:border-neutral-800">
-              <table className="w-full min-w-[1060px] text-sm">
-                <thead className="bg-neutral-50 dark:bg-neutral-950">
-                  <tr className="text-left text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
-                    <th className="px-4 py-3">Email</th>
-                    <th className="px-4 py-3">Status</th>
-                    <th className="px-4 py-3">Preferences</th>
-                    <th className="px-4 py-3">Clicks (7d)</th>
-                    <th className="px-4 py-3">Last Clicked</th>
-                    <th className="px-4 py-3">Subscribed</th>
-                    <th className="px-4 py-3">Source</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {subscribers.map((sub) => (
-                    <tr key={sub.id} className="border-t border-neutral-200 align-top dark:border-neutral-800">
-                      <td className="px-4 py-3">
-                        <span className="font-semibold text-neutral-900 dark:text-neutral-50">{sub.email}</span>
-                      </td>
-                      <td className="px-4 py-3">
-                        <span
-                          className={cx(
-                            "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold",
-                            sub.status === "active"
-                              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                              : sub.status === "pending"
-                                ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
-                                : "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-400"
-                          )}
-                        >
-                          {sub.status.charAt(0).toUpperCase() + sub.status.slice(1)}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3">
-                        <div className="flex flex-wrap gap-1">
-                          {sub.preferences
-                            .filter((p) => p.enabled)
-                            .map((p) => (
-                              <span
-                                key={p.type}
-                                className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-500/15 dark:text-indigo-200"
-                              >
-                                {p.type}
-                              </span>
-                            ))}
-                          {sub.preferences.filter((p) => p.enabled).length === 0 && (
-                            <span className="text-xs text-neutral-400 dark:text-neutral-500">None</span>
-                          )}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap">
-                        {sub.clicks7d && sub.clicks7d > 0 ? (
-                          <span className="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 dark:bg-blue-500/15 dark:text-blue-200">
-                            {sub.clicks7d}
-                          </span>
-                        ) : (
-                          <span className="text-xs text-neutral-400 dark:text-neutral-500">0</span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 text-neutral-700 dark:text-neutral-200">
-                        {sub.lastClickedLink ? (
-                          <a
-                            href={sub.lastClickedLink}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            title={sub.lastClickedLink}
-                            className="text-xs text-blue-600 underline decoration-blue-300 underline-offset-2 hover:text-blue-800 dark:text-blue-400 dark:decoration-blue-600 dark:hover:text-blue-300"
-                          >
-                            {sub.lastClickedLink.length > 40
-                              ? sub.lastClickedLink.slice(0, 40) + "\u2026"
-                              : sub.lastClickedLink}
-                          </a>
-                        ) : (
-                          <span className="text-xs text-neutral-400 dark:text-neutral-500">--</span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-neutral-700 dark:text-neutral-200">
-                        {new Date(sub.createdAt).toLocaleDateString()}
-                      </td>
-                      <td className="px-4 py-3 text-neutral-700 dark:text-neutral-200">
-                        {sub.source || <span className="text-neutral-400 dark:text-neutral-500">--</span>}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </section>
       )}
     </div>
   );

--- a/src/components/admin/NewsletterStudio.tsx
+++ b/src/components/admin/NewsletterStudio.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { ErrorAlert } from "@/components/admin/ActionButtons";
 import { adminFetch, getAdminApiKey } from "@/lib/admin-utils";
+import { canAutoRenderComposePreview } from "@/lib/newsletter-studio";
 
 type NewsletterType = "news" | "jobs" | "candidates";
 type NewsletterContentMode = "template" | "markdown" | "manual";
@@ -634,14 +635,14 @@ export function NewsletterStudio() {
   }, [composeForm, requestCampaignPreview]);
 
   useEffect(() => {
-    if (mode !== "compose") return;
+    if (!canAutoRenderComposePreview({ loading, mode, draft: composeForm })) return;
 
     const handle = setTimeout(() => {
       void renderComposePreview();
     }, 250);
 
     return () => clearTimeout(handle);
-  }, [mode, renderComposePreview]);
+  }, [loading, mode, renderComposePreview]);
 
   const closeEditPanel = useCallback(
     (force = false) => {
@@ -1801,7 +1802,7 @@ export function NewsletterStudio() {
                             <button
                               type="button"
                               onClick={() => sendNow(campaign.id)}
-                              disabled={saving || campaign.status === "sent" || campaign.status === "sending"}
+                              disabled={saving || campaign.status === "sent"}
                               className="rounded-xl bg-emerald-600 px-3 py-2 text-xs font-semibold text-white disabled:opacity-50"
                             >
                               Send now

--- a/src/components/admin/NewsletterStudio.tsx
+++ b/src/components/admin/NewsletterStudio.tsx
@@ -4,6 +4,15 @@ import ReactMarkdown from "react-markdown";
 import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { ErrorAlert } from "@/components/admin/ActionButtons";
 import { adminFetch, getAdminApiKey } from "@/lib/admin-utils";
+import {
+  buildNewsletterTypes,
+  isPreferenceRowDirty,
+  toPreferenceFlags,
+  toSubscriberDraftRow,
+  type NewsletterSubscriberApiRow,
+  type NewsletterSubscriberPreference,
+  type NewsletterSubscriberRowDraft,
+} from "@/lib/newsletter-subscribers";
 import { canAutoRenderComposePreview } from "@/lib/newsletter-studio";
 
 type NewsletterType = "news" | "jobs" | "candidates";
@@ -11,7 +20,7 @@ type NewsletterContentMode = "template" | "markdown" | "manual";
 type CampaignStatus = "draft" | "scheduled" | "sending" | "sent" | "failed";
 type WorkspaceView = "editor" | "split" | "preview";
 
-type Mode = "compose" | "queue" | "templates";
+type Mode = "compose" | "queue" | "subscribers" | "templates";
 type PreviewTab = "subject" | "html" | "text" | "starter";
 type TemplateFieldKey = "subjectTemplate" | "htmlTemplate" | "textTemplate" | "markdownTemplate";
 type ComposeFieldKey = "markdownContent" | "manualHtml" | "manualText";
@@ -83,6 +92,15 @@ interface NewsletterTemplate {
   htmlTemplate: string;
   textTemplate: string;
   markdownTemplate: string;
+}
+
+interface SubscriberUpdateResult {
+  subscriber: {
+    id: string;
+    email: string;
+    status: string;
+  };
+  preferences: NewsletterSubscriberPreference[];
 }
 
 type CampaignDraft = {
@@ -252,6 +270,43 @@ function StatusPill({ status }: { status: CampaignStatus }) {
   );
 }
 
+function SubscriberStatusPill({ status }: { status: string }) {
+  const styles = {
+    active:
+      "border border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/25 dark:bg-emerald-500/15 dark:text-emerald-200",
+    pending:
+      "border border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-500/25 dark:bg-amber-500/15 dark:text-amber-200",
+    unsubscribed:
+      "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200",
+  }[status] || "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200";
+
+  return (
+    <span className={cx("inline-flex rounded-full px-2.5 py-1 text-xs font-semibold capitalize", styles)}>
+      {status}
+    </span>
+  );
+}
+
+function SubscriberPreferenceToggle(props: {
+  checked: boolean;
+  disabled?: boolean;
+  label: string;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="inline-flex cursor-pointer items-center justify-center">
+      <input
+        type="checkbox"
+        aria-label={props.label}
+        checked={props.checked}
+        disabled={props.disabled}
+        onChange={(event) => props.onChange(event.target.checked)}
+        className="h-4 w-4 rounded border-neutral-300 text-indigo-600 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-950"
+      />
+    </label>
+  );
+}
+
 function SegmentedControl<T extends string>(props: {
   value: T;
   onChange: (value: T) => void;
@@ -407,6 +462,9 @@ export function NewsletterStudio() {
 
   const [campaigns, setCampaigns] = useState<NewsletterCampaign[]>([]);
   const [templates, setTemplates] = useState<Record<NewsletterType, NewsletterTemplate> | null>(null);
+  const [subscribers, setSubscribers] = useState<NewsletterSubscriberRowDraft[]>([]);
+  const [subscribersLoading, setSubscribersLoading] = useState(false);
+  const [subscribersLoaded, setSubscribersLoaded] = useState(false);
 
   const [composeForm, setComposeForm] = useState<CampaignDraft>({
     newsletterType: "news",
@@ -509,6 +567,25 @@ export function NewsletterStudio() {
     }
   }, [activeTemplateType]);
 
+  const refreshSubscribers = useCallback(async () => {
+    setSubscribersLoading(true);
+    setError(null);
+
+    const result = await adminFetch<NewsletterSubscriberApiRow[]>("/api/v1/newsletter/subscribers?limit=200", {
+      headers: { "x-api-key": getAdminApiKey() },
+    });
+
+    setSubscribersLoading(false);
+
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+
+    setSubscribers((result.data || []).map((subscriber) => toSubscriberDraftRow(subscriber)));
+    setSubscribersLoaded(true);
+  }, []);
+
   useEffect(() => {
     const load = async () => {
       setLoading(true);
@@ -517,6 +594,11 @@ export function NewsletterStudio() {
     };
     load();
   }, [refreshData]);
+
+  useEffect(() => {
+    if (mode !== "subscribers" || subscribersLoaded || subscribersLoading) return;
+    void refreshSubscribers();
+  }, [mode, refreshSubscribers, subscribersLoaded, subscribersLoading]);
 
   const sortedCampaigns = useMemo(() => {
     return [...campaigns].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
@@ -1289,6 +1371,92 @@ export function NewsletterStudio() {
     setEditForm((current) => (current ? { ...current, contentMode: next } : current));
   };
 
+  const setSubscriberDraftFlag = (subscriberId: string, newsletterType: NewsletterType, enabled: boolean) => {
+    setSubscribers((current) =>
+      current.map((subscriber) =>
+        subscriber.id === subscriberId
+          ? {
+            ...subscriber,
+            draft: { ...subscriber.draft, [newsletterType]: enabled },
+            error: null,
+          }
+          : subscriber
+      )
+    );
+  };
+
+  const resetSubscriberDraft = (subscriberId: string) => {
+    setSubscribers((current) =>
+      current.map((subscriber) =>
+        subscriber.id === subscriberId
+          ? {
+            ...subscriber,
+            draft: { ...subscriber.current },
+            error: null,
+          }
+          : subscriber
+      )
+    );
+  };
+
+  const saveSubscriberDraft = async (subscriberId: string) => {
+    const subscriber = subscribers.find((row) => row.id === subscriberId);
+    if (!subscriber) return;
+
+    setSubscribers((current) =>
+      current.map((row) =>
+        row.id === subscriberId
+          ? {
+            ...row,
+            saving: true,
+            error: null,
+          }
+          : row
+      )
+    );
+
+    const result = await adminFetch<SubscriberUpdateResult>(`/api/v1/newsletter/subscribers/${subscriberId}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": getAdminApiKey(),
+      },
+      body: JSON.stringify({ newsletterTypes: buildNewsletterTypes(subscriber.draft) }),
+    });
+
+    if (result.error || !result.data) {
+      setSubscribers((current) =>
+        current.map((row) =>
+          row.id === subscriberId
+            ? {
+              ...row,
+              saving: false,
+              error: result.error || "Unable to update subscriber preferences",
+            }
+            : row
+        )
+      );
+      return;
+    }
+
+    const nextCurrent = toPreferenceFlags(result.data.preferences);
+    setSubscribers((current) =>
+      current.map((row) =>
+        row.id === subscriberId
+          ? {
+            ...row,
+            status: result.data!.subscriber.status,
+            current: nextCurrent,
+            draft: { ...nextCurrent },
+            saving: false,
+            error: null,
+          }
+          : row
+      )
+    );
+    setStatusMessage(`Updated subscriptions for ${subscriber.email}`);
+  };
+
   if (loading) {
     return (
       <div className="rounded-2xl border border-neutral-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-900">
@@ -1304,7 +1472,11 @@ export function NewsletterStudio() {
           message={error}
           onRetry={() => {
             setError(null);
-            refreshData();
+            if (mode === "subscribers") {
+              void refreshSubscribers();
+              return;
+            }
+            void refreshData();
           }}
         />
       )}
@@ -1331,6 +1503,7 @@ export function NewsletterStudio() {
                 options={[
                   { value: "compose", label: "Compose" },
                   { value: "queue", label: "Queue" },
+                  { value: "subscribers", label: "Subscribers" },
                   { value: "templates", label: "Templates" },
                 ]}
               />
@@ -1689,6 +1862,129 @@ export function NewsletterStudio() {
             </div>
           </section>
         </div>
+      )}
+
+      {mode === "subscribers" && (
+        <section className="rounded-2xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">Subscribers</h2>
+              <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">
+                One row per subscriber with local toggle drafts for News, Jobs, and Candidates.
+              </p>
+            </div>
+            <div className="rounded-full border border-neutral-200 px-3 py-1 text-xs font-semibold text-neutral-600 dark:border-neutral-700 dark:text-neutral-300">
+              {subscribers.length} loaded
+            </div>
+          </div>
+
+          {subscribersLoading && subscribers.length === 0 && (
+            <div className="mt-5 rounded-xl border border-neutral-200 bg-neutral-50 p-6 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300">
+              Loading subscribers...
+            </div>
+          )}
+
+          {!subscribersLoading && subscribers.length === 0 && (
+            <div className="mt-5 rounded-xl border border-neutral-200 bg-neutral-50 p-6 text-sm text-neutral-700 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-300">
+              No subscribers found.
+            </div>
+          )}
+
+          {subscribers.length > 0 && (
+            <div className="mt-5 overflow-x-auto rounded-xl border border-neutral-200 dark:border-neutral-800">
+              <table className="w-full min-w-[1180px] text-sm">
+                <thead className="bg-neutral-50 dark:bg-neutral-950">
+                  <tr className="text-left text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                    <th className="px-4 py-3">Email</th>
+                    <th className="px-4 py-3">Status</th>
+                    <th className="px-4 py-3 text-center">News</th>
+                    <th className="px-4 py-3 text-center">Jobs</th>
+                    <th className="px-4 py-3 text-center">Candidates</th>
+                    <th className="px-4 py-3">Clicks 7d</th>
+                    <th className="px-4 py-3">Last clicked</th>
+                    <th className="px-4 py-3">Created</th>
+                    <th className="px-4 py-3 text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {subscribers.map((subscriber) => {
+                    const isDirty = isPreferenceRowDirty(subscriber.current, subscriber.draft);
+
+                    return (
+                      <tr key={subscriber.id} className="border-t border-neutral-200 align-top dark:border-neutral-800">
+                        <td className="px-4 py-3">
+                          <div className="font-semibold text-neutral-900 dark:text-neutral-50">{subscriber.email}</div>
+                          <div className="mt-1 flex flex-wrap items-center gap-2">
+                            {isDirty && (
+                              <span className="rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+                                Unsaved
+                              </span>
+                            )}
+                            {subscriber.saving && (
+                              <span className="text-xs text-neutral-500 dark:text-neutral-400">Saving...</span>
+                            )}
+                          </div>
+                          {subscriber.error && (
+                            <div className="mt-2 text-xs text-red-700 dark:text-red-300">{subscriber.error}</div>
+                          )}
+                        </td>
+                        <td className="px-4 py-3">
+                          <SubscriberStatusPill status={subscriber.status} />
+                        </td>
+                        {NEWSLETTER_TYPES.map((newsletterType) => (
+                          <td key={newsletterType} className="px-4 py-3 text-center">
+                            <SubscriberPreferenceToggle
+                              checked={subscriber.draft[newsletterType]}
+                              disabled={subscriber.saving}
+                              label={`${subscriber.email} ${newsletterType} subscription`}
+                              onChange={(enabled) => setSubscriberDraftFlag(subscriber.id, newsletterType, enabled)}
+                            />
+                          </td>
+                        ))}
+                        <td className="px-4 py-3">{subscriber.clicks7d}</td>
+                        <td className="px-4 py-3">
+                          {subscriber.lastClickedLink ? (
+                            <a
+                              href={subscriber.lastClickedLink}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="line-clamp-2 break-all text-xs text-indigo-700 underline decoration-indigo-300 underline-offset-2 dark:text-indigo-300"
+                            >
+                              {subscriber.lastClickedLink}
+                            </a>
+                          ) : (
+                            <span className="text-neutral-400">-</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 whitespace-nowrap">{new Date(subscriber.createdAt).toLocaleString()}</td>
+                        <td className="px-4 py-3">
+                          <div className="flex justify-end gap-2">
+                            <button
+                              type="button"
+                              onClick={() => resetSubscriberDraft(subscriber.id)}
+                              disabled={subscriber.saving || !isDirty}
+                              className="rounded-xl border px-3 py-2 text-xs font-semibold disabled:opacity-50"
+                            >
+                              Reset
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => void saveSubscriberDraft(subscriber.id)}
+                              disabled={subscriber.saving || !isDirty}
+                              className="rounded-xl bg-neutral-900 px-3 py-2 text-xs font-semibold text-white disabled:opacity-50 dark:bg-neutral-50 dark:text-neutral-900"
+                            >
+                              Save
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
       )}
 
       {mode === "queue" && (

--- a/src/data/news.ts
+++ b/src/data/news.ts
@@ -22,6 +22,7 @@ export interface CuratedLink {
 	title: string;
 	url: string;
 	source: string;
+	sourceImage?: string;
 	date: string;
 	description?: string;
 	category: NewsCategory;

--- a/src/data/news.ts
+++ b/src/data/news.ts
@@ -7,12 +7,18 @@ export type NewsSource = "curated" | "blog" | "announcement";
 
 export type NewsCategory =
 	| "crypto"
+	| "ethereum"
+	| "cryptography"
 	| "ai"
+	| "health"
 	| "infrastructure"
 	| "defi"
 	| "research"
 	| "product"
+	| "cool_product"
+	| "developer_tooling"
 	| "funding"
+	| "world"
 	| "general"
 	| "x_post";
 
@@ -59,12 +65,18 @@ export type NewsItem =
 
 export const categoryLabels: Record<NewsCategory, string> = {
 	crypto: "Crypto",
+	ethereum: "Ethereum",
+	cryptography: "Cryptography",
 	ai: "AI",
+	health: "Health",
 	infrastructure: "Infrastructure",
 	defi: "DeFi",
 	research: "Research",
 	product: "Product",
+	cool_product: "Cool Product",
+	developer_tooling: "Developer Tooling",
 	funding: "Funding",
+	world: "World",
 	general: "General",
 	x_post: "X Post",
 };

--- a/src/data/news.ts
+++ b/src/data/news.ts
@@ -7,18 +7,12 @@ export type NewsSource = "curated" | "blog" | "announcement";
 
 export type NewsCategory =
 	| "crypto"
-	| "ethereum"
-	| "cryptography"
 	| "ai"
-	| "health"
 	| "infrastructure"
 	| "defi"
 	| "research"
 	| "product"
-	| "cool_product"
-	| "developer_tooling"
 	| "funding"
-	| "world"
 	| "general"
 	| "x_post";
 
@@ -65,18 +59,12 @@ export type NewsItem =
 
 export const categoryLabels: Record<NewsCategory, string> = {
 	crypto: "Crypto",
-	ethereum: "Ethereum",
-	cryptography: "Cryptography",
 	ai: "AI",
-	health: "Health",
 	infrastructure: "Infrastructure",
 	defi: "DeFi",
 	research: "Research",
 	product: "Product",
-	cool_product: "Cool Product",
-	developer_tooling: "Developer Tooling",
 	funding: "Funding",
-	world: "World",
 	general: "General",
 	x_post: "X Post",
 };

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -4,3 +4,4 @@ export * from "./news";
 export * from "./investments";
 export * from "./blog";
 export * from "./misc";
+export * from "./newsletter";

--- a/src/db/schema/newsletter.ts
+++ b/src/db/schema/newsletter.ts
@@ -1,0 +1,141 @@
+import { createId } from "@paralleldrive/cuid2";
+import { boolean, index, integer, text, timestamp, pgTable } from "drizzle-orm/pg-core";
+
+export const newsletterSubscribers = pgTable(
+  "newsletter_subscribers",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    email: text("email").notNull().unique(),
+    status: text("status").notNull().default("pending"), // pending | active | unsubscribed
+    confirmedAt: timestamp("confirmed_at"),
+    unsubscribedAt: timestamp("unsubscribed_at"),
+    source: text("source").notNull().default("news-page"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [index("newsletter_subscribers_status_idx").on(table.status)]
+);
+
+export const newsletterPreferences = pgTable(
+  "newsletter_preferences",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    subscriberId: text("subscriber_id").notNull(),
+    newsletterType: text("newsletter_type").notNull(), // news | jobs | candidates
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("newsletter_preferences_subscriber_idx").on(table.subscriberId),
+    index("newsletter_preferences_type_idx").on(table.newsletterType),
+  ]
+);
+
+export const newsletterCampaigns = pgTable(
+  "newsletter_campaigns",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    newsletterType: text("newsletter_type").notNull(), // news | jobs | candidates
+    subject: text("subject").notNull(),
+    previewText: text("preview_text"),
+    status: text("status").notNull().default("draft"), // draft | scheduled | sending | sent | failed
+    periodDays: integer("period_days").notNull().default(7),
+    scheduledAt: timestamp("scheduled_at"),
+    sentAt: timestamp("sent_at"),
+    failureReason: text("failure_reason"),
+    createdBy: text("created_by"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("newsletter_campaigns_status_idx").on(table.status),
+    index("newsletter_campaigns_type_idx").on(table.newsletterType),
+    index("newsletter_campaigns_scheduled_idx").on(table.scheduledAt),
+  ]
+);
+
+export const newsletterCampaignRecipients = pgTable(
+  "newsletter_campaign_recipients",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    campaignId: text("campaign_id").notNull(),
+    subscriberId: text("subscriber_id").notNull(),
+    email: text("email").notNull(),
+    status: text("status").notNull().default("pending"), // pending | sent | failed | skipped
+    sentAt: timestamp("sent_at"),
+    errorMessage: text("error_message"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("newsletter_campaign_recipients_campaign_idx").on(table.campaignId),
+    index("newsletter_campaign_recipients_subscriber_idx").on(table.subscriberId),
+  ]
+);
+
+export const newsletterSendEvents = pgTable(
+  "newsletter_send_events",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    campaignId: text("campaign_id").notNull(),
+    recipientId: text("recipient_id"),
+    eventType: text("event_type").notNull(), // queued | sent | failed | bounced | complained
+    provider: text("provider"),
+    providerMessageId: text("provider_message_id"),
+    payload: text("payload"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("newsletter_send_events_campaign_idx").on(table.campaignId),
+    index("newsletter_send_events_type_idx").on(table.eventType),
+  ]
+);
+
+export const newsletterUnsubTokens = pgTable(
+  "newsletter_unsub_tokens",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    subscriberId: text("subscriber_id").notNull(),
+    newsletterType: text("newsletter_type"), // null means applies to all
+    tokenType: text("token_type").notNull().default("unsubscribe"), // confirm | unsubscribe | preferences
+    token: text("token").notNull().unique(),
+    expiresAt: timestamp("expires_at").notNull(),
+    usedAt: timestamp("used_at"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("newsletter_unsub_tokens_subscriber_idx").on(table.subscriberId),
+    index("newsletter_unsub_tokens_token_idx").on(table.token),
+  ]
+);
+
+export type NewsletterSubscriber = typeof newsletterSubscribers.$inferSelect;
+export type NewNewsletterSubscriber = typeof newsletterSubscribers.$inferInsert;
+
+export type NewsletterPreference = typeof newsletterPreferences.$inferSelect;
+export type NewNewsletterPreference = typeof newsletterPreferences.$inferInsert;
+
+export type NewsletterCampaign = typeof newsletterCampaigns.$inferSelect;
+export type NewNewsletterCampaign = typeof newsletterCampaigns.$inferInsert;
+
+export type NewsletterCampaignRecipient = typeof newsletterCampaignRecipients.$inferSelect;
+export type NewNewsletterCampaignRecipient = typeof newsletterCampaignRecipients.$inferInsert;
+
+export type NewsletterSendEvent = typeof newsletterSendEvents.$inferSelect;
+export type NewNewsletterSendEvent = typeof newsletterSendEvents.$inferInsert;
+
+export type NewsletterUnsubToken = typeof newsletterUnsubTokens.$inferSelect;
+export type NewNewsletterUnsubToken = typeof newsletterUnsubTokens.$inferInsert;

--- a/src/db/schema/newsletter.ts
+++ b/src/db/schema/newsletter.ts
@@ -65,6 +65,24 @@ export const newsletterCampaigns = pgTable(
   ]
 );
 
+export const newsletterTemplates = pgTable(
+  "newsletter_templates",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    newsletterType: text("newsletter_type").notNull().unique(), // news | jobs | candidates
+    subjectTemplate: text("subject_template").notNull(),
+    htmlTemplate: text("html_template").notNull(),
+    textTemplate: text("text_template").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("newsletter_templates_type_idx").on(table.newsletterType),
+  ]
+);
+
 export const newsletterCampaignRecipients = pgTable(
   "newsletter_campaign_recipients",
   {
@@ -138,6 +156,9 @@ export type NewNewsletterPreference = typeof newsletterPreferences.$inferInsert;
 
 export type NewsletterCampaign = typeof newsletterCampaigns.$inferSelect;
 export type NewNewsletterCampaign = typeof newsletterCampaigns.$inferInsert;
+
+export type NewsletterTemplate = typeof newsletterTemplates.$inferSelect;
+export type NewNewsletterTemplate = typeof newsletterTemplates.$inferInsert;
 
 export type NewsletterCampaignRecipient = typeof newsletterCampaignRecipients.$inferSelect;
 export type NewNewsletterCampaignRecipient = typeof newsletterCampaignRecipients.$inferInsert;

--- a/src/db/schema/newsletter.ts
+++ b/src/db/schema/newsletter.ts
@@ -1,5 +1,5 @@
 import { createId } from "@paralleldrive/cuid2";
-import { boolean, index, integer, text, timestamp, pgTable } from "drizzle-orm/pg-core";
+import { boolean, index, integer, text, timestamp, pgTable, uniqueIndex } from "drizzle-orm/pg-core";
 
 export const newsletterSubscribers = pgTable(
   "newsletter_subscribers",
@@ -33,6 +33,10 @@ export const newsletterPreferences = pgTable(
   (table) => [
     index("newsletter_preferences_subscriber_idx").on(table.subscriberId),
     index("newsletter_preferences_type_idx").on(table.newsletterType),
+    uniqueIndex("newsletter_preferences_subscriber_type_uidx").on(
+      table.subscriberId,
+      table.newsletterType
+    ),
   ]
 );
 
@@ -79,6 +83,10 @@ export const newsletterCampaignRecipients = pgTable(
   (table) => [
     index("newsletter_campaign_recipients_campaign_idx").on(table.campaignId),
     index("newsletter_campaign_recipients_subscriber_idx").on(table.subscriberId),
+    uniqueIndex("newsletter_campaign_recipients_campaign_subscriber_uidx").on(
+      table.campaignId,
+      table.subscriberId
+    ),
   ]
 );
 

--- a/src/db/schema/newsletter.ts
+++ b/src/db/schema/newsletter.ts
@@ -53,6 +53,8 @@ export const newsletterCampaigns = pgTable(
     markdownContent: text("markdown_content"),
     manualHtml: text("manual_html"),
     manualText: text("manual_text"),
+    renderedHtml: text("rendered_html"),
+    renderedText: text("rendered_text"),
     status: text("status").notNull().default("draft"), // draft | scheduled | sending | sent | failed
     periodDays: integer("period_days").notNull().default(7),
     scheduledAt: timestamp("scheduled_at"),

--- a/src/db/schema/newsletter.ts
+++ b/src/db/schema/newsletter.ts
@@ -49,6 +49,10 @@ export const newsletterCampaigns = pgTable(
     newsletterType: text("newsletter_type").notNull(), // news | jobs | candidates
     subject: text("subject").notNull(),
     previewText: text("preview_text"),
+    contentMode: text("content_mode").notNull().default("template"), // template | markdown | manual
+    markdownContent: text("markdown_content"),
+    manualHtml: text("manual_html"),
+    manualText: text("manual_text"),
     status: text("status").notNull().default("draft"), // draft | scheduled | sending | sent | failed
     periodDays: integer("period_days").notNull().default(7),
     scheduledAt: timestamp("scheduled_at"),
@@ -75,6 +79,7 @@ export const newsletterTemplates = pgTable(
     subjectTemplate: text("subject_template").notNull(),
     htmlTemplate: text("html_template").notNull(),
     textTemplate: text("text_template").notNull(),
+    markdownTemplate: text("markdown_template").notNull().default("{{default_markdown_body}}"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },

--- a/src/hooks/useNewsClicks.ts
+++ b/src/hooks/useNewsClicks.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface UseNewsClicksReturn {
+  getClickCount: (id: string) => number;
+  isPopular: (id: string) => boolean;
+  loaded: boolean;
+}
+
+export function useNewsClicks(): UseNewsClicksReturn {
+  const [clickCounts, setClickCounts] = useState<Map<string, number>>(new Map());
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch("/api/hot-news", { signal: controller.signal })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.clickCounts) {
+          setClickCounts(new Map(Object.entries(data.clickCounts) as [string, number][]));
+        }
+      })
+      .catch((error) => {
+        if (error.name !== "AbortError") {
+          console.debug("Failed to fetch news clicks:", error);
+        }
+      })
+      .finally(() => {
+        setLoaded(true);
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  const getClickCount = useCallback(
+    (id: string): number => clickCounts.get(id) ?? 0,
+    [clickCounts],
+  );
+
+  const isPopular = useCallback(
+    (id: string): boolean => (clickCounts.get(id) ?? 0) >= 10,
+    [clickCounts],
+  );
+
+  return { getClickCount, isPopular, loaded };
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -89,6 +89,7 @@ export async function getCuratedLinksFromDB(): Promise<CuratedLink[]> {
     title: link.title,
     url: link.url,
     source: link.source,
+    sourceImage: link.sourceImage || undefined,
     date: link.date.toISOString().split("T")[0],
     description: link.description || undefined,
     category: link.category as CuratedLink["category"],

--- a/src/lib/news-tools.ts
+++ b/src/lib/news-tools.ts
@@ -1,0 +1,29 @@
+import { type RecommendationItem, getRecommendedLinks } from "@/lib/recommendations";
+
+const RECOMMENDATION_PRIORITY = [
+  "The MEV Letter",
+  "SemiAnalysis",
+  "TBPN",
+  "Ethereal News",
+] as const;
+
+export function getNewsToolsRecommendationSummary(limit: number = 4): {
+  highlights: RecommendationItem[];
+  hiddenCount: number;
+} {
+  const links = getRecommendedLinks();
+  const prioritized = RECOMMENDATION_PRIORITY.flatMap((name) => {
+    const match = links.find((link) => link.name === name);
+    return match ? [match] : [];
+  });
+  const remaining = links.filter(
+    (link) => !RECOMMENDATION_PRIORITY.includes(link.name as (typeof RECOMMENDATION_PRIORITY)[number]),
+  );
+  const ordered = [...prioritized, ...remaining];
+  const highlights = ordered.slice(0, limit);
+
+  return {
+    highlights,
+    hiddenCount: Math.max(0, ordered.length - highlights.length),
+  };
+}

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -15,6 +15,7 @@ export interface AggregatedNewsItem {
   featured?: boolean;
   // Type-specific fields
   source?: string; // For curated links
+  sourceImage?: string; // For curated links
   company?: string; // For announcements
   companyLogo?: string; // For announcements
   platform?: string; // For announcements
@@ -54,6 +55,7 @@ export async function getAllNews(): Promise<AggregatedNewsItem[]> {
     category: link.category as NewsCategory,
     featured: link.featured || false,
     source: link.source,
+    sourceImage: link.sourceImage || undefined,
   }));
 
   // Map announcements

--- a/src/lib/newsletter-studio.ts
+++ b/src/lib/newsletter-studio.ts
@@ -1,0 +1,26 @@
+export type NewsletterStudioMode = "compose" | "queue" | "templates";
+
+export function canAutoRenderComposePreview(input: {
+  loading: boolean;
+  mode: NewsletterStudioMode;
+  draft: {
+    contentMode: "template" | "markdown" | "manual";
+    markdownContent: string;
+    manualHtml: string;
+    manualText: string;
+  };
+}) {
+  if (input.loading || input.mode !== "compose") {
+    return false;
+  }
+
+  if (input.draft.contentMode === "template") {
+    return true;
+  }
+
+  if (input.draft.contentMode === "markdown") {
+    return input.draft.markdownContent.trim().length > 0;
+  }
+
+  return input.draft.manualHtml.trim().length > 0 && input.draft.manualText.trim().length > 0;
+}

--- a/src/lib/newsletter-studio.ts
+++ b/src/lib/newsletter-studio.ts
@@ -24,3 +24,15 @@ export function canAutoRenderComposePreview(input: {
 
   return input.draft.manualHtml.trim().length > 0 && input.draft.manualText.trim().length > 0;
 }
+
+export function shouldLoadSubscribersOnModeChange(input: {
+  nextMode: NewsletterStudioMode;
+  subscribersLoaded: boolean;
+  subscribersLoading: boolean;
+}) {
+  return (
+    input.nextMode === "subscribers" &&
+    !input.subscribersLoaded &&
+    !input.subscribersLoading
+  );
+}

--- a/src/lib/newsletter-studio.ts
+++ b/src/lib/newsletter-studio.ts
@@ -1,4 +1,4 @@
-export type NewsletterStudioMode = "compose" | "queue" | "templates";
+export type NewsletterStudioMode = "compose" | "queue" | "subscribers" | "templates";
 
 export function canAutoRenderComposePreview(input: {
   loading: boolean;

--- a/src/lib/newsletter-subscribers.ts
+++ b/src/lib/newsletter-subscribers.ts
@@ -1,0 +1,70 @@
+export type NewsletterType = "news" | "jobs" | "candidates";
+
+export type PreferenceFlags = Record<NewsletterType, boolean>;
+
+export type NewsletterSubscriberPreference = {
+  newsletterType: string;
+  enabled: boolean;
+};
+
+export type NewsletterSubscriberApiRow = {
+  id: string;
+  email: string;
+  status: string;
+  createdAt: string;
+  clicks7d: number;
+  lastClickedLink: string | null;
+  preferences: NewsletterSubscriberPreference[];
+};
+
+export type NewsletterSubscriberRowDraft = {
+  id: string;
+  email: string;
+  status: string;
+  current: PreferenceFlags;
+  draft: PreferenceFlags;
+  clicks7d: number;
+  lastClickedLink: string | null;
+  createdAt: string;
+  saving: boolean;
+  error: string | null;
+};
+
+export const NEWSLETTER_TYPES: NewsletterType[] = ["news", "jobs", "candidates"];
+
+export function toPreferenceFlags(preferences: NewsletterSubscriberPreference[]): PreferenceFlags {
+  const enabledTypes = new Set(
+    preferences.filter((preference) => preference.enabled).map((preference) => preference.newsletterType)
+  );
+
+  return {
+    news: enabledTypes.has("news"),
+    jobs: enabledTypes.has("jobs"),
+    candidates: enabledTypes.has("candidates"),
+  };
+}
+
+export function buildNewsletterTypes(flags: PreferenceFlags): NewsletterType[] {
+  return NEWSLETTER_TYPES.filter((newsletterType) => flags[newsletterType]);
+}
+
+export function isPreferenceRowDirty(current: PreferenceFlags, draft: PreferenceFlags) {
+  return NEWSLETTER_TYPES.some((newsletterType) => current[newsletterType] !== draft[newsletterType]);
+}
+
+export function toSubscriberDraftRow(subscriber: NewsletterSubscriberApiRow): NewsletterSubscriberRowDraft {
+  const current = toPreferenceFlags(subscriber.preferences);
+
+  return {
+    id: subscriber.id,
+    email: subscriber.email,
+    status: subscriber.status,
+    current,
+    draft: { ...current },
+    clicks7d: subscriber.clicks7d,
+    lastClickedLink: subscriber.lastClickedLink,
+    createdAt: subscriber.createdAt,
+    saving: false,
+    error: null,
+  };
+}

--- a/src/lib/newsletter-utils.ts
+++ b/src/lib/newsletter-utils.ts
@@ -1,0 +1,19 @@
+export const NEWSLETTER_TYPES = ["news", "jobs", "candidates"] as const;
+export type NewsletterType = (typeof NEWSLETTER_TYPES)[number];
+
+export function dedupeNewsletterTypes(types: string[]): NewsletterType[] {
+  const valid = new Set<NewsletterType>();
+  for (const type of types) {
+    if (NEWSLETTER_TYPES.includes(type as NewsletterType)) {
+      valid.add(type as NewsletterType);
+    }
+  }
+  return Array.from(valid);
+}
+
+export function computeViewTotals(current: number, previous: number) {
+  return {
+    totalViews: current,
+    deltaViews: current - previous,
+  };
+}

--- a/src/lib/newsletter-utils.ts
+++ b/src/lib/newsletter-utils.ts
@@ -1,6 +1,9 @@
 export const NEWSLETTER_TYPES = ["news", "jobs", "candidates"] as const;
 export type NewsletterType = (typeof NEWSLETTER_TYPES)[number];
 
+export const NEWSLETTER_CONTENT_MODES = ["template", "markdown", "manual"] as const;
+export type NewsletterContentMode = (typeof NEWSLETTER_CONTENT_MODES)[number];
+
 export function dedupeNewsletterTypes(types: string[]): NewsletterType[] {
   const valid = new Set<NewsletterType>();
   for (const type of types) {
@@ -16,4 +19,11 @@ export function computeViewTotals(current: number, previous: number) {
     totalViews: current,
     deltaViews: current - previous,
   };
+}
+
+export function normalizeNewsletterContentMode(mode?: string): NewsletterContentMode {
+  if (mode && NEWSLETTER_CONTENT_MODES.includes(mode as NewsletterContentMode)) {
+    return mode as NewsletterContentMode;
+  }
+  return "template";
 }

--- a/src/lib/recommendations.ts
+++ b/src/lib/recommendations.ts
@@ -1,0 +1,77 @@
+export type RecommendationItem = {
+  name: string;
+  url: string;
+  description: string;
+};
+
+const COMMON_RECOMMENDED_LINKS: RecommendationItem[] = [
+  {
+    name: "TBPN",
+    url: "https://tbpn.substack.com",
+    description: "Technology Business Programming Network — daily live business & tech podcast by @johncoogan & @jordihays",
+  },
+  {
+    name: "SemiAnalysis",
+    url: "https://semianalysis.com",
+    description: "Deep dives on semiconductors, AI infrastructure, and compute",
+  },
+  {
+    name: "Ethereal News",
+    url: "https://etherealnews.substack.com",
+    description: "Ethereum ecosystem news and analysis",
+  },
+  {
+    name: "ZK Mesh",
+    url: "https://zkmesh.substack.com",
+    description: "Monthly zero-knowledge newsletter (zkmesh+ for premium)",
+  },
+  {
+    name: "The MEV Letter",
+    url: "https://collective.flashbots.net/tag/the-mev-letter",
+    description: "Flashbots' MEV research roundup covering papers, posts, and ecosystem updates",
+  },
+  {
+    name: "dcbuilder.dev/blog",
+    url: "/blog",
+    description: "Long-form thoughts and writeups",
+  },
+  {
+    name: "@dcbuilder on X",
+    url: "https://x.com/dcbuilder",
+    description: "More curated content on X",
+  },
+];
+
+const NEWSLETTER_EXTRA_RECOMMENDED_LINKS: RecommendationItem[] = [
+  {
+    name: "dcbuilder.dev/news",
+    url: "https://dcbuilder.dev/news",
+    description: "Older curated links and announcements",
+  },
+];
+
+export const OTHER_CONTENT_I_LIKE: RecommendationItem[] = [
+  {
+    name: "Zero Knowledge FM",
+    url: "https://zeroknowledge.fm",
+    description: "Podcast on ZK proofs and the decentralized web",
+  },
+  {
+    name: "TBPN Podcast",
+    url: "https://tbpn.substack.com",
+    description: "Daily live video & audio show on business and tech by @johncoogan & @jordihays",
+  },
+  {
+    name: "Hardcore History",
+    url: "https://www.dancarlin.com/hardcore-history-series",
+    description: "Dan Carlin's epic deep-dives into history",
+  },
+];
+
+export function getRecommendedLinks(options?: { includeNewsletterExtras?: boolean }): RecommendationItem[] {
+  if (options?.includeNewsletterExtras) {
+    return [...COMMON_RECOMMENDED_LINKS, ...NEWSLETTER_EXTRA_RECOMMENDED_LINKS];
+  }
+
+  return COMMON_RECOMMENDED_LINKS;
+}

--- a/src/services/newsletter-admin.ts
+++ b/src/services/newsletter-admin.ts
@@ -1,0 +1,1 @@
+export { adminUpdateSubscriberPreferences } from "@/services/newsletter";

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -1,0 +1,856 @@
+import { randomBytes } from "crypto";
+import { and, desc, eq, gt, inArray, isNull, lte } from "drizzle-orm";
+import {
+  db,
+  jobs,
+  candidates,
+  newsletterSubscribers,
+  newsletterPreferences,
+  newsletterCampaigns,
+  newsletterCampaignRecipients,
+  newsletterSendEvents,
+  newsletterUnsubTokens,
+} from "@/db";
+import {
+  getCandidateViewsForWindow,
+  getJobApplyClicksForWindow,
+  getNewsClicksLast7Days,
+} from "@/services/posthog";
+import { getAllNews } from "@/lib/news";
+import {
+  NEWSLETTER_TYPES,
+  type NewsletterType,
+  dedupeNewsletterTypes,
+  computeViewTotals,
+} from "@/lib/newsletter-utils";
+
+type SendResult = { success: true; messageId: string } | { success: false; error: string };
+
+type DigestItem = {
+  title: string;
+  subtitle?: string;
+  url?: string;
+  currentViews?: number;
+  delta?: number;
+};
+
+interface CampaignDigest {
+  heading: string;
+  summary: string;
+  periodDays: number;
+  totalViews?: number;
+  deltaViews?: number;
+  items: DigestItem[];
+}
+
+const DEFAULT_CAMPAIGN_PERIOD_DAYS = 7;
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function validateEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function getBaseUrl(): string {
+  if (process.env.NEXT_PUBLIC_BASE_URL) return process.env.NEXT_PUBLIC_BASE_URL;
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  return "https://dcbuilder.dev";
+}
+
+function makeToken(): string {
+  return randomBytes(24).toString("hex");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+async function sendEmail(params: {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}): Promise<SendResult> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.NEWSLETTER_FROM_EMAIL;
+  const replyTo = process.env.NEWSLETTER_REPLY_TO;
+
+  if (!apiKey || !from) {
+    return { success: false, error: "Email provider not configured (RESEND_API_KEY or NEWSLETTER_FROM_EMAIL missing)" };
+  }
+
+  try {
+    const response = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from,
+        to: [params.to],
+        subject: params.subject,
+        html: params.html,
+        text: params.text,
+        ...(replyTo ? { reply_to: replyTo } : {}),
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      return { success: false, error: `Resend error ${response.status}: ${body}` };
+    }
+
+    const payload = await response.json() as { id?: string };
+    return { success: true, messageId: payload.id || "unknown" };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : "Unknown email provider error" };
+  }
+}
+
+async function upsertPreferences(subscriberId: string, enabledTypes: NewsletterType[]) {
+  const now = new Date();
+  const existing = await db
+    .select()
+    .from(newsletterPreferences)
+    .where(eq(newsletterPreferences.subscriberId, subscriberId));
+
+  const existingByType = new Map(existing.map((pref) => [pref.newsletterType, pref]));
+
+  await Promise.all(
+    NEWSLETTER_TYPES.map(async (type) => {
+      const enabled = enabledTypes.includes(type);
+      const found = existingByType.get(type);
+      if (!found) {
+        await db.insert(newsletterPreferences).values({
+          subscriberId,
+          newsletterType: type,
+          enabled,
+          createdAt: now,
+          updatedAt: now,
+        });
+        return;
+      }
+
+      if (found.enabled !== enabled) {
+        await db
+          .update(newsletterPreferences)
+          .set({ enabled, updatedAt: now })
+          .where(eq(newsletterPreferences.id, found.id));
+      }
+    })
+  );
+}
+
+async function createSubscriberToken(params: {
+  subscriberId: string;
+  tokenType: "confirm" | "unsubscribe" | "preferences";
+  newsletterType?: NewsletterType;
+  expiresInHours: number;
+}) {
+  const token = makeToken();
+  const expiresAt = new Date(Date.now() + params.expiresInHours * 60 * 60 * 1000);
+
+  await db.insert(newsletterUnsubTokens).values({
+    subscriberId: params.subscriberId,
+    newsletterType: params.newsletterType ?? null,
+    tokenType: params.tokenType,
+    token,
+    expiresAt,
+  });
+
+  return token;
+}
+
+async function getValidToken(token: string, tokenType: "confirm" | "unsubscribe" | "preferences") {
+  const now = new Date();
+  const [record] = await db
+    .select()
+    .from(newsletterUnsubTokens)
+    .where(
+      and(
+        eq(newsletterUnsubTokens.token, token),
+        eq(newsletterUnsubTokens.tokenType, tokenType),
+        isNull(newsletterUnsubTokens.usedAt),
+        gt(newsletterUnsubTokens.expiresAt, now)
+      )
+    )
+    .limit(1);
+
+  return record;
+}
+
+export async function subscribeToNewsletters(input: {
+  email: string;
+  newsletterTypes: string[];
+  source?: string;
+}) {
+  const normalizedEmail = normalizeEmail(input.email);
+  if (!validateEmail(normalizedEmail)) {
+    return { ok: false as const, status: 400, error: "Invalid email address" };
+  }
+
+  const selectedTypes = dedupeNewsletterTypes(input.newsletterTypes);
+  if (selectedTypes.length === 0) {
+    return { ok: false as const, status: 400, error: "Select at least one newsletter type" };
+  }
+
+  const now = new Date();
+  const [existing] = await db
+    .select()
+    .from(newsletterSubscribers)
+    .where(eq(newsletterSubscribers.email, normalizedEmail))
+    .limit(1);
+
+  let subscriberId: string;
+  if (existing) {
+    subscriberId = existing.id;
+    await db
+      .update(newsletterSubscribers)
+      .set({
+        status: "pending",
+        source: input.source || existing.source,
+        unsubscribedAt: null,
+        updatedAt: now,
+      })
+      .where(eq(newsletterSubscribers.id, existing.id));
+  } else {
+    const [inserted] = await db
+      .insert(newsletterSubscribers)
+      .values({
+        email: normalizedEmail,
+        status: "pending",
+        source: input.source || "news-page",
+      })
+      .returning();
+    subscriberId = inserted.id;
+  }
+
+  await upsertPreferences(subscriberId, selectedTypes);
+
+  const confirmToken = await createSubscriberToken({
+    subscriberId,
+    tokenType: "confirm",
+    expiresInHours: 48,
+  });
+  const confirmUrl = `${getBaseUrl()}/api/v1/newsletter/confirm?token=${confirmToken}`;
+
+  const subject = "Confirm your newsletter subscription";
+  const html = `
+    <h2>Confirm subscription</h2>
+    <p>Please confirm your subscription for: <strong>${selectedTypes.join(", ")}</strong>.</p>
+    <p><a href="${confirmUrl}">Click here to confirm</a></p>
+    <p>This link expires in 48 hours.</p>
+  `;
+  const text = `Confirm your newsletter subscription (${selectedTypes.join(", ")}): ${confirmUrl}`;
+
+  const emailResult = await sendEmail({ to: normalizedEmail, subject, html, text });
+  if (!emailResult.success) {
+    return { ok: false as const, status: 503, error: emailResult.error };
+  }
+
+  return { ok: true as const, message: "Confirmation email sent" };
+}
+
+export async function confirmNewsletterSubscription(token: string) {
+  const record = await getValidToken(token, "confirm");
+  if (!record) {
+    return { ok: false as const, status: 400, error: "Token invalid or expired" };
+  }
+
+  const now = new Date();
+  await db.transaction(async (tx) => {
+    await tx
+      .update(newsletterSubscribers)
+      .set({
+        status: "active",
+        confirmedAt: now,
+        unsubscribedAt: null,
+        updatedAt: now,
+      })
+      .where(eq(newsletterSubscribers.id, record.subscriberId));
+
+    await tx
+      .update(newsletterUnsubTokens)
+      .set({ usedAt: now })
+      .where(eq(newsletterUnsubTokens.id, record.id));
+  });
+
+  return { ok: true as const };
+}
+
+export async function getPreferenceContext(token: string) {
+  const record = await getValidToken(token, "preferences");
+  if (!record) {
+    return { ok: false as const, status: 400, error: "Token invalid or expired" };
+  }
+
+  const [subscriber] = await db
+    .select()
+    .from(newsletterSubscribers)
+    .where(eq(newsletterSubscribers.id, record.subscriberId))
+    .limit(1);
+
+  if (!subscriber) {
+    return { ok: false as const, status: 404, error: "Subscriber not found" };
+  }
+
+  const preferences = await db
+    .select()
+    .from(newsletterPreferences)
+    .where(eq(newsletterPreferences.subscriberId, subscriber.id));
+
+  return {
+    ok: true as const,
+    data: {
+      email: subscriber.email,
+      preferences: NEWSLETTER_TYPES.map((type) => ({
+        type,
+        enabled: preferences.find((pref) => pref.newsletterType === type)?.enabled ?? false,
+      })),
+    },
+  };
+}
+
+export async function updatePreferencesByToken(token: string, newsletterTypes: string[]) {
+  const record = await getValidToken(token, "preferences");
+  if (!record) {
+    return { ok: false as const, status: 400, error: "Token invalid or expired" };
+  }
+
+  const selected = dedupeNewsletterTypes(newsletterTypes);
+  await upsertPreferences(record.subscriberId, selected);
+
+  if (selected.length === 0) {
+    await db
+      .update(newsletterSubscribers)
+      .set({
+        status: "unsubscribed",
+        unsubscribedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(newsletterSubscribers.id, record.subscriberId));
+  } else {
+    await db
+      .update(newsletterSubscribers)
+      .set({
+        status: "active",
+        unsubscribedAt: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(newsletterSubscribers.id, record.subscriberId));
+  }
+
+  return { ok: true as const };
+}
+
+export async function unsubscribeByToken(token: string) {
+  const record = await getValidToken(token, "unsubscribe");
+  if (!record) {
+    return { ok: false as const, status: 400, error: "Token invalid or expired" };
+  }
+
+  const now = new Date();
+  await db.transaction(async (tx) => {
+    if (record.newsletterType) {
+      await tx
+        .update(newsletterPreferences)
+        .set({ enabled: false, updatedAt: now })
+        .where(
+          and(
+            eq(newsletterPreferences.subscriberId, record.subscriberId),
+            eq(newsletterPreferences.newsletterType, record.newsletterType)
+          )
+        );
+    } else {
+      await tx
+        .update(newsletterPreferences)
+        .set({ enabled: false, updatedAt: now })
+        .where(eq(newsletterPreferences.subscriberId, record.subscriberId));
+    }
+
+    const remainingEnabled = await tx
+      .select()
+      .from(newsletterPreferences)
+      .where(
+        and(
+          eq(newsletterPreferences.subscriberId, record.subscriberId),
+          eq(newsletterPreferences.enabled, true)
+        )
+      );
+
+    await tx
+      .update(newsletterSubscribers)
+      .set({
+        status: remainingEnabled.length > 0 ? "active" : "unsubscribed",
+        unsubscribedAt: remainingEnabled.length > 0 ? null : now,
+        updatedAt: now,
+      })
+      .where(eq(newsletterSubscribers.id, record.subscriberId));
+
+    await tx
+      .update(newsletterUnsubTokens)
+      .set({ usedAt: now })
+      .where(eq(newsletterUnsubTokens.id, record.id));
+  });
+
+  return { ok: true as const };
+}
+
+async function resolveRecipients(newsletterType: NewsletterType) {
+  const [subscribers, preferences] = await Promise.all([
+    db
+      .select()
+      .from(newsletterSubscribers)
+      .where(eq(newsletterSubscribers.status, "active")),
+    db
+      .select()
+      .from(newsletterPreferences)
+      .where(
+        and(
+          eq(newsletterPreferences.newsletterType, newsletterType),
+          eq(newsletterPreferences.enabled, true)
+        )
+      ),
+  ]);
+
+  const preferredSubscriberIds = new Set(preferences.map((pref) => pref.subscriberId));
+  return subscribers.filter((subscriber) => preferredSubscriberIds.has(subscriber.id));
+}
+
+async function buildJobsDigest(periodDays: number): Promise<CampaignDigest> {
+  const [currentResult, previousResult] = await Promise.all([
+    getJobApplyClicksForWindow(periodDays, 0),
+    getJobApplyClicksForWindow(periodDays, periodDays),
+  ]);
+
+  const currentRows = currentResult.success ? currentResult.data : [];
+  const previousRows = previousResult.success ? previousResult.data : [];
+  const previousMap = new Map(previousRows.map((row) => [row.id, row.count]));
+
+  const currentTotal = currentRows.reduce((sum, row) => sum + row.count, 0);
+  const previousTotal = previousRows.reduce((sum, row) => sum + row.count, 0);
+  const totals = computeViewTotals(currentTotal, previousTotal);
+
+  const jobIds = currentRows.slice(0, 10).map((row) => row.id);
+  const jobsById = new Map<string, { title: string; company: string; link: string }>();
+  if (jobIds.length > 0) {
+    const dbJobs = await db
+      .select({ id: jobs.id, title: jobs.title, company: jobs.company, link: jobs.link })
+      .from(jobs)
+      .where(inArray(jobs.id, jobIds));
+    for (const job of dbJobs) {
+      jobsById.set(job.id, { title: job.title, company: job.company, link: job.link });
+    }
+  }
+
+  const items: DigestItem[] = currentRows.slice(0, 10).map((row) => {
+    const job = jobsById.get(row.id);
+    return {
+      title: job ? job.title : `Job ${row.id}`,
+      subtitle: job ? job.company : "Unknown company",
+      url: job?.link,
+      currentViews: row.count,
+      delta: row.count - (previousMap.get(row.id) || 0),
+    };
+  });
+
+  return {
+    heading: "Jobs performance digest",
+    summary: `Views and engagement updates for the last ${periodDays} days.`,
+    periodDays,
+    totalViews: totals.totalViews,
+    deltaViews: totals.deltaViews,
+    items,
+  };
+}
+
+async function buildCandidatesDigest(periodDays: number): Promise<CampaignDigest> {
+  const [currentResult, previousResult] = await Promise.all([
+    getCandidateViewsForWindow(periodDays, 0),
+    getCandidateViewsForWindow(periodDays, periodDays),
+  ]);
+
+  const currentRows = currentResult.success ? currentResult.data : [];
+  const previousRows = previousResult.success ? previousResult.data : [];
+  const previousMap = new Map(previousRows.map((row) => [row.id, row.count]));
+
+  const currentTotal = currentRows.reduce((sum, row) => sum + row.count, 0);
+  const previousTotal = previousRows.reduce((sum, row) => sum + row.count, 0);
+  const totals = computeViewTotals(currentTotal, previousTotal);
+
+  const candidateIds = currentRows.slice(0, 10).map((row) => row.id);
+  const candidatesById = new Map<string, { name: string; title: string | null }>();
+  if (candidateIds.length > 0) {
+    const dbCandidates = await db
+      .select({ id: candidates.id, name: candidates.name, title: candidates.title })
+      .from(candidates)
+      .where(inArray(candidates.id, candidateIds));
+    for (const candidate of dbCandidates) {
+      candidatesById.set(candidate.id, { name: candidate.name, title: candidate.title });
+    }
+  }
+
+  const items: DigestItem[] = currentRows.slice(0, 10).map((row) => {
+    const candidate = candidatesById.get(row.id);
+    return {
+      title: candidate ? candidate.name : `Candidate ${row.id}`,
+      subtitle: candidate?.title || undefined,
+      currentViews: row.count,
+      delta: row.count - (previousMap.get(row.id) || 0),
+    };
+  });
+
+  return {
+    heading: "Candidates performance digest",
+    summary: `Candidate profile views for the last ${periodDays} days.`,
+    periodDays,
+    totalViews: totals.totalViews,
+    deltaViews: totals.deltaViews,
+    items,
+  };
+}
+
+async function buildNewsDigest(periodDays: number): Promise<CampaignDigest> {
+  const cutoff = new Date(Date.now() - periodDays * 24 * 60 * 60 * 1000);
+  const [allNews, clicksResult] = await Promise.all([getAllNews(), getNewsClicksLast7Days()]);
+  const clickMap = new Map((clicksResult.success ? clicksResult.data : []).map((row) => [row.id, row.count]));
+
+  const items: DigestItem[] = allNews
+    .filter((item) => new Date(item.date) > cutoff)
+    .slice(0, 10)
+    .map((item) => ({
+      title: item.title,
+      subtitle: item.source || item.company || item.type,
+      url: item.url,
+      currentViews: clickMap.get(item.id) || 0,
+    }));
+
+  return {
+    heading: "News digest",
+    summary: `Recent highlights from the last ${periodDays} days.`,
+    periodDays,
+    items,
+  };
+}
+
+async function buildDigest(newsletterType: NewsletterType, periodDays: number): Promise<CampaignDigest> {
+  if (newsletterType === "jobs") {
+    return buildJobsDigest(periodDays);
+  }
+  if (newsletterType === "candidates") {
+    return buildCandidatesDigest(periodDays);
+  }
+  return buildNewsDigest(periodDays);
+}
+
+function renderDigestHtml(digest: CampaignDigest, links: { unsubscribe: string; preferences: string }) {
+  const itemsHtml = digest.items.length
+    ? digest.items
+      .map((item) => {
+        const metric = item.currentViews !== undefined
+          ? `${item.currentViews} views${item.delta !== undefined ? ` (${item.delta >= 0 ? "+" : ""}${item.delta})` : ""}`
+          : "";
+        const line = [
+          `<strong>${escapeHtml(item.title)}</strong>`,
+          item.subtitle ? `<span>${escapeHtml(item.subtitle)}</span>` : "",
+          metric ? `<span>${escapeHtml(metric)}</span>` : "",
+        ]
+          .filter(Boolean)
+          .join(" · ");
+        if (item.url) {
+          return `<li><a href="${item.url}">${line}</a></li>`;
+        }
+        return `<li>${line}</li>`;
+      })
+      .join("")
+    : "<li>No items available for this period.</li>";
+
+  const totals = digest.totalViews !== undefined
+    ? `<p><strong>Total views:</strong> ${digest.totalViews}${digest.deltaViews !== undefined ? ` (${digest.deltaViews >= 0 ? "+" : ""}${digest.deltaViews} vs previous period)` : ""}</p>`
+    : "";
+
+  return `
+    <h2>${escapeHtml(digest.heading)}</h2>
+    <p>${escapeHtml(digest.summary)}</p>
+    ${totals}
+    <ul>${itemsHtml}</ul>
+    <hr />
+    <p><a href="${links.preferences}">Manage preferences</a> · <a href="${links.unsubscribe}">Unsubscribe</a></p>
+  `;
+}
+
+function renderDigestText(digest: CampaignDigest, links: { unsubscribe: string; preferences: string }) {
+  const totals = digest.totalViews !== undefined
+    ? `Total views: ${digest.totalViews}${digest.deltaViews !== undefined ? ` (${digest.deltaViews >= 0 ? "+" : ""}${digest.deltaViews} vs previous period)` : ""}\n`
+    : "";
+
+  const lines = digest.items.length > 0
+    ? digest.items.map((item) => {
+      const metric = item.currentViews !== undefined
+        ? `${item.currentViews} views${item.delta !== undefined ? ` (${item.delta >= 0 ? "+" : ""}${item.delta})` : ""}`
+        : "";
+      const parts = [item.title, item.subtitle, metric, item.url].filter(Boolean);
+      return `- ${parts.join(" | ")}`;
+    })
+    : ["- No items available for this period."];
+
+  return `${digest.heading}\n${digest.summary}\n${totals}${lines.join("\n")}\n\nManage preferences: ${links.preferences}\nUnsubscribe: ${links.unsubscribe}`;
+}
+
+export async function listNewsletterCampaigns(limit: number = 50) {
+  return db
+    .select()
+    .from(newsletterCampaigns)
+    .orderBy(desc(newsletterCampaigns.createdAt))
+    .limit(Math.min(Math.max(limit, 1), 200));
+}
+
+export async function createNewsletterCampaign(input: {
+  newsletterType: string;
+  subject: string;
+  previewText?: string;
+  periodDays?: number;
+  scheduledAt?: string;
+  createdBy?: string;
+}) {
+  if (!NEWSLETTER_TYPES.includes(input.newsletterType as NewsletterType)) {
+    return { ok: false as const, status: 400, error: "Invalid newsletter type" };
+  }
+  if (!input.subject?.trim()) {
+    return { ok: false as const, status: 400, error: "Subject is required" };
+  }
+
+  const periodDays = Number.isInteger(input.periodDays) && input.periodDays! > 0
+    ? Math.min(input.periodDays!, 30)
+    : DEFAULT_CAMPAIGN_PERIOD_DAYS;
+
+  const scheduledAt = input.scheduledAt ? new Date(input.scheduledAt) : null;
+  if (scheduledAt && Number.isNaN(scheduledAt.getTime())) {
+    return { ok: false as const, status: 400, error: "Invalid scheduledAt value" };
+  }
+
+  const [campaign] = await db
+    .insert(newsletterCampaigns)
+    .values({
+      newsletterType: input.newsletterType as NewsletterType,
+      subject: input.subject.trim(),
+      previewText: input.previewText || null,
+      periodDays,
+      status: scheduledAt ? "scheduled" : "draft",
+      scheduledAt,
+      createdBy: input.createdBy || null,
+    })
+    .returning();
+
+  return { ok: true as const, data: campaign };
+}
+
+export async function scheduleNewsletterCampaign(campaignId: string, scheduledAtIso: string) {
+  const scheduledAt = new Date(scheduledAtIso);
+  if (Number.isNaN(scheduledAt.getTime())) {
+    return { ok: false as const, status: 400, error: "Invalid scheduledAt value" };
+  }
+
+  const [campaign] = await db
+    .update(newsletterCampaigns)
+    .set({
+      status: "scheduled",
+      scheduledAt,
+      updatedAt: new Date(),
+    })
+    .where(eq(newsletterCampaigns.id, campaignId))
+    .returning();
+
+  if (!campaign) {
+    return { ok: false as const, status: 404, error: "Campaign not found" };
+  }
+
+  return { ok: true as const, data: campaign };
+}
+
+async function sendCampaignInternal(campaignId: string, force: boolean) {
+  const [campaign] = await db
+    .select()
+    .from(newsletterCampaigns)
+    .where(eq(newsletterCampaigns.id, campaignId))
+    .limit(1);
+
+  if (!campaign) {
+    return { ok: false as const, status: 404, error: "Campaign not found" };
+  }
+  if (campaign.status === "sent") {
+    return { ok: true as const, data: { campaign, sent: 0, failed: 0, skipped: 0, alreadySent: true } };
+  }
+  if (campaign.status === "sending") {
+    return { ok: false as const, status: 409, error: "Campaign is already being sent" };
+  }
+  if (!force && campaign.status === "scheduled" && campaign.scheduledAt && campaign.scheduledAt > new Date()) {
+    return { ok: false as const, status: 409, error: "Campaign schedule is in the future" };
+  }
+
+  const recipients = await resolveRecipients(campaign.newsletterType as NewsletterType);
+  if (recipients.length === 0) {
+    return { ok: false as const, status: 409, error: "No active recipients for this campaign type" };
+  }
+
+  const now = new Date();
+  await db
+    .update(newsletterCampaigns)
+    .set({ status: "sending", failureReason: null, updatedAt: now })
+    .where(eq(newsletterCampaigns.id, campaign.id));
+
+  const existingRecipients = await db
+    .select()
+    .from(newsletterCampaignRecipients)
+    .where(eq(newsletterCampaignRecipients.campaignId, campaign.id));
+  const existingBySubscriber = new Map(existingRecipients.map((row) => [row.subscriberId, row]));
+
+  const pendingRecipientRows = recipients.filter((recipient) => !existingBySubscriber.has(recipient.id));
+  if (pendingRecipientRows.length > 0) {
+    await db.insert(newsletterCampaignRecipients).values(
+      pendingRecipientRows.map((recipient) => ({
+        campaignId: campaign.id,
+        subscriberId: recipient.id,
+        email: recipient.email,
+        status: "pending",
+      }))
+    );
+  }
+
+  const campaignRecipients = await db
+    .select()
+    .from(newsletterCampaignRecipients)
+    .where(eq(newsletterCampaignRecipients.campaignId, campaign.id));
+
+  const digest = await buildDigest(campaign.newsletterType as NewsletterType, campaign.periodDays || DEFAULT_CAMPAIGN_PERIOD_DAYS);
+  let sentCount = 0;
+  let failedCount = 0;
+  let skippedCount = 0;
+
+  for (const recipient of campaignRecipients) {
+    if (recipient.status === "sent") {
+      skippedCount += 1;
+      continue;
+    }
+
+    const unsubscribeToken = await createSubscriberToken({
+      subscriberId: recipient.subscriberId,
+      tokenType: "unsubscribe",
+      newsletterType: campaign.newsletterType as NewsletterType,
+      expiresInHours: 24 * 365,
+    });
+    const preferencesToken = await createSubscriberToken({
+      subscriberId: recipient.subscriberId,
+      tokenType: "preferences",
+      expiresInHours: 24 * 365,
+    });
+
+    const links = {
+      unsubscribe: `${getBaseUrl()}/api/v1/newsletter/unsubscribe?token=${unsubscribeToken}`,
+      preferences: `${getBaseUrl()}/api/v1/newsletter/preferences?token=${preferencesToken}`,
+    };
+
+    const emailResult = await sendEmail({
+      to: recipient.email,
+      subject: campaign.subject,
+      html: renderDigestHtml(digest, links),
+      text: renderDigestText(digest, links),
+    });
+
+    if (emailResult.success) {
+      sentCount += 1;
+      await db.transaction(async (tx) => {
+        await tx
+          .update(newsletterCampaignRecipients)
+          .set({ status: "sent", sentAt: new Date(), errorMessage: null, updatedAt: new Date() })
+          .where(eq(newsletterCampaignRecipients.id, recipient.id));
+
+        await tx.insert(newsletterSendEvents).values({
+          campaignId: campaign.id,
+          recipientId: recipient.id,
+          eventType: "sent",
+          provider: "resend",
+          providerMessageId: emailResult.messageId,
+          payload: JSON.stringify({ email: recipient.email }),
+        });
+      });
+      continue;
+    }
+
+    failedCount += 1;
+    await db.transaction(async (tx) => {
+      await tx
+        .update(newsletterCampaignRecipients)
+        .set({ status: "failed", errorMessage: emailResult.error, updatedAt: new Date() })
+        .where(eq(newsletterCampaignRecipients.id, recipient.id));
+
+      await tx.insert(newsletterSendEvents).values({
+        campaignId: campaign.id,
+        recipientId: recipient.id,
+        eventType: "failed",
+        provider: "resend",
+        payload: JSON.stringify({ email: recipient.email, error: emailResult.error }),
+      });
+    });
+  }
+
+  await db
+    .update(newsletterCampaigns)
+    .set({
+      status: failedCount > 0 ? "failed" : "sent",
+      sentAt: failedCount > 0 ? null : new Date(),
+      failureReason: failedCount > 0 ? `${failedCount} recipients failed` : null,
+      updatedAt: new Date(),
+    })
+    .where(eq(newsletterCampaigns.id, campaign.id));
+
+  return {
+    ok: true as const,
+    data: {
+      campaignId: campaign.id,
+      sent: sentCount,
+      failed: failedCount,
+      skipped: skippedCount,
+      alreadySent: false,
+    },
+  };
+}
+
+export async function sendNewsletterCampaignNow(campaignId: string) {
+  return sendCampaignInternal(campaignId, true);
+}
+
+export async function sendDueNewsletterCampaigns() {
+  const now = new Date();
+  const dueCampaigns = await db
+    .select({ id: newsletterCampaigns.id })
+    .from(newsletterCampaigns)
+    .where(
+      and(
+        eq(newsletterCampaigns.status, "scheduled"),
+        lte(newsletterCampaigns.scheduledAt, now),
+        isNull(newsletterCampaigns.sentAt)
+      )
+    );
+
+  const results = [];
+  for (const campaign of dueCampaigns) {
+    const result = await sendCampaignInternal(campaign.id, false);
+    results.push({ campaignId: campaign.id, result });
+  }
+
+  return {
+    ok: true as const,
+    data: {
+      processed: dueCampaigns.length,
+      results,
+    },
+  };
+}

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -815,6 +815,7 @@ export async function upsertNewsletterTemplate(input: {
 export async function renderNewsletterTemplatePreview(input: {
   newsletterType: string;
   periodDays?: number;
+  campaignSubject?: string;
   subjectTemplate?: string;
   htmlTemplate?: string;
   textTemplate?: string;
@@ -839,7 +840,9 @@ export async function renderNewsletterTemplatePreview(input: {
 
   const rendered = renderTemplateContent({
     template,
-    campaignSubject: `Preview: ${digest.heading}`,
+    campaignSubject: input.campaignSubject?.trim()
+      ? input.campaignSubject.trim()
+      : `Preview: ${digest.heading}`,
     campaignType: newsletterType,
     periodDays,
     digest,

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -15,15 +15,18 @@ import {
 import {
   getCandidateViewsForWindow,
   getJobApplyClicksForWindow,
-  getNewsClicksLast7Days,
+  getNewsClicksForWindow,
 } from "@/services/posthog";
 import { getAllNews } from "@/lib/news";
 import { categoryLabels, type NewsCategory } from "@/data/news";
 import {
   NEWSLETTER_TYPES,
+  NEWSLETTER_CONTENT_MODES,
+  type NewsletterContentMode,
   type NewsletterType,
   dedupeNewsletterTypes,
   computeViewTotals,
+  normalizeNewsletterContentMode,
 } from "@/lib/newsletter-utils";
 
 type SendResult = { success: true; messageId: string } | { success: false; error: string };
@@ -53,6 +56,29 @@ interface CampaignDigest {
   groups?: DigestGroup[];
 }
 
+const newsletterCategoryLabels: Partial<Record<NewsCategory, string>> = {
+  x_post: "X Posts",
+};
+
+function newsletterLabel(cat: string): string {
+  return newsletterCategoryLabels[cat as NewsCategory] || categoryLabels[cat as NewsCategory] || cat;
+}
+
+const NEWSLETTER_CATEGORY_ORDER: string[] = ["x_post", "general", "product", "cool_product"];
+
+function sortGroupsByCategory<T extends { category?: string }>(groups: T[]): T[] {
+  return [...groups].sort((a, b) => {
+    const catA = a.category || "general";
+    const catB = b.category || "general";
+    const idxA = NEWSLETTER_CATEGORY_ORDER.indexOf(catA);
+    const idxB = NEWSLETTER_CATEGORY_ORDER.indexOf(catB);
+    const orderA = idxA >= 0 ? idxA : NEWSLETTER_CATEGORY_ORDER.length;
+    const orderB = idxB >= 0 ? idxB : NEWSLETTER_CATEGORY_ORDER.length;
+    if (orderA !== orderB) return orderA - orderB;
+    return catA.localeCompare(catB);
+  });
+}
+
 const DEFAULT_CAMPAIGN_PERIOD_DAYS = 7;
 
 interface NewsletterTemplatePayload {
@@ -60,6 +86,7 @@ interface NewsletterTemplatePayload {
   subjectTemplate: string;
   htmlTemplate: string;
   textTemplate: string;
+  markdownTemplate: string;
 }
 
 export const NEWSLETTER_TEMPLATE_PLACEHOLDERS = [
@@ -74,10 +101,13 @@ export const NEWSLETTER_TEMPLATE_PLACEHOLDERS = [
   "digest_items_text",
   "recent_news_html",
   "recent_news_text",
+  "digest_items_markdown",
+  "recent_news_markdown",
   "unsubscribe_url",
   "preferences_url",
   "default_html_body",
   "default_text_body",
+  "default_markdown_body",
   "generated_at_iso",
 ] as const;
 
@@ -87,20 +117,71 @@ const DEFAULT_NEWSLETTER_TEMPLATES: Record<NewsletterType, NewsletterTemplatePay
     subjectTemplate: "{{campaign_subject}}",
     htmlTemplate: "{{default_html_body}}",
     textTemplate: "{{default_text_body}}",
+    markdownTemplate: "{{default_markdown_body}}",
   },
   jobs: {
     newsletterType: "jobs",
     subjectTemplate: "{{campaign_subject}}",
     htmlTemplate: "{{default_html_body}}",
     textTemplate: "{{default_text_body}}",
+    markdownTemplate: "{{default_markdown_body}}",
   },
   candidates: {
     newsletterType: "candidates",
     subjectTemplate: "{{campaign_subject}}",
     htmlTemplate: "{{default_html_body}}",
     textTemplate: "{{default_text_body}}",
+    markdownTemplate: "{{default_markdown_body}}",
   },
 };
+
+const LEGACY_NEWS_HTML_TEMPLATE = "{{default_html_body}}<hr /><h3>Recent News</h3><ul>{{recent_news_html}}</ul>";
+const LEGACY_NEWS_TEXT_TEMPLATE = "{{default_text_body}}\n\nRecent News:\n{{recent_news_text}}";
+const LEGACY_NEWS_MARKDOWN_TEMPLATE = `## {{digest_heading}}
+
+{{digest_summary}}
+
+{{digest_items_markdown}}
+
+---
+
+### Recent News
+
+{{recent_news_markdown}}
+
+[Manage preferences]({{preferences_url}}) | [Unsubscribe]({{unsubscribe_url}})`;
+
+const SUBSTACK_SANS_FONT_STACK = "'SF Pro Display', -apple-system, system-ui, BlinkMacSystemFont, 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'";
+const MONO_FONT_STACK = "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace";
+
+const RECOMMENDED_NEWSLETTERS: Array<{ name: string; url: string; description: string }> = [
+  { name: "TBPN", url: "https://tbpn.substack.com", description: "Technology Business Programming Network — daily live business & tech podcast by @johncoogan & @jordihays" },
+  { name: "SemiAnalysis", url: "https://semianalysis.com", description: "Deep dives on semiconductors, AI infrastructure, and compute" },
+  { name: "Ethereal News", url: "https://etherealnews.substack.com", description: "Ethereum ecosystem news and analysis" },
+  { name: "ZK Mesh", url: "https://zkmesh.substack.com", description: "Monthly zero-knowledge newsletter (zkmesh+ for premium)" },
+  { name: "dcbuilder.dev/news", url: "https://dcbuilder.dev/news", description: "Older curated links and announcements" },
+  { name: "dcbuilder.dev/blog", url: "https://dcbuilder.dev/blog", description: "Long-form thoughts and writeups" },
+  { name: "@dcbuilder on X", url: "https://x.com/dcbuilder", description: "More curated content on X" },
+];
+
+const OTHER_CONTENT_I_LIKE: Array<{ name: string; url: string; description: string }> = [
+  { name: "Zero Knowledge FM", url: "https://zeroknowledge.fm", description: "Podcast on ZK proofs and the decentralized web" },
+  { name: "TBPN Podcast", url: "https://tbpn.substack.com", description: "Daily live video & audio show on business and tech by @johncoogan & @jordihays" },
+  { name: "Hardcore History", url: "https://www.dancarlin.com/hardcore-history-series", description: "Dan Carlin's epic deep-dives into history" },
+];
+
+const FEATURED_CATEGORIES: Array<{ key: string; label: string }> = [
+  { key: "ethereum", label: "Ethereum" },
+  { key: "ai", label: "AI" },
+  { key: "crypto", label: "Crypto" },
+  { key: "defi", label: "DeFi" },
+  { key: "research", label: "Research" },
+  { key: "infrastructure", label: "Infrastructure" },
+  { key: "developer_tooling", label: "Dev Tooling" },
+  { key: "product", label: "Product" },
+];
+
+const MUTABLE_CAMPAIGN_STATUSES = new Set(["draft", "scheduled"] as const);
 
 function normalizeEmail(email: string): string {
   return email.trim().toLowerCase();
@@ -114,6 +195,30 @@ function getBaseUrl(): string {
   if (process.env.NEXT_PUBLIC_BASE_URL) return process.env.NEXT_PUBLIC_BASE_URL;
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
   return "https://dcbuilder.dev";
+}
+
+function toAbsoluteUrl(url: string): string {
+  try {
+    return new URL(url, getBaseUrl()).toString();
+  } catch {
+    return url;
+  }
+}
+
+function normalizeLegacyTemplatePayload(template: NewsletterTemplatePayload): NewsletterTemplatePayload {
+  if (template.newsletterType !== "news") return template;
+  return {
+    ...template,
+    htmlTemplate: template.htmlTemplate.trim() === LEGACY_NEWS_HTML_TEMPLATE
+      ? "{{default_html_body}}"
+      : template.htmlTemplate,
+    textTemplate: template.textTemplate.trim() === LEGACY_NEWS_TEXT_TEMPLATE
+      ? "{{default_text_body}}"
+      : template.textTemplate,
+    markdownTemplate: template.markdownTemplate.trim() === LEGACY_NEWS_MARKDOWN_TEMPLATE
+      ? "{{default_markdown_body}}"
+      : template.markdownTemplate,
+  };
 }
 
 function makeToken(): string {
@@ -299,13 +404,35 @@ export async function subscribeToNewsletters(input: {
   const confirmUrl = `${getBaseUrl()}/api/v1/newsletter/confirm?token=${confirmToken}`;
 
   const subject = "Confirm your newsletter subscription";
+  const typeLabels: Record<string, string> = {
+    news: "News Digest",
+    jobs: "Jobs Updates",
+    candidates: "Candidates Updates",
+  };
+  const formattedTypes = selectedTypes.map((t) => typeLabels[t] || t).join(", ");
   const html = `
-    <h2>Confirm subscription</h2>
-    <p>Please confirm your subscription for: <strong>${selectedTypes.join(", ")}</strong>.</p>
-    <p><a href="${confirmUrl}">Click here to confirm</a></p>
-    <p>This link expires in 48 hours.</p>
+    <div style="max-width:560px;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#171717;line-height:1.6">
+      <div style="padding:32px 0 20px">
+        <div style="width:64px;height:64px;border-radius:50%;overflow:hidden">
+          <img src="https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png" alt="dcbuilder.eth" width="64" height="64" style="display:block;width:64px;height:64px;object-fit:cover" />
+        </div>
+      </div>
+      <h2 style="font-size:22px;font-weight:700;margin:0 0 12px;color:#171717">One more step</h2>
+      <p style="margin:0 0 28px;color:#525252;font-size:15px;line-height:1.5">
+        Confirm your subscription to <strong style="color:#171717">${formattedTypes}</strong> and you'll start receiving updates from dcbuilder.eth.
+      </p>
+      <div style="margin:0 0 28px">
+        <a href="${confirmUrl}" style="display:inline-block;background:#171717;color:#ffffff;font-size:14px;font-weight:600;padding:12px 28px;border-radius:8px;text-decoration:none">
+          Confirm subscription
+        </a>
+      </div>
+      <hr style="border:none;border-top:1px solid #e5e5e5;margin:0 0 16px" />
+      <p style="margin:0;color:#a3a3a3;font-size:12px">
+        This link expires in 48 hours. If you didn't subscribe, ignore this email.
+      </p>
+    </div>
   `;
-  const text = `Confirm your newsletter subscription (${selectedTypes.join(", ")}): ${confirmUrl}`;
+  const text = `Confirm your subscription to dcbuilder.eth (${formattedTypes}): ${confirmUrl}\n\nThis link expires in 48 hours. If you didn't subscribe, you can safely ignore this email.`;
 
   const emailResult = await sendEmail({ to: normalizedEmail, subject, html, text });
   if (!emailResult.success) {
@@ -576,14 +703,14 @@ async function buildCandidatesDigest(periodDays: number): Promise<CampaignDigest
 
 async function buildNewsDigest(periodDays: number): Promise<CampaignDigest> {
   const cutoff = new Date(Date.now() - periodDays * 24 * 60 * 60 * 1000);
-  const [allNews, clicksResult] = await Promise.all([getAllNews(), getNewsClicksLast7Days()]);
+  const [allNews, clicksResult] = await Promise.all([getAllNews(), getNewsClicksForWindow(periodDays, 0)]);
   const clickMap = new Map((clicksResult.success ? clicksResult.data : []).map((row) => [row.id, row.count]));
 
   const filtered = allNews.filter((item) => new Date(item.date) > cutoff);
 
   const items: DigestItem[] = filtered.slice(0, 20).map((item) => ({
     title: item.title,
-    subtitle: item.source || item.company || item.type,
+    subtitle: item.description || item.source || item.company || item.type,
     url: item.url,
     currentViews: clickMap.get(item.id) || 0,
     category: item.category,
@@ -596,11 +723,13 @@ async function buildNewsDigest(periodDays: number): Promise<CampaignDigest> {
     groupMap.get(cat)!.push(item);
   }
 
-  const groups: DigestGroup[] = Array.from(groupMap.entries()).map(([cat, catItems]) => ({
-    category: cat,
-    label: categoryLabels[cat as NewsCategory] || cat,
-    items: catItems,
-  }));
+  const groups: DigestGroup[] = sortGroupsByCategory(
+    Array.from(groupMap.entries()).map(([cat, catItems]) => ({
+      category: cat,
+      label: newsletterLabel(cat),
+      items: catItems,
+    }))
+  );
 
   return {
     heading: "News digest",
@@ -622,37 +751,32 @@ async function buildDigest(newsletterType: NewsletterType, periodDays: number): 
 }
 
 function renderDigestItemsHtml(digest: CampaignDigest) {
+  const renderItem = (item: DigestItem) => {
+    const metric = item.currentViews !== undefined
+      ? `${item.currentViews} views${item.delta !== undefined ? ` (${item.delta >= 0 ? "+" : ""}${item.delta})` : ""}`
+      : "";
+    const title = item.url
+      ? `<a href="${item.url}" style="color:#171717;text-decoration:underline;text-underline-offset:2px;text-decoration-color:#d4d4d4;font-weight:600;font-size:15px">${escapeHtml(item.title)}</a>`
+      : `<strong style="font-size:15px">${escapeHtml(item.title)}</strong>`;
+    const subtitle = item.subtitle
+      ? `<div style="color:#525252;font-size:14px;margin-top:2px">${escapeHtml(item.subtitle)}</div>`
+      : "";
+    const metricHtml = metric
+      ? `<div style="color:#a3a3a3;font-size:12px;margin-top:2px">${escapeHtml(metric)}</div>`
+      : "";
+    return `<li style="padding:10px 0;border-bottom:1px solid #f5f5f5">${title}${subtitle}${metricHtml}</li>`;
+  };
+
   if (digest.groups && digest.groups.length > 0) {
     return digest.groups.map((group) => {
-      const itemsHtml = group.items.map((item) => {
-        const metric = item.currentViews !== undefined
-          ? `${item.currentViews} views${item.delta !== undefined ? ` (${item.delta >= 0 ? "+" : ""}${item.delta})` : ""}`
-          : "";
-        const line = [
-          `<strong>${escapeHtml(item.title)}</strong>`,
-          item.subtitle ? `<span>${escapeHtml(item.subtitle)}</span>` : "",
-          metric ? `<span>${escapeHtml(metric)}</span>` : "",
-        ].filter(Boolean).join(" · ");
-        return item.url ? `<li><a href="${item.url}">${line}</a></li>` : `<li>${line}</li>`;
-      }).join("");
-      return `<h4>${escapeHtml(group.label)}</h4><ul>${itemsHtml}</ul>`;
+      const itemsHtml = group.items.map(renderItem).join("");
+      return `<h3 style="font-size:15px;font-weight:700;color:#171717;margin:24px 0 8px;padding-bottom:8px;border-bottom:2px solid #171717">${escapeHtml(group.label)}</h3><ul style="list-style:none;padding:0;margin:0">${itemsHtml}</ul>`;
     }).join("");
   }
 
   return digest.items.length
-    ? digest.items.map((item) => {
-      const metric = item.currentViews !== undefined
-        ? `${item.currentViews} views${item.delta !== undefined ? ` (${item.delta >= 0 ? "+" : ""}${item.delta})` : ""}`
-        : "";
-      const line = [
-        `<strong>${escapeHtml(item.title)}</strong>`,
-        item.subtitle ? `<span>${escapeHtml(item.subtitle)}</span>` : "",
-        metric ? `<span>${escapeHtml(metric)}</span>` : "",
-      ].filter(Boolean).join(" · ");
-      if (item.url) return `<li><a href="${item.url}">${line}</a></li>`;
-      return `<li>${line}</li>`;
-    }).join("")
-    : "<li>No items available for this period.</li>";
+    ? digest.items.map(renderItem).join("")
+    : `<li style="padding:8px 0;color:#a3a3a3">No items available for this period.</li>`;
 }
 
 function renderDigestItemsText(digest: CampaignDigest) {
@@ -681,24 +805,71 @@ function renderDigestItemsText(digest: CampaignDigest) {
     : "- No items available for this period.";
 }
 
+function renderWantMoreHtml() {
+  const baseUrl = getBaseUrl();
+  const newslettersHtml = RECOMMENDED_NEWSLETTERS.map((nl) =>
+    `<li style="padding:6px 0"><a href="${nl.url}" style="color:#171717;text-decoration:underline;text-underline-offset:2px;text-decoration-color:#d4d4d4;font-weight:600;font-size:14px">${escapeHtml(nl.name)} &rarr;</a><span style="color:#a3a3a3;font-size:13px"> ${escapeHtml(nl.description)}</span></li>`
+  ).join("");
+
+  const otherContentHtml = OTHER_CONTENT_I_LIKE.map((item) =>
+    `<li style="padding:6px 0"><a href="${item.url}" style="color:#171717;text-decoration:underline;text-underline-offset:2px;text-decoration-color:#d4d4d4;font-weight:600;font-size:14px">${escapeHtml(item.name)} &rarr;</a><span style="color:#a3a3a3;font-size:13px"> ${escapeHtml(item.description)}</span></li>`
+  ).join("");
+
+  const categoriesHtml = FEATURED_CATEGORIES.map((cat) =>
+    `<a href="${baseUrl}/news" style="display:inline-block;background:#f5f5f5;color:#525252;font-size:13px;font-weight:600;padding:5px 12px;border-radius:999px;text-decoration:none;margin:3px 4px 3px 0">${escapeHtml(cat.label)}</a>`
+  ).join("");
+
+  return `
+      <div style="margin:32px 0 0;padding:24px;background:#fafafa;border-radius:12px">
+        <h2 style="font-size:18px;font-weight:800;margin:0 0 16px;color:#171717">Want to read more?</h2>
+        <p style="margin:0 0 12px;font-size:13px;font-weight:700;color:#a3a3a3;text-transform:uppercase;letter-spacing:0.05em">Recommended newsletters &amp; links</p>
+        <ul style="list-style:none;padding:0;margin:0 0 20px">${newslettersHtml}</ul>
+        <p style="margin:0 0 12px;font-size:13px;font-weight:700;color:#a3a3a3;text-transform:uppercase;letter-spacing:0.05em">Other content I like</p>
+        <ul style="list-style:none;padding:0;margin:0 0 20px">${otherContentHtml}</ul>
+        <p style="margin:0 0 10px;font-size:13px;font-weight:700;color:#a3a3a3;text-transform:uppercase;letter-spacing:0.05em">Browse by topic</p>
+        <div>${categoriesHtml}</div>
+      </div>`;
+}
+
 function renderDigestHtml(digest: CampaignDigest, links: { unsubscribe: string; preferences: string }) {
   const itemsHtml = renderDigestItemsHtml(digest);
   const totals = digest.totalViews !== undefined
-    ? `<p><strong>Total views:</strong> ${digest.totalViews}${digest.deltaViews !== undefined ? ` (${digest.deltaViews >= 0 ? "+" : ""}${digest.deltaViews} vs previous period)` : ""}</p>`
+    ? `<div style="display:inline-block;background:#f5f5f5;border-radius:8px;padding:8px 16px;margin-bottom:8px;font-size:14px;color:#525252"><strong style="color:#171717">${digest.totalViews.toLocaleString()}</strong> total views${digest.deltaViews !== undefined ? ` <span style="color:${digest.deltaViews >= 0 ? "#16a34a" : "#dc2626"}">${digest.deltaViews >= 0 ? "+" : ""}${digest.deltaViews.toLocaleString()}</span>` : ""}</div>`
     : "";
 
   const body = digest.groups && digest.groups.length > 0
     ? itemsHtml
-    : `<ul>${itemsHtml}</ul>`;
+    : `<ul style="list-style:none;padding:0;margin:0">${itemsHtml}</ul>`;
 
   return `
-    <h2>${escapeHtml(digest.heading)}</h2>
-    <p>${escapeHtml(digest.summary)}</p>
-    ${totals}
-    ${body}
-    <hr />
-    <p><a href="${links.preferences}">Manage preferences</a> · <a href="${links.unsubscribe}">Unsubscribe</a></p>
+    <div style="max-width:560px;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#171717;line-height:1.6">
+      <div style="padding:32px 0 20px">
+        <div style="width:64px;height:64px;border-radius:50%;overflow:hidden">
+          <img src="https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png" alt="dcbuilder.eth" width="64" height="64" style="display:block;width:64px;height:64px;object-fit:cover" />
+        </div>
+      </div>
+      <h1 style="font-size:24px;font-weight:800;margin:0 0 6px;color:#171717">${escapeHtml(digest.heading)}</h1>
+      <p style="margin:0 0 20px;color:#737373;font-size:15px">${escapeHtml(digest.summary)}</p>
+      ${totals}
+      ${body}
+      ${renderWantMoreHtml()}
+      <hr style="border:none;border-top:1px solid #e5e5e5;margin:32px 0 16px" />
+      <p style="margin:0;font-size:12px;color:#a3a3a3">
+        <a href="${links.preferences}" style="color:#a3a3a3;text-decoration:underline">Manage preferences</a> · <a href="${links.unsubscribe}" style="color:#a3a3a3;text-decoration:underline">Unsubscribe</a>
+      </p>
+    </div>
   `;
+}
+
+function renderWantMoreText() {
+  const newslettersText = RECOMMENDED_NEWSLETTERS.map((nl) =>
+    `- ${nl.name} — ${nl.description} (${nl.url})`
+  ).join("\n");
+  const otherText = OTHER_CONTENT_I_LIKE.map((item) =>
+    `- ${item.name} — ${item.description} (${item.url})`
+  ).join("\n");
+  const categoriesText = FEATURED_CATEGORIES.map((cat) => cat.label).join(" · ");
+  return `\n\nWant to read more?\n\nRecommended newsletters & links:\n${newslettersText}\n\nOther content I like:\n${otherText}\n\nBrowse by topic: ${categoriesText}\n${getBaseUrl()}/news`;
 }
 
 function renderDigestText(digest: CampaignDigest, links: { unsubscribe: string; preferences: string }) {
@@ -706,27 +877,230 @@ function renderDigestText(digest: CampaignDigest, links: { unsubscribe: string; 
     ? `Total views: ${digest.totalViews}${digest.deltaViews !== undefined ? ` (${digest.deltaViews >= 0 ? "+" : ""}${digest.deltaViews} vs previous period)` : ""}\n`
     : "";
 
-  return `${digest.heading}\n${digest.summary}\n${totals}${renderDigestItemsText(digest)}\n\nManage preferences: ${links.preferences}\nUnsubscribe: ${links.unsubscribe}`;
+  return `${digest.heading}\n${digest.summary}\n${totals}${renderDigestItemsText(digest)}${renderWantMoreText()}\n\nManage preferences: ${links.preferences}\nUnsubscribe: ${links.unsubscribe}`;
+}
+
+function renderDigestItemsMarkdown(digest: CampaignDigest) {
+  return digest.items.length > 0
+    ? digest.items.map((item) => {
+      const metric = item.currentViews !== undefined
+        ? `${item.currentViews} views${item.delta !== undefined ? ` (${item.delta >= 0 ? "+" : ""}${item.delta})` : ""}`
+        : "";
+      const pieces = [
+        `**${item.title}**`,
+        item.subtitle || "",
+        metric,
+        item.url ? `[open](${item.url})` : "",
+      ].filter(Boolean);
+      return `- ${pieces.join(" · ")}`;
+    }).join("\n")
+    : "- No items available for this period.";
+}
+
+function renderRecentNewsMarkdown(recentNews: Awaited<ReturnType<typeof getRecentNewsSnapshot>>) {
+  return recentNews.length > 0
+    ? recentNews.map((item) => `- [${item.title}](${item.url}) · ${item.source} · ${item.date}`).join("\n")
+    : "- No recent news available.";
+}
+
+function renderWantMoreMarkdown() {
+  const baseUrl = getBaseUrl();
+  const newslettersMd = RECOMMENDED_NEWSLETTERS.map((nl) =>
+    `- **[${nl.name}](${nl.url})** — ${nl.description}`
+  ).join("\n");
+  const otherMd = OTHER_CONTENT_I_LIKE.map((item) =>
+    `- **[${item.name}](${item.url})** — ${item.description}`
+  ).join("\n");
+  const categoriesMd = FEATURED_CATEGORIES.map((cat) =>
+    `\`${cat.label}\``
+  ).join(" · ");
+  return `\n---\n\n### Want to read more?\n\n**Recommended newsletters & links**\n\n${newslettersMd}\n\n**Other content I like**\n\n${otherMd}\n\n**Browse by topic:** ${categoriesMd}\n\n[View all news →](${baseUrl}/news)`;
+}
+
+function renderDigestMarkdown(
+  digest: CampaignDigest,
+  links: { unsubscribe: string; preferences: string },
+) {
+  const totals = digest.totalViews !== undefined
+    ? `\nTotal views: ${digest.totalViews}${digest.deltaViews !== undefined ? ` (${digest.deltaViews >= 0 ? "+" : ""}${digest.deltaViews} vs previous period)` : ""}\n`
+    : "\n";
+
+  return `## ${digest.heading}
+
+${digest.summary}
+${totals}
+${renderDigestItemsMarkdown(digest)}
+${renderWantMoreMarkdown()}
+
+[Manage preferences](${links.preferences}) | [Unsubscribe](${links.unsubscribe})`;
 }
 
 function interpolateTemplate(template: string, values: Record<string, string>) {
   return template.replace(/{{\s*([a-z0-9_]+)\s*}}/gi, (_, key: string) => values[key] ?? "");
 }
 
+function renderInlineMarkdown(value: string): string {
+  let html = escapeHtml(value);
+
+  html = html.replace(/`([^`]+)`/g, `<code style="font-family:${MONO_FONT_STACK};font-size:0.95em;border:1px solid #e5e5e5;background:#fafafa;padding:1px 4px;border-radius:4px;">$1</code>`);
+  html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, "<a href=\"$2\" style=\"color:#111111;text-decoration:underline;text-underline-offset:2px;text-decoration-thickness:1px;\">$1</a>");
+  html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+
+  return html;
+}
+
+function markdownToHtml(markdown: string): string {
+  const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+  const output: string[] = [];
+  let paragraphLines: string[] = [];
+  let listItems: string[] = [];
+  let listLooksLikeDigest = false;
+  let quoteLines: string[] = [];
+  let inCodeBlock = false;
+  let codeLines: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraphLines.length === 0) return;
+    output.push(`<p style="margin:0 0 14px;font-size:16px;line-height:1.75;color:#1f1f1f;">${paragraphLines.join("<br />")}</p>`);
+    paragraphLines = [];
+  };
+
+  const flushList = () => {
+    if (listItems.length === 0) return;
+    output.push(
+      listLooksLikeDigest
+        ? `<ul style="margin:0 0 18px;padding:0;list-style:none;">${listItems.join("")}</ul>`
+        : `<ul style="margin:0 0 18px;padding:0 0 0 20px;">${listItems.join("")}</ul>`
+    );
+    listItems = [];
+    listLooksLikeDigest = false;
+  };
+
+  const flushQuote = () => {
+    if (quoteLines.length === 0) return;
+    output.push(`<blockquote style="margin:0 0 18px;padding:0 0 0 14px;border-left:2px solid #d4d4d4;"><p style="margin:0;font-size:16px;line-height:1.75;color:#404040;">${quoteLines.join("<br />")}</p></blockquote>`);
+    quoteLines = [];
+  };
+
+  const flushAll = () => {
+    flushParagraph();
+    flushList();
+    flushQuote();
+  };
+
+  for (const rawLine of lines) {
+    const trimmed = rawLine.trim();
+
+    if (inCodeBlock) {
+      if (trimmed.startsWith("```")) {
+        output.push(`<pre style="margin:0 0 18px;padding:12px 14px;border:1px solid #e5e5e5;background:#fafafa;overflow:auto;"><code style="font-family:${MONO_FONT_STACK};font-size:13px;line-height:1.6;color:#171717;">${escapeHtml(codeLines.join("\n"))}</code></pre>`);
+        codeLines = [];
+        inCodeBlock = false;
+      } else {
+        codeLines.push(rawLine);
+      }
+      continue;
+    }
+
+    if (trimmed.startsWith("```")) {
+      flushAll();
+      inCodeBlock = true;
+      continue;
+    }
+
+    if (!trimmed) {
+      flushAll();
+      continue;
+    }
+
+    if (/^(---|\*\*\*)$/.test(trimmed)) {
+      flushAll();
+      output.push("<hr style=\"border:0;border-top:1px solid #e5e5e5;margin:20px 0;\" />");
+      continue;
+    }
+
+    const headingMatch = trimmed.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      flushAll();
+      const level = headingMatch[1].length;
+      const fontSizeByLevel = [0, 34, 30, 24, 20, 18, 16];
+      const headingSize = fontSizeByLevel[level] ?? 16;
+      output.push(`<h${level} style="margin:20px 0 10px;font-family:${SUBSTACK_SANS_FONT_STACK};font-size:${headingSize}px;line-height:1.22;font-weight:700;color:#111111;">${renderInlineMarkdown(headingMatch[2])}</h${level}>`);
+      continue;
+    }
+
+    const listMatch = trimmed.match(/^[-*]\s+(.+)$/);
+    if (listMatch) {
+      flushParagraph();
+      flushQuote();
+      const itemContent = listMatch[1];
+      const isDigestItem = itemContent.includes(" · ") || itemContent.includes("|");
+      if (isDigestItem) {
+        listLooksLikeDigest = true;
+        listItems.push(
+          `<li style="margin:0 0 10px;padding:14px 16px;border:1px solid #e5e5e5;background:#fafafa;">
+            <div style="font-size:16px;line-height:1.65;color:#1f1f1f;">${renderInlineMarkdown(itemContent)}</div>
+          </li>`
+        );
+      } else {
+        listItems.push(`<li style="margin:0 0 10px;font-size:16px;line-height:1.75;color:#1f1f1f;">${renderInlineMarkdown(itemContent)}</li>`);
+      }
+      continue;
+    }
+
+    const quoteMatch = trimmed.match(/^>\s?(.*)$/);
+    if (quoteMatch) {
+      flushParagraph();
+      flushList();
+      quoteLines.push(renderInlineMarkdown(quoteMatch[1]));
+      continue;
+    }
+
+    flushList();
+    flushQuote();
+    paragraphLines.push(renderInlineMarkdown(trimmed));
+  }
+
+  if (inCodeBlock) {
+    output.push(`<pre style="margin:0 0 18px;padding:12px 14px;border:1px solid #e5e5e5;background:#fafafa;overflow:auto;"><code style="font-family:${MONO_FONT_STACK};font-size:13px;line-height:1.6;color:#171717;">${escapeHtml(codeLines.join("\n"))}</code></pre>`);
+  }
+
+  flushAll();
+  const html = output.join("\n").trim();
+  if (!html) return "";
+  return `<div style="font-family:${SUBSTACK_SANS_FONT_STACK};color:#111111;">${html}</div>`;
+}
+
+function htmlToText(html: string): string {
+  return html
+    .replace(/<\s*br\s*\/?>/gi, "\n")
+    .replace(/<\s*\/p\s*>/gi, "\n\n")
+    .replace(/<[^>]*>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, "\"")
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 async function getRecentNewsSnapshot(limit: number = 8) {
   const allNews = await getAllNews();
   return allNews.slice(0, limit).map((item) => ({
     title: item.title,
-    url: item.url,
+    url: toAbsoluteUrl(item.url),
     date: item.date,
     type: item.type,
     source: item.source || item.company || item.type,
-    category: item.category,
+    category: item.category || "general",
   }));
 }
 
 function renderRecentNewsHtml(recentNews: Awaited<ReturnType<typeof getRecentNewsSnapshot>>) {
-  if (recentNews.length === 0) return "<li>No recent news available.</li>";
+  if (recentNews.length === 0) return `<p style="color:#a3a3a3">No recent news available.</p>`;
 
   const groupMap = new Map<string, typeof recentNews>();
   for (const item of recentNews) {
@@ -735,12 +1109,16 @@ function renderRecentNewsHtml(recentNews: Awaited<ReturnType<typeof getRecentNew
     groupMap.get(cat)!.push(item);
   }
 
-  return Array.from(groupMap.entries()).map(([cat, items]) => {
-    const label = categoryLabels[cat as NewsCategory] || cat;
+  const sortedEntries = sortGroupsByCategory(
+    Array.from(groupMap.entries()).map(([cat, items]) => ({ category: cat, items }))
+  );
+
+  return sortedEntries.map(({ category: cat, items }) => {
+    const label = newsletterLabel(cat);
     const itemsHtml = items.map((item) =>
-      `<li><a href="${item.url}"><strong>${escapeHtml(item.title)}</strong></a> · ${escapeHtml(item.source)} · ${escapeHtml(item.date)}</li>`
+      `<li style="padding:8px 0;border-bottom:1px solid #f5f5f5"><a href="${item.url}" style="color:#171717;text-decoration:underline;text-underline-offset:2px;text-decoration-color:#d4d4d4;font-weight:600">${escapeHtml(item.title)}</a><br/><span style="color:#a3a3a3;font-size:13px">${escapeHtml(item.source)} · ${escapeHtml(item.date)}</span></li>`
     ).join("");
-    return `<h4>${escapeHtml(label)}</h4><ul>${itemsHtml}</ul>`;
+    return `<h3 style="font-size:15px;font-weight:700;color:#171717;margin:24px 0 8px;padding-bottom:8px;border-bottom:2px solid #171717">${escapeHtml(label)}</h3><ul style="list-style:none;padding:0;margin:0">${itemsHtml}</ul>`;
   }).join("");
 }
 
@@ -754,8 +1132,12 @@ function renderRecentNewsText(recentNews: Awaited<ReturnType<typeof getRecentNew
     groupMap.get(cat)!.push(item);
   }
 
-  return Array.from(groupMap.entries()).map(([cat, items]) => {
-    const label = categoryLabels[cat as NewsCategory] || cat;
+  const sortedEntries = sortGroupsByCategory(
+    Array.from(groupMap.entries()).map(([cat, items]) => ({ category: cat, items }))
+  );
+
+  return sortedEntries.map(({ category: cat, items }) => {
+    const label = newsletterLabel(cat);
     const header = `\n## ${label}`;
     const lines = items.map((item) => `- ${item.title} | ${item.source} | ${item.date} | ${item.url}`).join("\n");
     return `${header}\n${lines}`;
@@ -773,11 +1155,60 @@ async function getNewsletterTemplatePayload(newsletterType: NewsletterType): Pro
     return DEFAULT_NEWSLETTER_TEMPLATES[newsletterType];
   }
 
-  return {
+  return normalizeLegacyTemplatePayload({
     newsletterType,
     subjectTemplate: stored.subjectTemplate,
     htmlTemplate: stored.htmlTemplate,
     textTemplate: stored.textTemplate,
+    markdownTemplate: stored.markdownTemplate,
+  });
+}
+
+function buildTemplateValues(params: {
+  campaignSubject: string;
+  campaignType: NewsletterType;
+  periodDays: number;
+  digest: CampaignDigest;
+  links: { unsubscribe: string; preferences: string };
+  recentNews: Awaited<ReturnType<typeof getRecentNewsSnapshot>>;
+  now?: Date;
+}) {
+  const now = params.now || new Date();
+  const recentHtml = renderRecentNewsHtml(params.recentNews);
+  const recentText = renderRecentNewsText(params.recentNews);
+  const recentMarkdown = renderRecentNewsMarkdown(params.recentNews);
+
+  const defaultHtmlBody = renderDigestHtml(params.digest, params.links);
+  const defaultTextBody = renderDigestText(params.digest, params.links);
+  const defaultMarkdownBody = renderDigestMarkdown(params.digest, params.links);
+
+  const values: Record<string, string> = {
+    campaign_subject: params.campaignSubject,
+    campaign_type: params.campaignType,
+    period_days: String(params.periodDays),
+    digest_heading: params.digest.heading,
+    digest_summary: params.digest.summary,
+    total_views: params.digest.totalViews !== undefined ? String(params.digest.totalViews) : "",
+    delta_views: params.digest.deltaViews !== undefined ? String(params.digest.deltaViews) : "",
+    digest_items_html: renderDigestItemsHtml(params.digest),
+    digest_items_text: renderDigestItemsText(params.digest),
+    digest_items_markdown: renderDigestItemsMarkdown(params.digest),
+    recent_news_html: recentHtml,
+    recent_news_text: recentText,
+    recent_news_markdown: recentMarkdown,
+    unsubscribe_url: params.links.unsubscribe,
+    preferences_url: params.links.preferences,
+    default_html_body: defaultHtmlBody,
+    default_text_body: defaultTextBody,
+    default_markdown_body: defaultMarkdownBody,
+    generated_at_iso: now.toISOString(),
+  };
+
+  return {
+    values,
+    defaultHtmlBody,
+    defaultTextBody,
+    defaultMarkdownBody,
   };
 }
 
@@ -791,36 +1222,143 @@ function renderTemplateContent(params: {
   recentNews: Awaited<ReturnType<typeof getRecentNewsSnapshot>>;
   now?: Date;
 }) {
-  const now = params.now || new Date();
-  const defaultHtmlBody = renderDigestHtml(params.digest, params.links);
-  const defaultTextBody = renderDigestText(params.digest, params.links);
-  const values: Record<string, string> = {
-    campaign_subject: params.campaignSubject,
-    campaign_type: params.campaignType,
-    period_days: String(params.periodDays),
-    digest_heading: params.digest.heading,
-    digest_summary: params.digest.summary,
-    total_views: params.digest.totalViews !== undefined ? String(params.digest.totalViews) : "",
-    delta_views: params.digest.deltaViews !== undefined ? String(params.digest.deltaViews) : "",
-    digest_items_html: renderDigestItemsHtml(params.digest),
-    digest_items_text: renderDigestItemsText(params.digest),
-    recent_news_html: renderRecentNewsHtml(params.recentNews),
-    recent_news_text: renderRecentNewsText(params.recentNews),
-    unsubscribe_url: params.links.unsubscribe,
-    preferences_url: params.links.preferences,
-    default_html_body: defaultHtmlBody,
-    default_text_body: defaultTextBody,
-    generated_at_iso: now.toISOString(),
+  const { values, defaultHtmlBody, defaultTextBody } = buildTemplateValues(params);
+  const resolvedCampaignSubject = interpolateTemplate(
+    params.campaignSubject,
+    { ...values, campaign_subject: params.campaignSubject }
+  ).trim() || params.campaignSubject;
+  const nextValues: Record<string, string> = {
+    ...values,
+    campaign_subject: resolvedCampaignSubject,
   };
 
-  const renderedSubject = interpolateTemplate(params.template.subjectTemplate, values).trim();
-  const renderedHtml = interpolateTemplate(params.template.htmlTemplate, values).trim();
-  const renderedText = interpolateTemplate(params.template.textTemplate, values).trim();
+  const renderedSubject = interpolateTemplate(params.template.subjectTemplate, nextValues).trim();
+  const renderedHtml = interpolateTemplate(params.template.htmlTemplate, nextValues).trim();
+  const renderedText = interpolateTemplate(params.template.textTemplate, nextValues).trim();
 
   return {
-    subject: renderedSubject || params.campaignSubject,
+    subject: renderedSubject || resolvedCampaignSubject,
     html: renderedHtml || defaultHtmlBody,
     text: renderedText || defaultTextBody,
+    values: nextValues,
+  };
+}
+
+function renderMarkdownStarter(params: {
+  template: NewsletterTemplatePayload;
+  campaignSubject: string;
+  campaignType: NewsletterType;
+  periodDays: number;
+  digest: CampaignDigest;
+  links: { unsubscribe: string; preferences: string };
+  recentNews: Awaited<ReturnType<typeof getRecentNewsSnapshot>>;
+  now?: Date;
+}) {
+  const templateRender = renderTemplateContent(params);
+  const starter = interpolateTemplate(params.template.markdownTemplate, templateRender.values).trim();
+  return {
+    markdown: starter || templateRender.values.default_markdown_body,
+    values: templateRender.values,
+  };
+}
+
+type CampaignContentDraft = {
+  campaignSubject: string;
+  contentMode: NewsletterContentMode;
+  markdownContent?: string | null;
+  manualHtml?: string | null;
+  manualText?: string | null;
+};
+
+function validateCampaignContentDraft(input: CampaignContentDraft) {
+  if (!NEWSLETTER_CONTENT_MODES.includes(input.contentMode)) {
+    return { ok: false as const, status: 400, error: "Invalid content mode" };
+  }
+
+  if (input.contentMode === "markdown" && !input.markdownContent?.trim()) {
+    return { ok: false as const, status: 400, error: "Markdown content is required for markdown mode" };
+  }
+
+  if (input.contentMode === "manual") {
+    if (!input.manualHtml?.trim() || !input.manualText?.trim()) {
+      return { ok: false as const, status: 400, error: "manualHtml and manualText are required for manual mode" };
+    }
+  }
+
+  return { ok: true as const };
+}
+
+function resolveCampaignRenderContent(params: {
+  campaign: CampaignContentDraft;
+  template: NewsletterTemplatePayload;
+  campaignType: NewsletterType;
+  periodDays: number;
+  digest: CampaignDigest;
+  links: { unsubscribe: string; preferences: string };
+  recentNews: Awaited<ReturnType<typeof getRecentNewsSnapshot>>;
+  now?: Date;
+}) {
+  const validation = validateCampaignContentDraft(params.campaign);
+  if (!validation.ok) {
+    return validation;
+  }
+
+  const templateRendered = renderTemplateContent({
+    template: params.template,
+    campaignSubject: params.campaign.campaignSubject,
+    campaignType: params.campaignType,
+    periodDays: params.periodDays,
+    digest: params.digest,
+    links: params.links,
+    recentNews: params.recentNews,
+    now: params.now,
+  });
+
+  if (params.campaign.contentMode === "template") {
+    return {
+      ok: true as const,
+      data: {
+        subject: templateRendered.subject,
+        html: templateRendered.html,
+        text: templateRendered.text,
+      },
+    };
+  }
+
+  if (params.campaign.contentMode === "markdown") {
+    const renderedMarkdown = interpolateTemplate(
+      params.campaign.markdownContent || "",
+      templateRendered.values
+    ).trim();
+    if (!renderedMarkdown) {
+      return { ok: false as const, status: 400, error: "Markdown content resolved to empty output" };
+    }
+
+    const html = markdownToHtml(renderedMarkdown);
+    const text = htmlToText(html);
+    return {
+      ok: true as const,
+      data: {
+        subject: templateRendered.values.campaign_subject,
+        html,
+        text,
+      },
+    };
+  }
+
+  const html = interpolateTemplate(params.campaign.manualHtml || "", templateRendered.values).trim();
+  const text = interpolateTemplate(params.campaign.manualText || "", templateRendered.values).trim();
+  if (!html || !text) {
+    return { ok: false as const, status: 400, error: "manualHtml and manualText resolved to empty output" };
+  }
+
+  return {
+    ok: true as const,
+    data: {
+      subject: templateRendered.values.campaign_subject,
+      html,
+      text,
+    },
   };
 }
 
@@ -833,12 +1371,13 @@ export async function listNewsletterTemplates() {
     if (!stored) {
       return DEFAULT_NEWSLETTER_TEMPLATES[type];
     }
-    return {
+    return normalizeLegacyTemplatePayload({
       newsletterType: type,
       subjectTemplate: stored.subjectTemplate,
       htmlTemplate: stored.htmlTemplate,
       textTemplate: stored.textTemplate,
-    };
+      markdownTemplate: stored.markdownTemplate,
+    });
   });
 }
 
@@ -847,11 +1386,17 @@ export async function upsertNewsletterTemplate(input: {
   subjectTemplate: string;
   htmlTemplate: string;
   textTemplate: string;
+  markdownTemplate: string;
 }) {
   if (!NEWSLETTER_TYPES.includes(input.newsletterType as NewsletterType)) {
     return { ok: false as const, status: 400, error: "Invalid newsletter type" };
   }
-  if (!input.subjectTemplate.trim() || !input.htmlTemplate.trim() || !input.textTemplate.trim()) {
+  if (
+    !input.subjectTemplate.trim() ||
+    !input.htmlTemplate.trim() ||
+    !input.textTemplate.trim() ||
+    !input.markdownTemplate.trim()
+  ) {
     return { ok: false as const, status: 400, error: "All template fields are required" };
   }
 
@@ -870,6 +1415,7 @@ export async function upsertNewsletterTemplate(input: {
         subjectTemplate: input.subjectTemplate,
         htmlTemplate: input.htmlTemplate,
         textTemplate: input.textTemplate,
+        markdownTemplate: input.markdownTemplate,
       })
       .returning();
 
@@ -882,6 +1428,7 @@ export async function upsertNewsletterTemplate(input: {
       subjectTemplate: input.subjectTemplate,
       htmlTemplate: input.htmlTemplate,
       textTemplate: input.textTemplate,
+      markdownTemplate: input.markdownTemplate,
       updatedAt: new Date(),
     })
     .where(eq(newsletterTemplates.id, existing.id))
@@ -897,6 +1444,7 @@ export async function renderNewsletterTemplatePreview(input: {
   subjectTemplate?: string;
   htmlTemplate?: string;
   textTemplate?: string;
+  markdownTemplate?: string;
 }) {
   if (!NEWSLETTER_TYPES.includes(input.newsletterType as NewsletterType)) {
     return { ok: false as const, status: 400, error: "Invalid newsletter type" };
@@ -914,13 +1462,16 @@ export async function renderNewsletterTemplatePreview(input: {
     subjectTemplate: input.subjectTemplate ?? storedTemplate.subjectTemplate,
     htmlTemplate: input.htmlTemplate ?? storedTemplate.htmlTemplate,
     textTemplate: input.textTemplate ?? storedTemplate.textTemplate,
+    markdownTemplate: input.markdownTemplate ?? storedTemplate.markdownTemplate,
   };
 
-  const rendered = renderTemplateContent({
+  const campaignSubject = typeof input.campaignSubject === "string" && input.campaignSubject.trim()
+    ? input.campaignSubject.trim()
+    : `Preview: ${digest.heading}`;
+
+  const renderInput = {
     template,
-    campaignSubject: input.campaignSubject?.trim()
-      ? input.campaignSubject.trim()
-      : `Preview: ${digest.heading}`,
+    campaignSubject,
     campaignType: newsletterType,
     periodDays,
     digest,
@@ -930,7 +1481,9 @@ export async function renderNewsletterTemplatePreview(input: {
     },
     recentNews,
     now: new Date(),
-  });
+  };
+  const rendered = renderTemplateContent(renderInput);
+  const starter = renderMarkdownStarter(renderInput);
 
   return {
     ok: true as const,
@@ -938,6 +1491,7 @@ export async function renderNewsletterTemplatePreview(input: {
       placeholders: [...NEWSLETTER_TEMPLATE_PLACEHOLDERS],
       template,
       rendered,
+      starter,
       context: {
         digest,
         recentNews,
@@ -952,6 +1506,70 @@ export async function listNewsletterCampaigns(limit: number = 50) {
     .from(newsletterCampaigns)
     .orderBy(desc(newsletterCampaigns.createdAt))
     .limit(Math.min(Math.max(limit, 1), 200));
+}
+
+export async function getNewsletterCampaignById(campaignId: string) {
+  const [campaign] = await db
+    .select()
+    .from(newsletterCampaigns)
+    .where(eq(newsletterCampaigns.id, campaignId))
+    .limit(1);
+
+  if (!campaign) {
+    return { ok: false as const, status: 404, error: "Campaign not found" };
+  }
+
+  return { ok: true as const, data: campaign };
+}
+
+function validatePeriodDays(periodDays?: number) {
+  if (periodDays === undefined) {
+    return { ok: true as const, data: DEFAULT_CAMPAIGN_PERIOD_DAYS };
+  }
+  if (!Number.isInteger(periodDays) || periodDays < 1 || periodDays > 30) {
+    return { ok: false as const, status: 400, error: "periodDays must be an integer between 1 and 30" };
+  }
+  return { ok: true as const, data: periodDays };
+}
+
+function parseScheduledAt(scheduledAtIso?: string): Date | null | "invalid" {
+  if (!scheduledAtIso) return null;
+  const scheduledAt = new Date(scheduledAtIso);
+  if (Number.isNaN(scheduledAt.getTime())) return "invalid";
+  return scheduledAt;
+}
+
+function isCampaignMutable(status: string): boolean {
+  return MUTABLE_CAMPAIGN_STATUSES.has(status as "draft" | "scheduled");
+}
+
+function normalizeCampaignContentByMode(input: {
+  contentMode: NewsletterContentMode;
+  markdownContent?: string | null;
+  manualHtml?: string | null;
+  manualText?: string | null;
+}) {
+  if (input.contentMode === "template") {
+    return {
+      markdownContent: null,
+      manualHtml: null,
+      manualText: null,
+    };
+  }
+
+  if (input.contentMode === "markdown") {
+    return {
+      markdownContent: input.markdownContent?.trim() || null,
+      manualHtml: null,
+      manualText: null,
+    };
+  }
+
+  return {
+    markdownContent: null,
+    manualHtml: input.manualHtml?.trim() || null,
+    manualText: input.manualText?.trim() || null,
+  };
 }
 
 function formatUtcDay(date: Date): string {
@@ -1039,6 +1657,10 @@ export async function createNewsletterCampaign(input: {
   periodDays?: number;
   scheduledAt?: string;
   createdBy?: string;
+  contentMode?: string;
+  markdownContent?: string | null;
+  manualHtml?: string | null;
+  manualText?: string | null;
 }) {
   if (!NEWSLETTER_TYPES.includes(input.newsletterType as NewsletterType)) {
     return { ok: false as const, status: 400, error: "Invalid newsletter type" };
@@ -1047,14 +1669,36 @@ export async function createNewsletterCampaign(input: {
     return { ok: false as const, status: 400, error: "Subject is required" };
   }
 
-  const periodDays = Number.isInteger(input.periodDays) && input.periodDays! > 0
-    ? Math.min(input.periodDays!, 30)
-    : DEFAULT_CAMPAIGN_PERIOD_DAYS;
+  if (input.contentMode && !NEWSLETTER_CONTENT_MODES.includes(input.contentMode as NewsletterContentMode)) {
+    return { ok: false as const, status: 400, error: "Invalid content mode" };
+  }
+  const contentMode = normalizeNewsletterContentMode(input.contentMode);
+  const contentValidation = validateCampaignContentDraft({
+    campaignSubject: input.subject,
+    contentMode,
+    markdownContent: input.markdownContent,
+    manualHtml: input.manualHtml,
+    manualText: input.manualText,
+  });
+  if (!contentValidation.ok) {
+    return contentValidation;
+  }
 
-  const scheduledAt = input.scheduledAt ? new Date(input.scheduledAt) : null;
-  if (scheduledAt && Number.isNaN(scheduledAt.getTime())) {
+  const periodValidation = validatePeriodDays(input.periodDays);
+  if (!periodValidation.ok) {
+    return periodValidation;
+  }
+  const periodDays = periodValidation.data;
+  const scheduledAt = parseScheduledAt(input.scheduledAt);
+  if (scheduledAt === "invalid") {
     return { ok: false as const, status: 400, error: "Invalid scheduledAt value" };
   }
+  const content = normalizeCampaignContentByMode({
+    contentMode,
+    markdownContent: input.markdownContent,
+    manualHtml: input.manualHtml,
+    manualText: input.manualText,
+  });
 
   const [campaign] = await db
     .insert(newsletterCampaigns)
@@ -1062,6 +1706,10 @@ export async function createNewsletterCampaign(input: {
       newsletterType: input.newsletterType as NewsletterType,
       subject: input.subject.trim(),
       previewText: input.previewText || null,
+      contentMode,
+      markdownContent: content.markdownContent,
+      manualHtml: content.manualHtml,
+      manualText: content.manualText,
       periodDays,
       status: scheduledAt ? "scheduled" : "draft",
       scheduledAt,
@@ -1073,8 +1721,16 @@ export async function createNewsletterCampaign(input: {
 }
 
 export async function scheduleNewsletterCampaign(campaignId: string, scheduledAtIso: string) {
-  const scheduledAt = new Date(scheduledAtIso);
-  if (Number.isNaN(scheduledAt.getTime())) {
+  const existing = await getNewsletterCampaignById(campaignId);
+  if (!existing.ok) {
+    return existing;
+  }
+  if (!isCampaignMutable(existing.data.status)) {
+    return { ok: false as const, status: 409, error: "Only draft or scheduled campaigns can be modified" };
+  }
+
+  const scheduledAt = parseScheduledAt(scheduledAtIso);
+  if (scheduledAt === "invalid") {
     return { ok: false as const, status: 400, error: "Invalid scheduledAt value" };
   }
 
@@ -1093,6 +1749,206 @@ export async function scheduleNewsletterCampaign(campaignId: string, scheduledAt
   }
 
   return { ok: true as const, data: campaign };
+}
+
+export async function updateNewsletterCampaign(campaignId: string, input: {
+  newsletterType?: string;
+  subject?: string;
+  previewText?: string | null;
+  periodDays?: number;
+  scheduledAt?: string | null;
+  contentMode?: string;
+  markdownContent?: string | null;
+  manualHtml?: string | null;
+  manualText?: string | null;
+}) {
+  const current = await getNewsletterCampaignById(campaignId);
+  if (!current.ok) {
+    return current;
+  }
+  if (!isCampaignMutable(current.data.status)) {
+    return { ok: false as const, status: 409, error: "Only draft or scheduled campaigns can be modified" };
+  }
+
+  const newsletterType = input.newsletterType
+    ? (NEWSLETTER_TYPES.includes(input.newsletterType as NewsletterType) ? input.newsletterType as NewsletterType : null)
+    : current.data.newsletterType as NewsletterType;
+  if (!newsletterType) {
+    return { ok: false as const, status: 400, error: "Invalid newsletter type" };
+  }
+
+  const subject = (input.subject ?? current.data.subject)?.trim();
+  if (!subject) {
+    return { ok: false as const, status: 400, error: "Subject is required" };
+  }
+
+  if (input.contentMode && !NEWSLETTER_CONTENT_MODES.includes(input.contentMode as NewsletterContentMode)) {
+    return { ok: false as const, status: 400, error: "Invalid content mode" };
+  }
+  const contentMode = normalizeNewsletterContentMode(input.contentMode ?? current.data.contentMode);
+  const draftValidation = validateCampaignContentDraft({
+    campaignSubject: subject,
+    contentMode,
+    markdownContent: input.markdownContent ?? current.data.markdownContent,
+    manualHtml: input.manualHtml ?? current.data.manualHtml,
+    manualText: input.manualText ?? current.data.manualText,
+  });
+  if (!draftValidation.ok) {
+    return draftValidation;
+  }
+
+  const periodValidation = validatePeriodDays(input.periodDays);
+  if (!periodValidation.ok) {
+    return periodValidation;
+  }
+  const periodDays = input.periodDays === undefined ? current.data.periodDays : periodValidation.data;
+  const scheduledAt = input.scheduledAt === null
+    ? null
+    : parseScheduledAt(input.scheduledAt ?? (current.data.scheduledAt ? current.data.scheduledAt.toISOString() : undefined));
+  if (scheduledAt === "invalid") {
+    return { ok: false as const, status: 400, error: "Invalid scheduledAt value" };
+  }
+
+  const normalizedContent = normalizeCampaignContentByMode({
+    contentMode,
+    markdownContent: input.markdownContent ?? current.data.markdownContent,
+    manualHtml: input.manualHtml ?? current.data.manualHtml,
+    manualText: input.manualText ?? current.data.manualText,
+  });
+
+  const [updated] = await db
+    .update(newsletterCampaigns)
+    .set({
+      newsletterType,
+      subject,
+      previewText: input.previewText === undefined ? current.data.previewText : (input.previewText || null),
+      periodDays,
+      scheduledAt,
+      status: scheduledAt ? "scheduled" : "draft",
+      contentMode,
+      markdownContent: normalizedContent.markdownContent,
+      manualHtml: normalizedContent.manualHtml,
+      manualText: normalizedContent.manualText,
+      updatedAt: new Date(),
+    })
+    .where(eq(newsletterCampaigns.id, campaignId))
+    .returning();
+
+  return { ok: true as const, data: updated };
+}
+
+export async function deleteNewsletterCampaign(campaignId: string) {
+  const current = await getNewsletterCampaignById(campaignId);
+  if (!current.ok) {
+    return current;
+  }
+  if (!isCampaignMutable(current.data.status)) {
+    return { ok: false as const, status: 409, error: "Only draft or scheduled campaigns can be deleted" };
+  }
+
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(newsletterSendEvents)
+      .where(eq(newsletterSendEvents.campaignId, campaignId));
+    await tx
+      .delete(newsletterCampaignRecipients)
+      .where(eq(newsletterCampaignRecipients.campaignId, campaignId));
+    await tx
+      .delete(newsletterCampaigns)
+      .where(eq(newsletterCampaigns.id, campaignId));
+  });
+
+  return { ok: true as const, data: { id: campaignId } };
+}
+
+export async function previewNewsletterCampaignDraft(input: {
+  newsletterType: string;
+  subject: string;
+  periodDays?: number;
+  contentMode?: string;
+  markdownContent?: string | null;
+  manualHtml?: string | null;
+  manualText?: string | null;
+}) {
+  if (!NEWSLETTER_TYPES.includes(input.newsletterType as NewsletterType)) {
+    return { ok: false as const, status: 400, error: "Invalid newsletter type" };
+  }
+  if (!input.subject?.trim()) {
+    return { ok: false as const, status: 400, error: "Subject is required" };
+  }
+
+  if (input.contentMode && !NEWSLETTER_CONTENT_MODES.includes(input.contentMode as NewsletterContentMode)) {
+    return { ok: false as const, status: 400, error: "Invalid content mode" };
+  }
+  const newsletterType = input.newsletterType as NewsletterType;
+  const periodValidation = validatePeriodDays(input.periodDays);
+  if (!periodValidation.ok) {
+    return periodValidation;
+  }
+  const periodDays = periodValidation.data;
+  const contentMode = normalizeNewsletterContentMode(input.contentMode);
+
+  const validation = validateCampaignContentDraft({
+    campaignSubject: input.subject.trim(),
+    contentMode,
+    markdownContent: input.markdownContent,
+    manualHtml: input.manualHtml,
+    manualText: input.manualText,
+  });
+  if (!validation.ok) {
+    return validation;
+  }
+
+  const [digest, recentNews, template] = await Promise.all([
+    buildDigest(newsletterType, periodDays),
+    getRecentNewsSnapshot(8),
+    getNewsletterTemplatePayload(newsletterType),
+  ]);
+  const links = {
+    unsubscribe: "https://dcbuilder.dev/api/v1/newsletter/unsubscribe?token=preview-token",
+    preferences: "https://dcbuilder.dev/api/v1/newsletter/preferences?token=preview-token",
+  };
+
+  const renderResult = resolveCampaignRenderContent({
+    campaign: {
+      campaignSubject: input.subject.trim(),
+      contentMode,
+      markdownContent: input.markdownContent,
+      manualHtml: input.manualHtml,
+      manualText: input.manualText,
+    },
+    template,
+    campaignType: newsletterType,
+    periodDays,
+    digest,
+    links,
+    recentNews,
+    now: new Date(),
+  });
+  if (!renderResult.ok) {
+    return renderResult;
+  }
+
+  const starter = renderMarkdownStarter({
+    template,
+    campaignSubject: input.subject.trim(),
+    campaignType: newsletterType,
+    periodDays,
+    digest,
+    links,
+    recentNews,
+    now: new Date(),
+  });
+
+  return {
+    ok: true as const,
+    data: {
+      rendered: renderResult.data,
+      starter: { markdown: starter.markdown },
+      placeholders: [...NEWSLETTER_TEMPLATE_PLACEHOLDERS],
+      context: { digest, recentNews },
+    },
+  };
 }
 
 async function sendCampaignInternal(campaignId: string, force: boolean) {
@@ -1115,29 +1971,83 @@ async function sendCampaignInternal(campaignId: string, force: boolean) {
     return { ok: false as const, status: 409, error: "Campaign schedule is in the future" };
   }
 
-  const recipients = await resolveRecipients(campaign.newsletterType as NewsletterType);
+  const contentMode = normalizeNewsletterContentMode(campaign.contentMode);
+  const contentValidation = validateCampaignContentDraft({
+    campaignSubject: campaign.subject,
+    contentMode,
+    markdownContent: campaign.markdownContent,
+    manualHtml: campaign.manualHtml,
+    manualText: campaign.manualText,
+  });
+  if (!contentValidation.ok) {
+    await db
+      .update(newsletterCampaigns)
+      .set({
+        status: "failed",
+        failureReason: contentValidation.error,
+        updatedAt: new Date(),
+      })
+      .where(eq(newsletterCampaigns.id, campaign.id));
+    return contentValidation;
+  }
+
+  const now = new Date();
+  const [lockedCampaign] = await db
+    .update(newsletterCampaigns)
+    .set({ status: "sending", failureReason: null, updatedAt: now })
+    .where(
+      and(
+        eq(newsletterCampaigns.id, campaign.id),
+        eq(newsletterCampaigns.status, campaign.status)
+      )
+    )
+    .returning();
+  if (!lockedCampaign) {
+    const [latest] = await db
+      .select()
+      .from(newsletterCampaigns)
+      .where(eq(newsletterCampaigns.id, campaign.id))
+      .limit(1);
+
+    if (!latest) {
+      return { ok: false as const, status: 404, error: "Campaign not found" };
+    }
+    if (latest.status === "sent") {
+      return {
+        ok: true as const,
+        data: { campaign: latest, sent: 0, failed: 0, skipped: 0, alreadySent: true },
+      };
+    }
+    if (latest.status === "sending") {
+      return { ok: false as const, status: 409, error: "Campaign is already being sent" };
+    }
+
+    return { ok: false as const, status: 409, error: "Campaign changed before send started" };
+  }
+  const sendingCampaign = lockedCampaign;
+  const sendingContentMode = normalizeNewsletterContentMode(sendingCampaign.contentMode);
+
+  const recipients = await resolveRecipients(sendingCampaign.newsletterType as NewsletterType);
   if (recipients.length === 0) {
+    await db
+      .update(newsletterCampaigns)
+      .set({ status: campaign.status, updatedAt: new Date() })
+      .where(eq(newsletterCampaigns.id, sendingCampaign.id));
     return { ok: false as const, status: 409, error: "No active recipients for this campaign type" };
   }
   const activeRecipientIds = new Set(recipients.map((recipient) => recipient.id));
 
-  const now = new Date();
-  await db
-    .update(newsletterCampaigns)
-    .set({ status: "sending", failureReason: null, updatedAt: now })
-    .where(eq(newsletterCampaigns.id, campaign.id));
-
   const existingRecipients = await db
     .select()
     .from(newsletterCampaignRecipients)
-    .where(eq(newsletterCampaignRecipients.campaignId, campaign.id));
+    .where(eq(newsletterCampaignRecipients.campaignId, sendingCampaign.id));
   const existingBySubscriber = new Map(existingRecipients.map((row) => [row.subscriberId, row]));
 
   const pendingRecipientRows = recipients.filter((recipient) => !existingBySubscriber.has(recipient.id));
   if (pendingRecipientRows.length > 0) {
     await db.insert(newsletterCampaignRecipients).values(
       pendingRecipientRows.map((recipient) => ({
-        campaignId: campaign.id,
+        campaignId: sendingCampaign.id,
         subscriberId: recipient.id,
         email: recipient.email,
         status: "pending",
@@ -1148,10 +2058,10 @@ async function sendCampaignInternal(campaignId: string, force: boolean) {
   const campaignRecipients = await db
     .select()
     .from(newsletterCampaignRecipients)
-    .where(eq(newsletterCampaignRecipients.campaignId, campaign.id));
+    .where(eq(newsletterCampaignRecipients.campaignId, sendingCampaign.id));
 
-  const campaignType = campaign.newsletterType as NewsletterType;
-  const periodDays = campaign.periodDays || DEFAULT_CAMPAIGN_PERIOD_DAYS;
+  const campaignType = sendingCampaign.newsletterType as NewsletterType;
+  const periodDays = sendingCampaign.periodDays || DEFAULT_CAMPAIGN_PERIOD_DAYS;
   const [digest, templatePayload, recentNews] = await Promise.all([
     buildDigest(campaignType, periodDays),
     getNewsletterTemplatePayload(campaignType),
@@ -1185,7 +2095,7 @@ async function sendCampaignInternal(campaignId: string, force: boolean) {
     const unsubscribeToken = await createSubscriberToken({
       subscriberId: recipient.subscriberId,
       tokenType: "unsubscribe",
-      newsletterType: campaign.newsletterType as NewsletterType,
+      newsletterType: sendingCampaign.newsletterType as NewsletterType,
       expiresInHours: 24 * 365,
     });
     const preferencesToken = await createSubscriberToken({
@@ -1198,9 +2108,15 @@ async function sendCampaignInternal(campaignId: string, force: boolean) {
       unsubscribe: `${getBaseUrl()}/api/v1/newsletter/unsubscribe?token=${unsubscribeToken}`,
       preferences: `${getBaseUrl()}/api/v1/newsletter/preferences?token=${preferencesToken}`,
     };
-    const renderedTemplate = renderTemplateContent({
+    const renderedTemplate = resolveCampaignRenderContent({
+      campaign: {
+        campaignSubject: sendingCampaign.subject,
+        contentMode: sendingContentMode,
+        markdownContent: sendingCampaign.markdownContent,
+        manualHtml: sendingCampaign.manualHtml,
+        manualText: sendingCampaign.manualText,
+      },
       template: templatePayload,
-      campaignSubject: campaign.subject,
       campaignType,
       periodDays,
       digest,
@@ -1208,12 +2124,30 @@ async function sendCampaignInternal(campaignId: string, force: boolean) {
       recentNews,
       now: new Date(),
     });
+    if (!renderedTemplate.ok) {
+      failedCount += 1;
+      await db.transaction(async (tx) => {
+        await tx
+          .update(newsletterCampaignRecipients)
+          .set({ status: "failed", errorMessage: renderedTemplate.error, updatedAt: new Date() })
+          .where(eq(newsletterCampaignRecipients.id, recipient.id));
+
+        await tx.insert(newsletterSendEvents).values({
+          campaignId: sendingCampaign.id,
+          recipientId: recipient.id,
+          eventType: "failed",
+          provider: "resend",
+          payload: JSON.stringify({ email: recipient.email, error: renderedTemplate.error }),
+        });
+      });
+      continue;
+    }
 
     const emailResult = await sendEmail({
       to: recipient.email,
-      subject: renderedTemplate.subject,
-      html: renderedTemplate.html,
-      text: renderedTemplate.text,
+      subject: renderedTemplate.data.subject,
+      html: renderedTemplate.data.html,
+      text: renderedTemplate.data.text,
     });
 
     if (emailResult.success) {
@@ -1225,7 +2159,7 @@ async function sendCampaignInternal(campaignId: string, force: boolean) {
           .where(eq(newsletterCampaignRecipients.id, recipient.id));
 
         await tx.insert(newsletterSendEvents).values({
-          campaignId: campaign.id,
+          campaignId: sendingCampaign.id,
           recipientId: recipient.id,
           eventType: "sent",
           provider: "resend",
@@ -1244,7 +2178,7 @@ async function sendCampaignInternal(campaignId: string, force: boolean) {
         .where(eq(newsletterCampaignRecipients.id, recipient.id));
 
       await tx.insert(newsletterSendEvents).values({
-        campaignId: campaign.id,
+        campaignId: sendingCampaign.id,
         recipientId: recipient.id,
         eventType: "failed",
         provider: "resend",
@@ -1261,12 +2195,12 @@ async function sendCampaignInternal(campaignId: string, force: boolean) {
       failureReason: failedCount > 0 ? `${failedCount} recipients failed` : null,
       updatedAt: new Date(),
     })
-    .where(eq(newsletterCampaigns.id, campaign.id));
+    .where(eq(newsletterCampaigns.id, sendingCampaign.id));
 
   return {
     ok: true as const,
     data: {
-      campaignId: campaign.id,
+      campaignId: sendingCampaign.id,
       sent: sentCount,
       failed: failedCount,
       skipped: skippedCount,

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -85,8 +85,8 @@ const DEFAULT_NEWSLETTER_TEMPLATES: Record<NewsletterType, NewsletterTemplatePay
   news: {
     newsletterType: "news",
     subjectTemplate: "{{campaign_subject}}",
-    htmlTemplate: "{{default_html_body}}<hr /><h3>Recent News</h3>{{recent_news_html}}",
-    textTemplate: "{{default_text_body}}\n\nRecent News:\n{{recent_news_text}}",
+    htmlTemplate: "{{default_html_body}}",
+    textTemplate: "{{default_text_body}}",
   },
   jobs: {
     newsletterType: "jobs",

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -28,7 +28,7 @@ import {
 
 type SendResult = { success: true; messageId: string } | { success: false; error: string };
 
-type DigestItem = {
+export type DigestItem = {
   title: string;
   subtitle?: string;
   url?: string;
@@ -37,7 +37,7 @@ type DigestItem = {
   category?: string;
 };
 
-interface DigestGroup {
+export interface DigestGroup {
   category: string;
   label: string;
   items: DigestItem[];

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -18,6 +18,7 @@ import {
   getNewsClicksLast7Days,
 } from "@/services/posthog";
 import { getAllNews } from "@/lib/news";
+import { categoryLabels, type NewsCategory } from "@/data/news";
 import {
   NEWSLETTER_TYPES,
   type NewsletterType,
@@ -33,7 +34,14 @@ type DigestItem = {
   url?: string;
   currentViews?: number;
   delta?: number;
+  category?: string;
 };
+
+interface DigestGroup {
+  category: string;
+  label: string;
+  items: DigestItem[];
+}
 
 interface CampaignDigest {
   heading: string;
@@ -42,6 +50,7 @@ interface CampaignDigest {
   totalViews?: number;
   deltaViews?: number;
   items: DigestItem[];
+  groups?: DigestGroup[];
 }
 
 const DEFAULT_CAMPAIGN_PERIOD_DAYS = 7;
@@ -570,21 +579,35 @@ async function buildNewsDigest(periodDays: number): Promise<CampaignDigest> {
   const [allNews, clicksResult] = await Promise.all([getAllNews(), getNewsClicksLast7Days()]);
   const clickMap = new Map((clicksResult.success ? clicksResult.data : []).map((row) => [row.id, row.count]));
 
-  const items: DigestItem[] = allNews
-    .filter((item) => new Date(item.date) > cutoff)
-    .slice(0, 10)
-    .map((item) => ({
-      title: item.title,
-      subtitle: item.source || item.company || item.type,
-      url: item.url,
-      currentViews: clickMap.get(item.id) || 0,
-    }));
+  const filtered = allNews.filter((item) => new Date(item.date) > cutoff);
+
+  const items: DigestItem[] = filtered.slice(0, 20).map((item) => ({
+    title: item.title,
+    subtitle: item.source || item.company || item.type,
+    url: item.url,
+    currentViews: clickMap.get(item.id) || 0,
+    category: item.category,
+  }));
+
+  const groupMap = new Map<string, DigestItem[]>();
+  for (const item of items) {
+    const cat = item.category || "general";
+    if (!groupMap.has(cat)) groupMap.set(cat, []);
+    groupMap.get(cat)!.push(item);
+  }
+
+  const groups: DigestGroup[] = Array.from(groupMap.entries()).map(([cat, catItems]) => ({
+    category: cat,
+    label: categoryLabels[cat as NewsCategory] || cat,
+    items: catItems,
+  }));
 
   return {
     heading: "News digest",
     summary: `Recent highlights from the last ${periodDays} days.`,
     periodDays,
     items,
+    groups,
   };
 }
 

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -28,6 +28,7 @@ import {
   computeViewTotals,
   normalizeNewsletterContentMode,
 } from "@/lib/newsletter-utils";
+import { getRecommendedLinks, OTHER_CONTENT_I_LIKE } from "@/lib/recommendations";
 
 type SendResult = { success: true; messageId: string } | { success: false; error: string };
 
@@ -153,22 +154,7 @@ const LEGACY_NEWS_MARKDOWN_TEMPLATE = `## {{digest_heading}}
 
 const SUBSTACK_SANS_FONT_STACK = "'SF Pro Display', -apple-system, system-ui, BlinkMacSystemFont, 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'";
 const MONO_FONT_STACK = "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace";
-
-const RECOMMENDED_NEWSLETTERS: Array<{ name: string; url: string; description: string }> = [
-  { name: "TBPN", url: "https://tbpn.substack.com", description: "Technology Business Programming Network — daily live business & tech podcast by @johncoogan & @jordihays" },
-  { name: "SemiAnalysis", url: "https://semianalysis.com", description: "Deep dives on semiconductors, AI infrastructure, and compute" },
-  { name: "Ethereal News", url: "https://etherealnews.substack.com", description: "Ethereum ecosystem news and analysis" },
-  { name: "ZK Mesh", url: "https://zkmesh.substack.com", description: "Monthly zero-knowledge newsletter (zkmesh+ for premium)" },
-  { name: "dcbuilder.dev/news", url: "https://dcbuilder.dev/news", description: "Older curated links and announcements" },
-  { name: "dcbuilder.dev/blog", url: "https://dcbuilder.dev/blog", description: "Long-form thoughts and writeups" },
-  { name: "@dcbuilder on X", url: "https://x.com/dcbuilder", description: "More curated content on X" },
-];
-
-const OTHER_CONTENT_I_LIKE: Array<{ name: string; url: string; description: string }> = [
-  { name: "Zero Knowledge FM", url: "https://zeroknowledge.fm", description: "Podcast on ZK proofs and the decentralized web" },
-  { name: "TBPN Podcast", url: "https://tbpn.substack.com", description: "Daily live video & audio show on business and tech by @johncoogan & @jordihays" },
-  { name: "Hardcore History", url: "https://www.dancarlin.com/hardcore-history-series", description: "Dan Carlin's epic deep-dives into history" },
-];
+const NEWSLETTER_AVATAR_URL = "https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png";
 
 const FEATURED_CATEGORIES: Array<{ key: string; label: string }> = [
   { key: "ethereum", label: "Ethereum" },
@@ -807,12 +793,12 @@ function renderDigestItemsText(digest: CampaignDigest) {
 
 function renderWantMoreHtml() {
   const baseUrl = getBaseUrl();
-  const newslettersHtml = RECOMMENDED_NEWSLETTERS.map((nl) =>
-    `<li style="padding:6px 0"><a href="${nl.url}" style="color:#171717;text-decoration:underline;text-underline-offset:2px;text-decoration-color:#d4d4d4;font-weight:600;font-size:14px">${escapeHtml(nl.name)} &rarr;</a><span style="color:#a3a3a3;font-size:13px"> ${escapeHtml(nl.description)}</span></li>`
+  const newslettersHtml = getRecommendedLinks({ includeNewsletterExtras: true }).map((nl) =>
+    `<li style="padding:6px 0"><a href="${toAbsoluteUrl(nl.url)}" style="color:#171717;text-decoration:underline;text-underline-offset:2px;text-decoration-color:#d4d4d4;font-weight:600;font-size:14px">${escapeHtml(nl.name)} &rarr;</a><span style="color:#a3a3a3;font-size:13px"> ${escapeHtml(nl.description)}</span></li>`
   ).join("");
 
   const otherContentHtml = OTHER_CONTENT_I_LIKE.map((item) =>
-    `<li style="padding:6px 0"><a href="${item.url}" style="color:#171717;text-decoration:underline;text-underline-offset:2px;text-decoration-color:#d4d4d4;font-weight:600;font-size:14px">${escapeHtml(item.name)} &rarr;</a><span style="color:#a3a3a3;font-size:13px"> ${escapeHtml(item.description)}</span></li>`
+    `<li style="padding:6px 0"><a href="${toAbsoluteUrl(item.url)}" style="color:#171717;text-decoration:underline;text-underline-offset:2px;text-decoration-color:#d4d4d4;font-weight:600;font-size:14px">${escapeHtml(item.name)} &rarr;</a><span style="color:#a3a3a3;font-size:13px"> ${escapeHtml(item.description)}</span></li>`
   ).join("");
 
   const categoriesHtml = FEATURED_CATEGORIES.map((cat) =>
@@ -845,7 +831,7 @@ function renderDigestHtml(digest: CampaignDigest, links: { unsubscribe: string; 
     <div style="max-width:560px;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#171717;line-height:1.6">
       <div style="padding:32px 0 20px">
         <div style="width:64px;height:64px;border-radius:50%;overflow:hidden">
-          <img src="https://pub-a22f31a467534add843b6cf22cf4f443.r2.dev/dcbuilder.png" alt="dcbuilder.eth" width="64" height="64" style="display:block;width:64px;height:64px;object-fit:cover" />
+          <img src="${NEWSLETTER_AVATAR_URL}" alt="dcbuilder.eth" width="64" height="64" style="display:block;width:64px;height:64px;object-fit:cover" />
         </div>
       </div>
       <h1 style="font-size:24px;font-weight:800;margin:0 0 6px;color:#171717">${escapeHtml(digest.heading)}</h1>
@@ -862,11 +848,11 @@ function renderDigestHtml(digest: CampaignDigest, links: { unsubscribe: string; 
 }
 
 function renderWantMoreText() {
-  const newslettersText = RECOMMENDED_NEWSLETTERS.map((nl) =>
-    `- ${nl.name} — ${nl.description} (${nl.url})`
+  const newslettersText = getRecommendedLinks({ includeNewsletterExtras: true }).map((nl) =>
+    `- ${nl.name} — ${nl.description} (${toAbsoluteUrl(nl.url)})`
   ).join("\n");
   const otherText = OTHER_CONTENT_I_LIKE.map((item) =>
-    `- ${item.name} — ${item.description} (${item.url})`
+    `- ${item.name} — ${item.description} (${toAbsoluteUrl(item.url)})`
   ).join("\n");
   const categoriesText = FEATURED_CATEGORIES.map((cat) => cat.label).join(" · ");
   return `\n\nWant to read more?\n\nRecommended newsletters & links:\n${newslettersText}\n\nOther content I like:\n${otherText}\n\nBrowse by topic: ${categoriesText}\n${getBaseUrl()}/news`;
@@ -905,11 +891,11 @@ function renderRecentNewsMarkdown(recentNews: Awaited<ReturnType<typeof getRecen
 
 function renderWantMoreMarkdown() {
   const baseUrl = getBaseUrl();
-  const newslettersMd = RECOMMENDED_NEWSLETTERS.map((nl) =>
-    `- **[${nl.name}](${nl.url})** — ${nl.description}`
+  const newslettersMd = getRecommendedLinks({ includeNewsletterExtras: true }).map((nl) =>
+    `- **[${nl.name}](${toAbsoluteUrl(nl.url)})** — ${nl.description}`
   ).join("\n");
   const otherMd = OTHER_CONTENT_I_LIKE.map((item) =>
-    `- **[${item.name}](${item.url})** — ${item.description}`
+    `- **[${item.name}](${toAbsoluteUrl(item.url)})** — ${item.description}`
   ).join("\n");
   const categoriesMd = FEATURED_CATEGORIES.map((cat) =>
     `\`${cat.label}\``
@@ -939,6 +925,75 @@ function interpolateTemplate(template: string, values: Record<string, string>) {
   return template.replace(/{{\s*([a-z0-9_]+)\s*}}/gi, (_, key: string) => values[key] ?? "");
 }
 
+function stripMarkdownBold(value: string): string {
+  const trimmed = value.trim();
+  const match = trimmed.match(/^\*\*(.+)\*\*$/);
+  return match ? match[1] : trimmed;
+}
+
+function parseMarkdownLink(value: string): { label: string; url: string } | null {
+  const match = value.trim().match(/^\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)$/);
+  if (!match) return null;
+  return { label: match[1], url: match[2] };
+}
+
+function isLikelyMetricPiece(value: string): boolean {
+  return /(?:views?|opens?|clicks?|subscribers?|applications?|applies?)(?:\s|$)/i.test(value.trim());
+}
+
+function renderDigestMarkdownListItem(itemContent: string): string {
+  const parts = itemContent.includes(" · ")
+    ? itemContent.split(" · ").map((part) => part.trim()).filter(Boolean)
+    : itemContent.split(" | ").map((part) => part.trim()).filter(Boolean);
+
+  const linkPart = parts.at(-1);
+  const openLink = linkPart ? parseMarkdownLink(linkPart) : null;
+  const itemUrl = openLink?.label.toLowerCase() === "open" ? openLink.url : undefined;
+  const contentParts = itemUrl ? parts.slice(0, -1) : [...parts];
+  const rawTitle = contentParts.shift() || "Untitled";
+  const titleLink = parseMarkdownLink(stripMarkdownBold(rawTitle));
+  const title = titleLink?.label || stripMarkdownBold(rawTitle);
+  const url = titleLink?.url || itemUrl;
+
+  let metric = "";
+  const subtitleParts: string[] = [];
+
+  for (const part of contentParts) {
+    if (!metric && isLikelyMetricPiece(part)) {
+      metric = part;
+      continue;
+    }
+    subtitleParts.push(part);
+  }
+
+  const titleHtml = url
+    ? `<a href="${url}" style="color:#171717;text-decoration:underline;text-underline-offset:2px;text-decoration-color:#d4d4d4;font-weight:600;font-size:15px">${escapeHtml(title)}</a>`
+    : `<strong style="font-size:15px">${escapeHtml(title)}</strong>`;
+  const subtitle = subtitleParts.join(" · ");
+  const subtitleHtml = subtitle
+    ? `<div style="color:#525252;font-size:14px;margin-top:2px">${renderInlineMarkdown(subtitle)}</div>`
+    : "";
+  const metricHtml = metric
+    ? `<div style="color:#a3a3a3;font-size:12px;margin-top:2px">${escapeHtml(metric)}</div>`
+    : "";
+
+  return `<li style="padding:10px 0;border-bottom:1px solid #f5f5f5">${titleHtml}${subtitleHtml}${metricHtml}</li>`;
+}
+
+function renderWantMoreMarkdownListItem(itemContent: string): string {
+  const emphasizedLinkMatch = itemContent.match(/^\*\*\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)\*\*\s+[—-]\s+(.+)$/);
+  if (emphasizedLinkMatch) {
+    const [, label, url, description] = emphasizedLinkMatch;
+    return `<li style="padding:6px 0"><a href="${url}" style="color:#171717;text-decoration:underline;text-underline-offset:2px;text-decoration-color:#d4d4d4;font-weight:600;font-size:14px">${escapeHtml(label)} &rarr;</a><span style="color:#a3a3a3;font-size:13px"> ${renderInlineMarkdown(description)}</span></li>`;
+  }
+
+  return `<li style="padding:6px 0;font-size:14px;line-height:1.7;color:#525252;">${renderInlineMarkdown(itemContent)}</li>`;
+}
+
+function renderNewsletterFooterHtml(value: string): string {
+  return `<p style="margin:0;font-size:12px;color:#a3a3a3">${renderInlineMarkdown(value.replace(/\s+\|\s+/g, " · "))}</p>`;
+}
+
 function renderInlineMarkdown(value: string): string {
   let html = escapeHtml(value);
 
@@ -950,31 +1005,58 @@ function renderInlineMarkdown(value: string): string {
   return html;
 }
 
-function markdownToHtml(markdown: string): string {
+export function markdownToHtml(markdown: string): string {
   const lines = markdown.replace(/\r\n/g, "\n").split("\n");
   const output: string[] = [];
   let paragraphLines: string[] = [];
   let listItems: string[] = [];
-  let listLooksLikeDigest = false;
+  let listMode: "plain" | "digest" | "wantMore" = "plain";
   let quoteLines: string[] = [];
   let inCodeBlock = false;
   let codeLines: string[] = [];
+  let sawPrimaryHeading = false;
+  let expectingSummary = false;
+  let inWantMoreCard = false;
+  let footerHtml = "";
+  let pendingDivider = false;
 
   const flushParagraph = () => {
     if (paragraphLines.length === 0) return;
-    output.push(`<p style="margin:0 0 14px;font-size:16px;line-height:1.75;color:#1f1f1f;">${paragraphLines.join("<br />")}</p>`);
+    const html = paragraphLines.join("<br />");
+
+    if (expectingSummary) {
+      output.push(`<p style="margin:0 0 20px;color:#737373;font-size:15px">${html}</p>`);
+      paragraphLines = [];
+      expectingSummary = false;
+      return;
+    }
+
+    const sectionLabel = !html.includes("href=") ? html.match(/^<strong>(.+)<\/strong>$/) : null;
+    if (inWantMoreCard && sectionLabel) {
+      output.push(`<p style="margin:0 0 12px;font-size:13px;font-weight:700;color:#a3a3a3;text-transform:uppercase;letter-spacing:0.05em">${sectionLabel[1]}</p>`);
+      paragraphLines = [];
+      return;
+    }
+
+    output.push(
+      inWantMoreCard
+        ? `<p style="margin:0 0 14px;font-size:14px;line-height:1.7;color:#525252;">${html}</p>`
+        : `<p style="margin:0 0 14px;font-size:16px;line-height:1.75;color:#1f1f1f;">${html}</p>`
+    );
     paragraphLines = [];
   };
 
   const flushList = () => {
     if (listItems.length === 0) return;
     output.push(
-      listLooksLikeDigest
-        ? `<ul style="margin:0 0 18px;padding:0;list-style:none;">${listItems.join("")}</ul>`
-        : `<ul style="margin:0 0 18px;padding:0 0 0 20px;">${listItems.join("")}</ul>`
+      listMode === "digest"
+        ? `<ul style="list-style:none;padding:0;margin:0">${listItems.join("")}</ul>`
+        : listMode === "wantMore"
+          ? `<ul style="list-style:none;padding:0;margin:0 0 20px">${listItems.join("")}</ul>`
+          : `<ul style="margin:0 0 18px;padding:0 0 0 20px;">${listItems.join("")}</ul>`
     );
     listItems = [];
-    listLooksLikeDigest = false;
+    listMode = "plain";
   };
 
   const flushQuote = () => {
@@ -987,6 +1069,13 @@ function markdownToHtml(markdown: string): string {
     flushParagraph();
     flushList();
     flushQuote();
+  };
+
+  const closeWantMoreCard = () => {
+    if (!inWantMoreCard) return;
+    flushAll();
+    output.push("</div>");
+    inWantMoreCard = false;
   };
 
   for (const rawLine of lines) {
@@ -1003,6 +1092,14 @@ function markdownToHtml(markdown: string): string {
       continue;
     }
 
+    if (trimmed && pendingDivider) {
+      const nextIsWantMore = /^#{1,6}\s+want to read more\??$/i.test(trimmed);
+      if (!nextIsWantMore) {
+        output.push("<hr style=\"border:0;border-top:1px solid #e5e5e5;margin:20px 0;\" />");
+      }
+      pendingDivider = false;
+    }
+
     if (trimmed.startsWith("```")) {
       flushAll();
       inCodeBlock = true;
@@ -1016,7 +1113,7 @@ function markdownToHtml(markdown: string): string {
 
     if (/^(---|\*\*\*)$/.test(trimmed)) {
       flushAll();
-      output.push("<hr style=\"border:0;border-top:1px solid #e5e5e5;margin:20px 0;\" />");
+      pendingDivider = true;
       continue;
     }
 
@@ -1024,9 +1121,25 @@ function markdownToHtml(markdown: string): string {
     if (headingMatch) {
       flushAll();
       const level = headingMatch[1].length;
-      const fontSizeByLevel = [0, 34, 30, 24, 20, 18, 16];
+      const headingText = headingMatch[2].trim();
+      if (!sawPrimaryHeading && level <= 2) {
+        output.push(`<h1 style="font-size:24px;font-weight:800;margin:0 0 6px;color:#171717">${renderInlineMarkdown(headingText)}</h1>`);
+        sawPrimaryHeading = true;
+        expectingSummary = true;
+        continue;
+      }
+
+      if (/^want to read more\??$/i.test(headingText)) {
+        closeWantMoreCard();
+        output.push('<div style="margin:32px 0 0;padding:24px;background:#fafafa;border-radius:12px">');
+        output.push(`<h2 style="font-size:18px;font-weight:800;margin:0 0 16px;color:#171717">${renderInlineMarkdown(headingText)}</h2>`);
+        inWantMoreCard = true;
+        continue;
+      }
+
+      const fontSizeByLevel = [0, 34, 24, 18, 16, 15, 14];
       const headingSize = fontSizeByLevel[level] ?? 16;
-      output.push(`<h${level} style="margin:20px 0 10px;font-family:${SUBSTACK_SANS_FONT_STACK};font-size:${headingSize}px;line-height:1.22;font-weight:700;color:#111111;">${renderInlineMarkdown(headingMatch[2])}</h${level}>`);
+      output.push(`<h${level} style="margin:20px 0 10px;font-family:${SUBSTACK_SANS_FONT_STACK};font-size:${headingSize}px;line-height:1.22;font-weight:700;color:#111111;">${renderInlineMarkdown(headingText)}</h${level}>`);
       continue;
     }
 
@@ -1035,14 +1148,13 @@ function markdownToHtml(markdown: string): string {
       flushParagraph();
       flushQuote();
       const itemContent = listMatch[1];
-      const isDigestItem = itemContent.includes(" · ") || itemContent.includes("|");
+      const isDigestItem = !inWantMoreCard && (itemContent.includes(" · ") || itemContent.includes("|"));
       if (isDigestItem) {
-        listLooksLikeDigest = true;
-        listItems.push(
-          `<li style="margin:0 0 10px;padding:14px 16px;border:1px solid #e5e5e5;background:#fafafa;">
-            <div style="font-size:16px;line-height:1.65;color:#1f1f1f;">${renderInlineMarkdown(itemContent)}</div>
-          </li>`
-        );
+        listMode = "digest";
+        listItems.push(renderDigestMarkdownListItem(itemContent));
+      } else if (inWantMoreCard) {
+        listMode = "wantMore";
+        listItems.push(renderWantMoreMarkdownListItem(itemContent));
       } else {
         listItems.push(`<li style="margin:0 0 10px;font-size:16px;line-height:1.75;color:#1f1f1f;">${renderInlineMarkdown(itemContent)}</li>`);
       }
@@ -1057,6 +1169,15 @@ function markdownToHtml(markdown: string): string {
       continue;
     }
 
+    if (trimmed.includes("[Manage preferences](") && trimmed.includes("[Unsubscribe](")) {
+      flushList();
+      flushQuote();
+      flushParagraph();
+      closeWantMoreCard();
+      footerHtml = renderNewsletterFooterHtml(trimmed);
+      continue;
+    }
+
     flushList();
     flushQuote();
     paragraphLines.push(renderInlineMarkdown(trimmed));
@@ -1066,10 +1187,25 @@ function markdownToHtml(markdown: string): string {
     output.push(`<pre style="margin:0 0 18px;padding:12px 14px;border:1px solid #e5e5e5;background:#fafafa;overflow:auto;"><code style="font-family:${MONO_FONT_STACK};font-size:13px;line-height:1.6;color:#171717;">${escapeHtml(codeLines.join("\n"))}</code></pre>`);
   }
 
+  if (pendingDivider) {
+    output.push("<hr style=\"border:0;border-top:1px solid #e5e5e5;margin:20px 0;\" />");
+  }
+
   flushAll();
+  closeWantMoreCard();
   const html = output.join("\n").trim();
   if (!html) return "";
-  return `<div style="font-family:${SUBSTACK_SANS_FONT_STACK};color:#111111;">${html}</div>`;
+  return `
+    <div style="max-width:560px;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#171717;line-height:1.6">
+      <div style="padding:32px 0 20px">
+        <div style="width:64px;height:64px;border-radius:50%;overflow:hidden">
+          <img src="${NEWSLETTER_AVATAR_URL}" alt="dcbuilder.eth" width="64" height="64" style="display:block;width:64px;height:64px;object-fit:cover" />
+        </div>
+      </div>
+      ${html}
+      ${footerHtml ? `<hr style="border:none;border-top:1px solid #e5e5e5;margin:32px 0 16px" />${footerHtml}` : ""}
+    </div>
+  `.trim();
 }
 
 function htmlToText(html: string): string {
@@ -1964,7 +2100,7 @@ async function sendCampaignInternal(campaignId: string, force: boolean) {
   if (campaign.status === "sent") {
     return { ok: true as const, data: { campaign, sent: 0, failed: 0, skipped: 0, alreadySent: true } };
   }
-  if (campaign.status === "sending") {
+  if (campaign.status === "sending" && !force) {
     return { ok: false as const, status: 409, error: "Campaign is already being sent" };
   }
   if (!force && campaign.status === "scheduled" && campaign.scheduledAt && campaign.scheduledAt > new Date()) {

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -85,7 +85,7 @@ const DEFAULT_NEWSLETTER_TEMPLATES: Record<NewsletterType, NewsletterTemplatePay
   news: {
     newsletterType: "news",
     subjectTemplate: "{{campaign_subject}}",
-    htmlTemplate: "{{default_html_body}}<hr /><h3>Recent News</h3><ul>{{recent_news_html}}</ul>",
+    htmlTemplate: "{{default_html_body}}<hr /><h3>Recent News</h3>{{recent_news_html}}",
     textTemplate: "{{default_text_body}}\n\nRecent News:\n{{recent_news_text}}",
   },
   jobs: {
@@ -622,6 +622,23 @@ async function buildDigest(newsletterType: NewsletterType, periodDays: number): 
 }
 
 function renderDigestItemsHtml(digest: CampaignDigest) {
+  if (digest.groups && digest.groups.length > 0) {
+    return digest.groups.map((group) => {
+      const itemsHtml = group.items.map((item) => {
+        const metric = item.currentViews !== undefined
+          ? `${item.currentViews} views${item.delta !== undefined ? ` (${item.delta >= 0 ? "+" : ""}${item.delta})` : ""}`
+          : "";
+        const line = [
+          `<strong>${escapeHtml(item.title)}</strong>`,
+          item.subtitle ? `<span>${escapeHtml(item.subtitle)}</span>` : "",
+          metric ? `<span>${escapeHtml(metric)}</span>` : "",
+        ].filter(Boolean).join(" · ");
+        return item.url ? `<li><a href="${item.url}">${line}</a></li>` : `<li>${line}</li>`;
+      }).join("");
+      return `<h4>${escapeHtml(group.label)}</h4><ul>${itemsHtml}</ul>`;
+    }).join("");
+  }
+
   return digest.items.length
     ? digest.items.map((item) => {
       const metric = item.currentViews !== undefined
@@ -631,18 +648,28 @@ function renderDigestItemsHtml(digest: CampaignDigest) {
         `<strong>${escapeHtml(item.title)}</strong>`,
         item.subtitle ? `<span>${escapeHtml(item.subtitle)}</span>` : "",
         metric ? `<span>${escapeHtml(metric)}</span>` : "",
-      ]
-        .filter(Boolean)
-        .join(" · ");
-      if (item.url) {
-        return `<li><a href="${item.url}">${line}</a></li>`;
-      }
+      ].filter(Boolean).join(" · ");
+      if (item.url) return `<li><a href="${item.url}">${line}</a></li>`;
       return `<li>${line}</li>`;
     }).join("")
     : "<li>No items available for this period.</li>";
 }
 
 function renderDigestItemsText(digest: CampaignDigest) {
+  if (digest.groups && digest.groups.length > 0) {
+    return digest.groups.map((group) => {
+      const header = `\n## ${group.label}`;
+      const items = group.items.map((item) => {
+        const metric = item.currentViews !== undefined
+          ? `${item.currentViews} views${item.delta !== undefined ? ` (${item.delta >= 0 ? "+" : ""}${item.delta})` : ""}`
+          : "";
+        const parts = [item.title, item.subtitle, metric, item.url].filter(Boolean);
+        return `- ${parts.join(" | ")}`;
+      }).join("\n");
+      return `${header}\n${items}`;
+    }).join("\n");
+  }
+
   return digest.items.length > 0
     ? digest.items.map((item) => {
       const metric = item.currentViews !== undefined
@@ -660,11 +687,15 @@ function renderDigestHtml(digest: CampaignDigest, links: { unsubscribe: string; 
     ? `<p><strong>Total views:</strong> ${digest.totalViews}${digest.deltaViews !== undefined ? ` (${digest.deltaViews >= 0 ? "+" : ""}${digest.deltaViews} vs previous period)` : ""}</p>`
     : "";
 
+  const body = digest.groups && digest.groups.length > 0
+    ? itemsHtml
+    : `<ul>${itemsHtml}</ul>`;
+
   return `
     <h2>${escapeHtml(digest.heading)}</h2>
     <p>${escapeHtml(digest.summary)}</p>
     ${totals}
-    <ul>${itemsHtml}</ul>
+    ${body}
     <hr />
     <p><a href="${links.preferences}">Manage preferences</a> · <a href="${links.unsubscribe}">Unsubscribe</a></p>
   `;
@@ -690,21 +721,45 @@ async function getRecentNewsSnapshot(limit: number = 8) {
     date: item.date,
     type: item.type,
     source: item.source || item.company || item.type,
+    category: item.category,
   }));
 }
 
 function renderRecentNewsHtml(recentNews: Awaited<ReturnType<typeof getRecentNewsSnapshot>>) {
-  return recentNews.length > 0
-    ? recentNews.map((item) => (
+  if (recentNews.length === 0) return "<li>No recent news available.</li>";
+
+  const groupMap = new Map<string, typeof recentNews>();
+  for (const item of recentNews) {
+    const cat = item.category || "general";
+    if (!groupMap.has(cat)) groupMap.set(cat, []);
+    groupMap.get(cat)!.push(item);
+  }
+
+  return Array.from(groupMap.entries()).map(([cat, items]) => {
+    const label = categoryLabels[cat as NewsCategory] || cat;
+    const itemsHtml = items.map((item) =>
       `<li><a href="${item.url}"><strong>${escapeHtml(item.title)}</strong></a> · ${escapeHtml(item.source)} · ${escapeHtml(item.date)}</li>`
-    )).join("")
-    : "<li>No recent news available.</li>";
+    ).join("");
+    return `<h4>${escapeHtml(label)}</h4><ul>${itemsHtml}</ul>`;
+  }).join("");
 }
 
 function renderRecentNewsText(recentNews: Awaited<ReturnType<typeof getRecentNewsSnapshot>>) {
-  return recentNews.length > 0
-    ? recentNews.map((item) => `- ${item.title} | ${item.source} | ${item.date} | ${item.url}`).join("\n")
-    : "- No recent news available.";
+  if (recentNews.length === 0) return "- No recent news available.";
+
+  const groupMap = new Map<string, typeof recentNews>();
+  for (const item of recentNews) {
+    const cat = item.category || "general";
+    if (!groupMap.has(cat)) groupMap.set(cat, []);
+    groupMap.get(cat)!.push(item);
+  }
+
+  return Array.from(groupMap.entries()).map(([cat, items]) => {
+    const label = categoryLabels[cat as NewsCategory] || cat;
+    const header = `\n## ${label}`;
+    const lines = items.map((item) => `- ${item.title} | ${item.source} | ${item.date} | ${item.url}`).join("\n");
+    return `${header}\n${lines}`;
+  }).join("\n");
 }
 
 async function getNewsletterTemplatePayload(newsletterType: NewsletterType): Promise<NewsletterTemplatePayload> {

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -1223,6 +1223,19 @@ function htmlToText(html: string): string {
     .trim();
 }
 
+function markdownToText(markdown: string): string {
+  return markdown
+    .replace(/\r\n/g, "\n")
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, "$1 ($2)")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^>\s?/gm, "")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 async function getRecentNewsSnapshot(limit: number = 8) {
   const allNews = await getAllNews();
   return allNews.slice(0, limit).map((item) => ({
@@ -1471,7 +1484,7 @@ function resolveCampaignRenderContent(params: {
     }
 
     const html = markdownToHtml(renderedMarkdown);
-    const text = htmlToText(html);
+    const text = markdownToText(renderedMarkdown);
     return {
       ok: true as const,
       data: {
@@ -2167,7 +2180,12 @@ async function sendCampaignInternal(campaignId: string, force: boolean) {
   if (recipients.length === 0) {
     await db
       .update(newsletterCampaigns)
-      .set({ status: campaign.status, updatedAt: new Date() })
+      .set({
+        status: "failed",
+        sentAt: null,
+        failureReason: "No active recipients for this campaign type",
+        updatedAt: new Date(),
+      })
       .where(eq(newsletterCampaigns.id, sendingCampaign.id));
     return { ok: false as const, status: 409, error: "No active recipients for this campaign type" };
   }

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -1262,21 +1262,6 @@ export function markdownToHtml(markdown: string): string {
   `.trim();
 }
 
-function htmlToText(html: string): string {
-  return html
-    .replace(/<\s*br\s*\/?>/gi, "\n")
-    .replace(/<\s*\/p\s*>/gi, "\n\n")
-    .replace(/<[^>]*>/g, "")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, "\"")
-    .replace(/&#39;/g, "'")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
 function markdownToText(markdown: string): string {
   return markdown
     .replace(/\r\n/g, "\n")

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -520,6 +520,60 @@ export async function updatePreferencesByToken(token: string, newsletterTypes: s
   return { ok: true as const };
 }
 
+export async function adminUpdateSubscriberPreferences(subscriberId: string, newsletterTypes: string[]) {
+  const [subscriber] = await db
+    .select()
+    .from(newsletterSubscribers)
+    .where(eq(newsletterSubscribers.id, subscriberId))
+    .limit(1);
+
+  if (!subscriber) {
+    return { ok: false as const, status: 404, error: "Subscriber not found" };
+  }
+
+  const selected = dedupeNewsletterTypes(newsletterTypes);
+  await upsertPreferences(subscriberId, selected);
+
+  const now = new Date();
+  const nextStatus =
+    subscriber.status === "pending"
+      ? "pending"
+      : selected.length > 0
+        ? "active"
+        : "unsubscribed";
+  const nextUnsubscribedAt =
+    subscriber.status === "pending"
+      ? subscriber.unsubscribedAt
+      : selected.length > 0
+        ? null
+        : now;
+
+  await db
+    .update(newsletterSubscribers)
+    .set({
+      status: nextStatus,
+      unsubscribedAt: nextUnsubscribedAt,
+      updatedAt: now,
+    })
+    .where(eq(newsletterSubscribers.id, subscriberId));
+
+  return {
+    ok: true as const,
+    data: {
+      subscriber: {
+        ...subscriber,
+        status: nextStatus,
+        unsubscribedAt: nextUnsubscribedAt,
+        updatedAt: now,
+      },
+      preferences: NEWSLETTER_TYPES.map((newsletterType) => ({
+        newsletterType,
+        enabled: selected.includes(newsletterType),
+      })),
+    },
+  };
+}
+
 export async function unsubscribeByToken(token: string) {
   const record = await getValidToken(token, "unsubscribe");
   if (!record) {

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -2067,6 +2067,39 @@ async function sendCampaignInternal(campaignId: string, force: boolean) {
     getNewsletterTemplatePayload(campaignType),
     getRecentNewsSnapshot(8),
   ]);
+
+  // Render a canonical archive version (generic links, no per-user tokens)
+  const archiveLinks = {
+    unsubscribe: `${getBaseUrl()}/newsletters`,
+    preferences: `${getBaseUrl()}/newsletters`,
+  };
+  const archiveRendered = resolveCampaignRenderContent({
+    campaign: {
+      campaignSubject: sendingCampaign.subject,
+      contentMode: sendingContentMode,
+      markdownContent: sendingCampaign.markdownContent,
+      manualHtml: sendingCampaign.manualHtml,
+      manualText: sendingCampaign.manualText,
+    },
+    template: templatePayload,
+    campaignType,
+    periodDays,
+    digest,
+    links: archiveLinks,
+    recentNews,
+    now: new Date(),
+  });
+  if (archiveRendered.ok) {
+    await db
+      .update(newsletterCampaigns)
+      .set({
+        renderedHtml: archiveRendered.data.html,
+        renderedText: archiveRendered.data.text,
+        updatedAt: new Date(),
+      })
+      .where(eq(newsletterCampaigns.id, sendingCampaign.id));
+  }
+
   let sentCount = 0;
   let failedCount = 0;
   let skippedCount = 0;
@@ -2239,4 +2272,49 @@ export async function sendDueNewsletterCampaigns() {
       results,
     },
   };
+}
+
+// ---------------------------------------------------------------------------
+// Public archive queries
+// ---------------------------------------------------------------------------
+
+export async function listSentNewsletterCampaigns(limit: number = 50) {
+  return db
+    .select({
+      id: newsletterCampaigns.id,
+      subject: newsletterCampaigns.subject,
+      previewText: newsletterCampaigns.previewText,
+      newsletterType: newsletterCampaigns.newsletterType,
+      sentAt: newsletterCampaigns.sentAt,
+    })
+    .from(newsletterCampaigns)
+    .where(eq(newsletterCampaigns.status, "sent"))
+    .orderBy(desc(newsletterCampaigns.sentAt))
+    .limit(limit);
+}
+
+export async function getSentNewsletterCampaignForArchive(id: string) {
+  const [campaign] = await db
+    .select({
+      id: newsletterCampaigns.id,
+      subject: newsletterCampaigns.subject,
+      previewText: newsletterCampaigns.previewText,
+      newsletterType: newsletterCampaigns.newsletterType,
+      sentAt: newsletterCampaigns.sentAt,
+      renderedHtml: newsletterCampaigns.renderedHtml,
+    })
+    .from(newsletterCampaigns)
+    .where(
+      and(
+        eq(newsletterCampaigns.id, id),
+        eq(newsletterCampaigns.status, "sent")
+      )
+    )
+    .limit(1);
+
+  if (!campaign || !campaign.renderedHtml) {
+    return null;
+  }
+
+  return campaign;
 }

--- a/src/services/posthog.ts
+++ b/src/services/posthog.ts
@@ -193,10 +193,18 @@ export function determineHotCandidates(
 }
 
 // News analytics - count news_click events by news_id
-export async function getNewsClicksLast7Days(): Promise<PostHogResult<ClickCount[]>> {
+export async function getNewsClicksForWindow(
+  days: number = 7,
+  offsetDays: number = 0
+): Promise<PostHogResult<ClickCount[]>> {
   if (!POSTHOG_API_KEY || !POSTHOG_PROJECT_ID) {
     return { success: false, error: "PostHog not configured", configured: false };
   }
+
+  const safeDays = sanitizeWindow(days, 7);
+  const safeOffsetDays = sanitizeOffset(offsetDays);
+  const upperBoundClause =
+    safeOffsetDays > 0 ? `AND timestamp <= now() - INTERVAL ${safeOffsetDays} DAY` : "";
 
   const query = `
     SELECT
@@ -204,7 +212,8 @@ export async function getNewsClicksLast7Days(): Promise<PostHogResult<ClickCount
       count() as count
     FROM events
     WHERE event = 'news_click'
-      AND timestamp > now() - INTERVAL 7 DAY
+      AND timestamp > now() - INTERVAL ${safeDays + safeOffsetDays} DAY
+      ${upperBoundClause}
       AND properties.news_id IS NOT NULL
     GROUP BY properties.news_id
     ORDER BY count DESC
@@ -221,6 +230,10 @@ export async function getNewsClicksLast7Days(): Promise<PostHogResult<ClickCount
   }));
 
   return { success: true, data: result };
+}
+
+export async function getNewsClicksLast7Days(): Promise<PostHogResult<ClickCount[]>> {
+  return getNewsClicksForWindow(7, 0);
 }
 
 // Blog analytics - count pageviews on /blog/* paths

--- a/src/services/posthog.ts
+++ b/src/services/posthog.ts
@@ -269,6 +269,45 @@ export function determineHotNews(
     .map((c) => c.id);
 }
 
+// Email click analytics - count email_link_clicked events by distinct_id (email)
+export type EmailClickRow = {
+  email: string;
+  count: number;
+  lastClickedLink: string;
+};
+
+export async function getEmailClicksLast7Days(): Promise<PostHogResult<EmailClickRow[]>> {
+  if (!POSTHOG_API_KEY || !POSTHOG_PROJECT_ID) {
+    return { success: false, error: "PostHog not configured", configured: false };
+  }
+
+  const query = `
+    SELECT
+      distinct_id as email,
+      count() as count,
+      argMax(properties.$current_url, timestamp) as lastClickedLink
+    FROM events
+    WHERE event = 'email_link_clicked'
+      AND timestamp > now() - INTERVAL 7 DAY
+    GROUP BY distinct_id
+    ORDER BY count DESC
+    LIMIT 100
+  `;
+
+  const data = await runHogQLQuery(query);
+  if (!data) {
+    return { success: false, error: "Failed to query PostHog", configured: true };
+  }
+
+  const result: EmailClickRow[] = data.results.map((row) => ({
+    email: String(row[0]),
+    count: Number(row[1]),
+    lastClickedLink: String(row[2] ?? ""),
+  }));
+
+  return { success: true, data: result };
+}
+
 // Site-wide analytics
 export async function getSiteStats(): Promise<SiteStats> {
   if (!POSTHOG_API_KEY || !POSTHOG_PROJECT_ID) {

--- a/tests/candidates.spec.ts
+++ b/tests/candidates.spec.ts
@@ -1,4 +1,7 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+
+const candidateCards = (page: Page) =>
+  page.locator('[data-testid="candidate-card"]');
 
 test.describe("Candidates Page", () => {
   test.beforeEach(async ({ page }) => {
@@ -114,7 +117,7 @@ test.describe("HOT/TOP Badge Display", () => {
 
   test("should display both HOT and TOP badges when candidate has both tags", async ({ page }) => {
     // Find cards that have both badges
-    const cards = page.locator('.rounded-xl.border');
+    const cards = candidateCards(page);
     const cardCount = await cards.count();
 
     for (let i = 0; i < cardCount; i++) {
@@ -142,7 +145,7 @@ test.describe("HOT/TOP Badge Display", () => {
     });
 
     // Find cards with HOT badge
-    const hotCards = page.locator('.rounded-xl.border:has(span:has-text("🔥 HOT"))');
+    const hotCards = candidateCards(page).filter({ has: page.locator('span:has-text("🔥 HOT")') });
     const count = await hotCards.count();
 
     if (count > 0) {
@@ -169,13 +172,13 @@ test.describe("HOT/TOP Badge Display", () => {
         await page.waitForTimeout(300);
 
         // All visible candidates should have the hot tag badge
-        const candidateCards = page.locator('.rounded-xl.border');
-        const count = await candidateCards.count();
+        const cards = candidateCards(page);
+        const count = await cards.count();
 
         // If there are results, each should have HOT badge
         if (count > 0) {
           for (let i = 0; i < Math.min(count, 3); i++) {
-            const card = candidateCards.nth(i);
+            const card = cards.nth(i);
             await expect(card.locator('span:has-text("🔥 HOT")')).toBeVisible();
           }
         }
@@ -200,13 +203,13 @@ test.describe("HOT/TOP Badge Display", () => {
         await page.waitForTimeout(300);
 
         // All visible candidates should have the top tag badge
-        const candidateCards = page.locator('.rounded-xl.border');
-        const count = await candidateCards.count();
+        const cards = candidateCards(page);
+        const count = await cards.count();
 
         // If there are results, each should have TOP badge
         if (count > 0) {
           for (let i = 0; i < Math.min(count, 3); i++) {
-            const card = candidateCards.nth(i);
+            const card = cards.nth(i);
             await expect(card.locator('span:has-text("✨ TOP")')).toBeVisible();
           }
         }
@@ -252,7 +255,7 @@ test.describe("Candidate Card Expanded View Badges", () => {
 
   test("expanded view header should have correct gradient for HOT candidates", async ({ page }) => {
     // Find a HOT candidate card
-    const hotCard = page.locator('.rounded-xl.border:has(span:has-text("🔥 HOT"))').first();
+    const hotCard = candidateCards(page).filter({ has: page.locator('span:has-text("🔥 HOT")') }).first();
 
     if (await hotCard.isVisible()) {
       // Click View Details
@@ -277,7 +280,7 @@ test.describe("Candidate Card Expanded View Badges", () => {
     ).catch(() => {});
 
     // Find a card that has TOP but not HOT badge
-    const cards = page.locator('.rounded-xl.border');
+    const cards = candidateCards(page);
     const cardCount = await cards.count();
 
     for (let i = 0; i < cardCount; i++) {

--- a/tests/hot-jobs-route.test.ts
+++ b/tests/hot-jobs-route.test.ts
@@ -6,6 +6,7 @@ describe("GET /api/hot-jobs", () => {
   });
 
   test("returns hot job ids without querying the jobs table", async () => {
+    const actualPosthog = await import("../src/services/posthog");
     const getJobApplyClicksLast7Days = mock(async () => ({
       success: true as const,
       data: [
@@ -14,17 +15,11 @@ describe("GET /api/hot-jobs", () => {
       ],
     }));
     const determineHotJobs = mock(() => ["wonderland-solidity-developer"]);
-    const select = mock(() => {
-      throw new Error("jobs table should not be queried");
-    });
 
     mock.module("@/services/posthog", () => ({
+      ...actualPosthog,
       getJobApplyClicksLast7Days,
       determineHotJobs,
-    }));
-    mock.module("@/db", () => ({
-      db: { select },
-      jobs: { id: "id" },
     }));
 
     const { GET } = await import("../src/app/api/hot-jobs/route");
@@ -42,6 +37,5 @@ describe("GET /api/hot-jobs", () => {
       ],
       5,
     );
-    expect(select).not.toHaveBeenCalled();
   });
 });

--- a/tests/hot-jobs-route.test.ts
+++ b/tests/hot-jobs-route.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("GET /api/hot-jobs", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("returns hot job ids without querying the jobs table", async () => {
+    const getJobApplyClicksLast7Days = mock(async () => ({
+      success: true as const,
+      data: [
+        { id: "wonderland-solidity-developer", count: 12 },
+        { id: "stale-job-id", count: 7 },
+      ],
+    }));
+    const determineHotJobs = mock(() => ["wonderland-solidity-developer"]);
+    const select = mock(() => {
+      throw new Error("jobs table should not be queried");
+    });
+
+    mock.module("@/services/posthog", () => ({
+      getJobApplyClicksLast7Days,
+      determineHotJobs,
+    }));
+    mock.module("@/db", () => ({
+      db: { select },
+      jobs: { id: "id" },
+    }));
+
+    const { GET } = await import("../src/app/api/hot-jobs/route");
+    const response = await GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.hotJobIds).toEqual(["wonderland-solidity-developer"]);
+    expect(typeof payload.updatedAt).toBe("string");
+    expect(getJobApplyClicksLast7Days).toHaveBeenCalledTimes(1);
+    expect(determineHotJobs).toHaveBeenCalledWith(
+      [
+        { id: "wonderland-solidity-developer", count: 12 },
+        { id: "stale-job-id", count: 7 },
+      ],
+      5,
+    );
+    expect(select).not.toHaveBeenCalled();
+  });
+});

--- a/tests/hot-news-route.test.ts
+++ b/tests/hot-news-route.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("GET /api/hot-news", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("returns hot news ids alongside click counts", async () => {
+    const actualPosthog = await import("../src/services/posthog");
+    const getNewsClicksLast7Days = mock(async () => ({
+      success: true as const,
+      data: [
+        { id: "news-1", count: 14 },
+        { id: "news-2", count: 3 },
+      ],
+    }));
+    const determineHotNews = mock(() => ["news-1"]);
+
+    mock.module("@/services/posthog", () => ({
+      ...actualPosthog,
+      getNewsClicksLast7Days,
+      determineHotNews,
+    }));
+
+    const { GET } = await import("../src/app/api/hot-news/route");
+    const response = await GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.hotNewsIds).toEqual(["news-1"]);
+    expect(payload.clickCounts).toEqual({
+      "news-1": 14,
+      "news-2": 3,
+    });
+    expect(typeof payload.updatedAt).toBe("string");
+    expect(getNewsClicksLast7Days).toHaveBeenCalledTimes(1);
+    expect(determineHotNews).toHaveBeenCalledWith(
+      [
+        { id: "news-1", count: 14 },
+        { id: "news-2", count: 3 },
+      ],
+      5,
+    );
+  });
+});

--- a/tests/news-tools.test.ts
+++ b/tests/news-tools.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { getNewsToolsRecommendationSummary } from "../src/lib/news-tools";
+
+describe("getNewsToolsRecommendationSummary", () => {
+  test("prioritizes The MEV Letter in the compact highlights", () => {
+    const summary = getNewsToolsRecommendationSummary();
+
+    expect(summary.highlights).toHaveLength(4);
+    expect(summary.highlights[0]?.name).toBe("The MEV Letter");
+    expect(summary.hiddenCount).toBeGreaterThan(0);
+  });
+});

--- a/tests/newsletter-admin-subscribers.test.ts
+++ b/tests/newsletter-admin-subscribers.test.ts
@@ -73,6 +73,7 @@ describe("adminUpdateSubscriberPreferences", () => {
   });
 
   test("updates subscriber status without auto-confirming pending subscribers", async () => {
+    const actualPosthog = await import("../src/services/posthog");
     const state: MockState = {
       subscriber: null,
       preferences: [],
@@ -128,6 +129,7 @@ describe("adminUpdateSubscriberPreferences", () => {
       newsletterUnsubTokens: {},
     }));
     mock.module("@/services/posthog", () => ({
+      ...actualPosthog,
       getCandidateViewsForWindow: async () => ({ success: true as const, data: [] }),
       getJobApplyClicksForWindow: async () => ({ success: true as const, data: [] }),
       getNewsClicksForWindow: async () => ({ success: true as const, data: [] }),

--- a/tests/newsletter-admin-subscribers.test.ts
+++ b/tests/newsletter-admin-subscribers.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+function makeQueryResult<T>(value: T) {
+  return {
+    limit: async () => value,
+    then: (resolve: (value: T) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(value).then(resolve, reject),
+  };
+}
+
+function makeAwaitable<T>(value: T) {
+  return {
+    then: (resolve: (value: T) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(value).then(resolve, reject),
+  };
+}
+
+type MockSubscriberStatus = "pending" | "active" | "unsubscribed";
+type MockNewsletterType = "news" | "jobs" | "candidates";
+
+type MockState = {
+  subscriber: {
+    id: string;
+    email: string;
+    status: MockSubscriberStatus;
+    confirmedAt: Date | null;
+    unsubscribedAt: Date | null;
+    source: string;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+  preferences: Array<{
+    id: string;
+    subscriberId: string;
+    newsletterType: MockNewsletterType;
+    enabled: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+  }>;
+  subscriberUpdates: Array<Record<string, unknown>>;
+};
+
+function resetState(
+  state: MockState,
+  subscriberStatus: MockSubscriberStatus,
+  enabledTypes: MockNewsletterType[]
+) {
+  const now = new Date("2026-03-09T10:00:00.000Z");
+  state.subscriber = {
+    id: "sub_123",
+    email: "reader@example.com",
+    status: subscriberStatus,
+    confirmedAt: subscriberStatus === "pending" ? null : now,
+    unsubscribedAt: subscriberStatus === "unsubscribed" ? now : null,
+    source: "news-page",
+    createdAt: now,
+    updatedAt: now,
+  };
+  state.preferences = (["news", "jobs", "candidates"] as const).map((newsletterType, index) => ({
+    id: `pref_${index + 1}`,
+    subscriberId: "sub_123",
+    newsletterType,
+    enabled: enabledTypes.includes(newsletterType),
+    createdAt: now,
+    updatedAt: now,
+  }));
+  state.subscriberUpdates = [];
+}
+
+describe("adminUpdateSubscriberPreferences", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("updates subscriber status without auto-confirming pending subscribers", async () => {
+    const state: MockState = {
+      subscriber: null,
+      preferences: [],
+      subscriberUpdates: [],
+    };
+
+    const newsletterSubscribers = { table: "newsletter_subscribers" };
+    const newsletterPreferences = { table: "newsletter_preferences" };
+
+    mock.module("@/db", () => ({
+      db: {
+        select: () => ({
+          from: (table: unknown) => ({
+            where: () => {
+              if (table === newsletterSubscribers) {
+                return makeQueryResult(state.subscriber ? [state.subscriber] : []);
+              }
+              if (table === newsletterPreferences) {
+                return makeQueryResult(state.preferences);
+              }
+              return makeQueryResult([]);
+            },
+          }),
+        }),
+        update: (table: unknown) => ({
+          set: (values: Record<string, unknown>) => ({
+            where: () => {
+              if (table === newsletterSubscribers) {
+                state.subscriberUpdates.push(values);
+                if (state.subscriber) {
+                  state.subscriber = {
+                    ...state.subscriber,
+                    ...values,
+                  };
+                }
+              }
+              return makeAwaitable([]);
+            },
+          }),
+        }),
+        insert: () => ({
+          values: async () => [],
+        }),
+      },
+      jobs: {},
+      candidates: {},
+      newsletterTemplates: {},
+      newsletterSubscribers,
+      newsletterPreferences,
+      newsletterCampaigns: {},
+      newsletterCampaignRecipients: {},
+      newsletterSendEvents: {},
+      newsletterUnsubTokens: {},
+    }));
+    mock.module("@/services/posthog", () => ({
+      getCandidateViewsForWindow: async () => ({ success: true as const, data: [] }),
+      getJobApplyClicksForWindow: async () => ({ success: true as const, data: [] }),
+      getNewsClicksForWindow: async () => ({ success: true as const, data: [] }),
+    }));
+    mock.module("@/lib/news", () => ({
+      getAllNews: async () => [],
+    }));
+
+    const { adminUpdateSubscriberPreferences } = await import("../src/services/newsletter");
+
+    resetState(state, "active", ["news"]);
+    const unsubscribedResult = await adminUpdateSubscriberPreferences("sub_123", []);
+    expect(unsubscribedResult.ok).toBe(true);
+    if (!unsubscribedResult.ok) throw new Error("expected unsubscribed result");
+    expect(state.subscriberUpdates[0]?.status).toBe("unsubscribed");
+    expect(state.subscriberUpdates[0]?.unsubscribedAt).toBeInstanceOf(Date);
+    expect(unsubscribedResult.data.subscriber.status).toBe("unsubscribed");
+
+    resetState(state, "unsubscribed", []);
+    const activeResult = await adminUpdateSubscriberPreferences("sub_123", ["news"]);
+    expect(activeResult.ok).toBe(true);
+    if (!activeResult.ok) throw new Error("expected active result");
+    expect(state.subscriberUpdates[0]?.status).toBe("active");
+    expect(state.subscriberUpdates[0]?.unsubscribedAt).toBeNull();
+    expect(activeResult.data.subscriber.status).toBe("active");
+
+    resetState(state, "pending", ["news"]);
+    const pendingResult = await adminUpdateSubscriberPreferences("sub_123", ["jobs"]);
+    expect(pendingResult.ok).toBe(true);
+    if (!pendingResult.ok) throw new Error("expected pending result");
+    expect(state.subscriberUpdates[0]?.status).toBe("pending");
+    expect(pendingResult.data.subscriber.status).toBe("pending");
+    expect(
+      pendingResult.data.preferences.find((preference) => preference.newsletterType === "jobs")?.enabled
+    ).toBe(true);
+    expect(
+      pendingResult.data.preferences.find((preference) => preference.newsletterType === "news")?.enabled
+    ).toBe(false);
+  });
+});

--- a/tests/newsletter-markdown-text.test.ts
+++ b/tests/newsletter-markdown-text.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("previewNewsletterCampaignDraft markdown text output", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("preserves links in rendered text output", async () => {
+    mock.module("@/db", () => ({
+      db: {
+        select: () => ({
+          from: () => ({
+            where: () => ({
+              limit: async () => [],
+            }),
+          }),
+        }),
+      },
+      jobs: {},
+      candidates: {},
+      newsletterTemplates: {},
+      newsletterSubscribers: {},
+      newsletterPreferences: {},
+      newsletterCampaigns: {},
+      newsletterCampaignRecipients: {},
+      newsletterSendEvents: {},
+      newsletterUnsubTokens: {},
+    }));
+    mock.module("@/services/posthog", () => ({
+      getCandidateViewsForWindow: async () => ({ success: true as const, data: [] }),
+      getJobApplyClicksForWindow: async () => ({ success: true as const, data: [] }),
+      getNewsClicksForWindow: async () => ({ success: true as const, data: [] }),
+    }));
+    mock.module("@/lib/news", () => ({
+      getAllNews: async () => [],
+    }));
+
+    const { previewNewsletterCampaignDraft } = await import("../src/services/newsletter");
+    const result = await previewNewsletterCampaignDraft({
+      newsletterType: "news",
+      subject: "Weekly digest",
+      contentMode: "markdown",
+      markdownContent: [
+        "## Weekly digest",
+        "",
+        "Read [Example](https://example.com).",
+        "",
+        "[Manage preferences]({{preferences_url}}) | [Unsubscribe]({{unsubscribe_url}})",
+      ].join("\n"),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected preview result");
+
+    expect(result.data.rendered.text).toContain("https://example.com");
+    expect(result.data.rendered.text).toContain("https://dcbuilder.dev/api/v1/newsletter/preferences?token=preview-token");
+    expect(result.data.rendered.text).toContain("https://dcbuilder.dev/api/v1/newsletter/unsubscribe?token=preview-token");
+  });
+});

--- a/tests/newsletter-markdown-text.test.ts
+++ b/tests/newsletter-markdown-text.test.ts
@@ -6,6 +6,7 @@ describe("previewNewsletterCampaignDraft markdown text output", () => {
   });
 
   test("preserves links in rendered text output", async () => {
+    const actualPosthog = await import("../src/services/posthog");
     mock.module("@/db", () => ({
       db: {
         select: () => ({
@@ -27,6 +28,7 @@ describe("previewNewsletterCampaignDraft markdown text output", () => {
       newsletterUnsubTokens: {},
     }));
     mock.module("@/services/posthog", () => ({
+      ...actualPosthog,
       getCandidateViewsForWindow: async () => ({ success: true as const, data: [] }),
       getJobApplyClicksForWindow: async () => ({ success: true as const, data: [] }),
       getNewsClicksForWindow: async () => ({ success: true as const, data: [] }),

--- a/tests/newsletter-markdown.test.ts
+++ b/tests/newsletter-markdown.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { markdownToHtml } from "../src/services/newsletter";
+
+describe("markdownToHtml", () => {
+  test("renders starter markdown with the newsletter shell and recommended-links card styling", () => {
+    const html = markdownToHtml(`## News digest
+
+Recent highlights from the last 7 days.
+
+- **Ethereal news weekly #14** · Weekly #14 covering the first ePBS devnet going live. · 0 views · [open](https://x.com/example/status/1)
+
+---
+
+### Want to read more?
+
+**Recommended newsletters & links**
+
+- **[The MEV Letter](https://collective.flashbots.net/tag/the-mev-letter)** — Flashbots' MEV research roundup
+
+[Manage preferences](https://dcbuilder.dev/preferences) | [Unsubscribe](https://dcbuilder.dev/unsubscribe)`);
+
+    expect(html).toContain("max-width:560px");
+    expect(html).toContain("dcbuilder.png");
+    expect(html).toContain("background:#fafafa;border-radius:12px");
+    expect(html).toContain("href=\"https://x.com/example/status/1\"");
+    expect(html).not.toContain(">open<");
+  });
+});

--- a/tests/newsletter-preferences-route.test.ts
+++ b/tests/newsletter-preferences-route.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("GET /api/v1/newsletter/preferences", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("renders an HTML preferences page for a valid token", async () => {
+    const actualNewsletter = await import("../src/services/newsletter");
+    const getPreferenceContext = mock(async () => ({
+      ok: true as const,
+      data: {
+        email: "reader@example.com",
+        preferences: [
+          { type: "news", enabled: true },
+          { type: "jobs", enabled: false },
+          { type: "candidates", enabled: true },
+        ],
+      },
+    }));
+
+    mock.module("@/services/newsletter", () => ({
+      ...actualNewsletter,
+      getPreferenceContext,
+    }));
+
+    const { GET } = await import("../src/app/api/v1/newsletter/preferences/route");
+    const response = await GET(new Request("https://dcbuilder.dev/api/v1/newsletter/preferences?token=test-token"));
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(body).toContain("reader@example.com");
+    expect(body).toContain("Manage your newsletter preferences");
+    expect(body).toContain('value="news"');
+    expect(body).toContain('value="candidates"');
+    expect(body).toContain("checked");
+  });
+});

--- a/tests/newsletter-resend-webhook.test.ts
+++ b/tests/newsletter-resend-webhook.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+describe("POST /api/v1/webhooks/resend", () => {
+  const originalWebhookSecret = process.env.RESEND_WEBHOOK_SECRET;
+
+  afterEach(() => {
+    if (originalWebhookSecret === undefined) {
+      delete process.env.RESEND_WEBHOOK_SECRET;
+    } else {
+      process.env.RESEND_WEBHOOK_SECRET = originalWebhookSecret;
+    }
+  });
+
+  test("fails closed when the webhook secret is not configured", async () => {
+    delete process.env.RESEND_WEBHOOK_SECRET;
+
+    const { POST } = await import("../src/app/api/v1/webhooks/resend/route");
+    const response = await POST(
+      new Request("https://dcbuilder.dev/api/v1/webhooks/resend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "email.clicked", data: { to: ["reader@example.com"] } }),
+      }) as never
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(payload.error).toContain("RESEND_WEBHOOK_SECRET");
+  });
+});

--- a/tests/newsletter-send-route.test.ts
+++ b/tests/newsletter-send-route.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("POST /api/cron/newsletter-send", () => {
+  const originalCronSecret = process.env.CRON_SECRET;
+
+  afterEach(() => {
+    mock.restore();
+    if (originalCronSecret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = originalCronSecret;
+    }
+  });
+
+  test("returns 500 when any scheduled campaign send fails", async () => {
+    process.env.CRON_SECRET = "test-secret";
+
+    const sendDueNewsletterCampaigns = mock(async () => ({
+      ok: true as const,
+      data: {
+        processed: 1,
+        results: [
+          {
+            campaignId: "camp-1",
+            result: { ok: false as const, status: 409, error: "No active recipients for this campaign type" },
+          },
+        ],
+      },
+    }));
+
+    mock.module("@/services/newsletter", () => ({
+      sendDueNewsletterCampaigns,
+    }));
+
+    const { POST } = await import("../src/app/api/cron/newsletter-send/route");
+    const response = await POST(
+      new Request("https://dcbuilder.dev/api/cron/newsletter-send", {
+        method: "POST",
+        headers: { authorization: "Bearer test-secret" },
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload.error).toContain("camp-1");
+    expect(payload.processed).toBe(1);
+  });
+
+  test("returns 500 when a campaign send completes with failed recipients", async () => {
+    process.env.CRON_SECRET = "test-secret";
+
+    const sendDueNewsletterCampaigns = mock(async () => ({
+      ok: true as const,
+      data: {
+        processed: 1,
+        results: [
+          {
+            campaignId: "camp-2",
+            result: {
+              ok: true as const,
+              data: { campaignId: "camp-2", sent: 12, failed: 3, skipped: 0, alreadySent: false },
+            },
+          },
+        ],
+      },
+    }));
+
+    mock.module("@/services/newsletter", () => ({
+      sendDueNewsletterCampaigns,
+    }));
+
+    const { POST } = await import("../src/app/api/cron/newsletter-send/route");
+    const response = await POST(
+      new Request("https://dcbuilder.dev/api/cron/newsletter-send", {
+        method: "POST",
+        headers: { authorization: "Bearer test-secret" },
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload.error).toContain("camp-2");
+    expect(payload.processed).toBe(1);
+  });
+});

--- a/tests/newsletter-send.test.ts
+++ b/tests/newsletter-send.test.ts
@@ -97,7 +97,9 @@ describe("sendDueNewsletterCampaigns", () => {
       getAllNews: async () => [],
     }));
 
-    const { sendDueNewsletterCampaigns } = await import("../src/services/newsletter");
+    const { sendDueNewsletterCampaigns } = await import(
+      `../src/services/newsletter?newsletter-send-test=${Date.now()}`
+    );
     const result = await sendDueNewsletterCampaigns();
 
     expect(result.ok).toBe(true);

--- a/tests/newsletter-send.test.ts
+++ b/tests/newsletter-send.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+function makeQueryResult<T>(value: T) {
+  return {
+    limit: async () => value,
+    then: (resolve: (value: T) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(value).then(resolve, reject),
+  };
+}
+
+function makeUpdateResult<T>(awaitValue: T, returningValue: T) {
+  return {
+    returning: async () => returningValue,
+    then: (resolve: (value: T) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(awaitValue).then(resolve, reject),
+  };
+}
+
+describe("sendDueNewsletterCampaigns", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("marks scheduled campaigns with zero recipients as failed", async () => {
+    const selectQueue = [
+      [{ id: "camp-1" }],
+      [{
+        id: "camp-1",
+        status: "scheduled",
+        scheduledAt: new Date("2026-03-09T10:00:00.000Z"),
+        sentAt: null,
+        newsletterType: "news",
+        contentMode: "template",
+        subject: "Weekly digest",
+        markdownContent: null,
+        manualHtml: null,
+        manualText: null,
+        periodDays: 7,
+      }],
+      [],
+      [],
+    ];
+    const updateCalls: Array<Record<string, unknown>> = [];
+
+    mock.module("@/db", () => ({
+      db: {
+        select: () => ({
+          from: () => ({
+            where: () => makeQueryResult(selectQueue.shift() ?? []),
+          }),
+        }),
+        update: () => ({
+          set: (values: Record<string, unknown>) => ({
+            where: () => {
+              updateCalls.push(values);
+              return makeUpdateResult(
+                [],
+                values.status === "sending"
+                  ? [{
+                      id: "camp-1",
+                      status: "sending",
+                      scheduledAt: new Date("2026-03-09T10:00:00.000Z"),
+                      sentAt: null,
+                      newsletterType: "news",
+                      contentMode: "template",
+                      subject: "Weekly digest",
+                      markdownContent: null,
+                      manualHtml: null,
+                      manualText: null,
+                      periodDays: 7,
+                    }]
+                  : [],
+              );
+            },
+          }),
+        }),
+        insert: () => ({
+          values: async () => [],
+        }),
+      },
+      jobs: {},
+      candidates: {},
+      newsletterTemplates: {},
+      newsletterSubscribers: {},
+      newsletterPreferences: {},
+      newsletterCampaigns: {},
+      newsletterCampaignRecipients: {},
+      newsletterSendEvents: {},
+      newsletterUnsubTokens: {},
+    }));
+    mock.module("@/services/posthog", () => ({
+      getCandidateViewsForWindow: async () => ({ success: true as const, data: [] }),
+      getJobApplyClicksForWindow: async () => ({ success: true as const, data: [] }),
+      getNewsClicksForWindow: async () => ({ success: true as const, data: [] }),
+    }));
+    mock.module("@/lib/news", () => ({
+      getAllNews: async () => [],
+    }));
+
+    const { sendDueNewsletterCampaigns } = await import("../src/services/newsletter");
+    const result = await sendDueNewsletterCampaigns();
+
+    expect(result.ok).toBe(true);
+    expect(result.data.processed).toBe(1);
+    expect(result.data.results[0]?.result.ok).toBe(false);
+    expect(updateCalls[1]?.status).toBe("failed");
+    expect(updateCalls[1]?.failureReason).toBe("No active recipients for this campaign type");
+  });
+});

--- a/tests/newsletter-send.test.ts
+++ b/tests/newsletter-send.test.ts
@@ -22,6 +22,7 @@ describe("sendDueNewsletterCampaigns", () => {
   });
 
   test("marks scheduled campaigns with zero recipients as failed", async () => {
+    const actualPosthog = await import("../src/services/posthog");
     const selectQueue = [
       [{ id: "camp-1" }],
       [{
@@ -89,6 +90,7 @@ describe("sendDueNewsletterCampaigns", () => {
       newsletterUnsubTokens: {},
     }));
     mock.module("@/services/posthog", () => ({
+      ...actualPosthog,
       getCandidateViewsForWindow: async () => ({ success: true as const, data: [] }),
       getJobApplyClicksForWindow: async () => ({ success: true as const, data: [] }),
       getNewsClicksForWindow: async () => ({ success: true as const, data: [] }),

--- a/tests/newsletter-studio.test.ts
+++ b/tests/newsletter-studio.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { canAutoRenderComposePreview } from "../src/lib/newsletter-studio";
+import {
+  canAutoRenderComposePreview,
+  shouldLoadSubscribersOnModeChange,
+} from "../src/lib/newsletter-studio";
 
 describe("canAutoRenderComposePreview", () => {
   test("waits for the studio data load to finish before auto-rendering preview", () => {
@@ -68,5 +71,39 @@ describe("canAutoRenderComposePreview", () => {
         draft: { contentMode: "manual", markdownContent: "", manualHtml: "<p>Hello</p>", manualText: "Hello" },
       })
     ).toBe(true);
+  });
+
+  test("loads subscribers only when entering the subscribers mode without cached data", () => {
+    expect(
+      shouldLoadSubscribersOnModeChange({
+        nextMode: "subscribers",
+        subscribersLoaded: false,
+        subscribersLoading: false,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldLoadSubscribersOnModeChange({
+        nextMode: "subscribers",
+        subscribersLoaded: true,
+        subscribersLoading: false,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldLoadSubscribersOnModeChange({
+        nextMode: "subscribers",
+        subscribersLoaded: false,
+        subscribersLoading: true,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldLoadSubscribersOnModeChange({
+        nextMode: "queue",
+        subscribersLoaded: false,
+        subscribersLoading: false,
+      })
+    ).toBe(false);
   });
 });

--- a/tests/newsletter-studio.test.ts
+++ b/tests/newsletter-studio.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { canAutoRenderComposePreview } from "../src/lib/newsletter-studio";
+
+describe("canAutoRenderComposePreview", () => {
+  test("waits for the studio data load to finish before auto-rendering preview", () => {
+    expect(
+      canAutoRenderComposePreview({
+        loading: true,
+        mode: "compose",
+        draft: { contentMode: "template", markdownContent: "", manualHtml: "", manualText: "" },
+      })
+    ).toBe(false);
+    expect(
+      canAutoRenderComposePreview({
+        loading: false,
+        mode: "compose",
+        draft: { contentMode: "template", markdownContent: "", manualHtml: "", manualText: "" },
+      })
+    ).toBe(true);
+  });
+
+  test("does not auto-render preview outside compose mode", () => {
+    expect(
+      canAutoRenderComposePreview({
+        loading: false,
+        mode: "queue",
+        draft: { contentMode: "template", markdownContent: "", manualHtml: "", manualText: "" },
+      })
+    ).toBe(false);
+    expect(
+      canAutoRenderComposePreview({
+        loading: false,
+        mode: "templates",
+        draft: { contentMode: "template", markdownContent: "", manualHtml: "", manualText: "" },
+      })
+    ).toBe(false);
+  });
+
+  test("does not auto-render markdown preview until markdown content exists", () => {
+    expect(
+      canAutoRenderComposePreview({
+        loading: false,
+        mode: "compose",
+        draft: { contentMode: "markdown", markdownContent: "", manualHtml: "", manualText: "" },
+      })
+    ).toBe(false);
+    expect(
+      canAutoRenderComposePreview({
+        loading: false,
+        mode: "compose",
+        draft: { contentMode: "markdown", markdownContent: "## News digest", manualHtml: "", manualText: "" },
+      })
+    ).toBe(true);
+  });
+
+  test("does not auto-render manual preview until html and text both exist", () => {
+    expect(
+      canAutoRenderComposePreview({
+        loading: false,
+        mode: "compose",
+        draft: { contentMode: "manual", markdownContent: "", manualHtml: "<p>Hello</p>", manualText: "" },
+      })
+    ).toBe(false);
+    expect(
+      canAutoRenderComposePreview({
+        loading: false,
+        mode: "compose",
+        draft: { contentMode: "manual", markdownContent: "", manualHtml: "<p>Hello</p>", manualText: "Hello" },
+      })
+    ).toBe(true);
+  });
+});

--- a/tests/newsletter-subscribers-route.test.ts
+++ b/tests/newsletter-subscribers-route.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("PATCH /api/v1/newsletter/subscribers/[id]", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("requires admin write access, validates the body, and returns updated subscriber data", async () => {
+    let requestedPermission: string | undefined;
+    let calledId: string | null = null;
+    let calledNewsletterTypes: string[] | null = null;
+
+    mock.module("@/services/auth", () => ({
+      requireAuth: async (_request: Request, permission?: string) => {
+        requestedPermission = permission;
+        return { valid: true as const, keyId: "key_123", name: "Admin" };
+      },
+    }));
+    mock.module("@/services/newsletter-admin", () => ({
+      adminUpdateSubscriberPreferences: async (id: string, newsletterTypes: string[]) => {
+        calledId = id;
+        calledNewsletterTypes = newsletterTypes;
+        return {
+          ok: true as const,
+          data: {
+            subscriber: {
+              id,
+              email: "reader@example.com",
+              status: "active",
+            },
+            preferences: [
+              { newsletterType: "news", enabled: true },
+              { newsletterType: "jobs", enabled: false },
+              { newsletterType: "candidates", enabled: true },
+            ],
+          },
+        };
+      },
+    }));
+
+    const { PATCH } = await import("../src/app/api/v1/newsletter/subscribers/[id]/route");
+
+    const response = await PATCH(
+      new Request("https://dcbuilder.dev/api/v1/newsletter/subscribers/sub_123", {
+        method: "PATCH",
+        body: JSON.stringify({ newsletterTypes: ["news", "candidates"] }),
+      }) as never,
+      { params: Promise.resolve({ id: "sub_123" }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(requestedPermission).toBe("admin:write");
+    expect(calledId === "sub_123").toBe(true);
+    expect(JSON.stringify(calledNewsletterTypes)).toBe(JSON.stringify(["news", "candidates"]));
+    expect(body.data.subscriber.status).toBe("active");
+    expect(body.data.preferences).toHaveLength(3);
+
+    calledId = null;
+    calledNewsletterTypes = null;
+    const invalidResponse = await PATCH(
+      new Request("https://dcbuilder.dev/api/v1/newsletter/subscribers/sub_123", {
+        method: "PATCH",
+        body: JSON.stringify({}),
+      }) as never,
+      { params: Promise.resolve({ id: "sub_123" }) }
+    );
+    const invalidBody = await invalidResponse.json();
+
+    expect(invalidResponse.status).toBe(400);
+    expect(invalidBody.error).toBe("newsletterTypes must be an array");
+    expect(calledId).toBeNull();
+    expect(calledNewsletterTypes).toBeNull();
+  });
+});

--- a/tests/newsletter-subscribers.test.ts
+++ b/tests/newsletter-subscribers.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildNewsletterTypes,
+  isPreferenceRowDirty,
+  toPreferenceFlags,
+  toSubscriberDraftRow,
+} from "../src/lib/newsletter-subscribers";
+
+describe("newsletter subscriber helpers", () => {
+  test("maps API preferences into all three newsletter flags", () => {
+    expect(
+      toPreferenceFlags([
+        { newsletterType: "news", enabled: true },
+        { newsletterType: "jobs", enabled: false },
+      ])
+    ).toEqual({
+      news: true,
+      jobs: false,
+      candidates: false,
+    });
+  });
+
+  test("builds enabled newsletter types from toggle flags", () => {
+    expect(buildNewsletterTypes({ news: true, jobs: false, candidates: true })).toEqual(["news", "candidates"]);
+  });
+
+  test("detects dirty subscriber preference rows", () => {
+    expect(
+      isPreferenceRowDirty(
+        { news: true, jobs: false, candidates: false },
+        { news: true, jobs: false, candidates: false }
+      )
+    ).toBe(false);
+    expect(
+      isPreferenceRowDirty(
+        { news: true, jobs: false, candidates: false },
+        { news: true, jobs: true, candidates: false }
+      )
+    ).toBe(true);
+  });
+
+  test("creates a subscriber row draft with matching current and draft flags", () => {
+    expect(
+      toSubscriberDraftRow({
+        id: "sub_123",
+        email: "reader@example.com",
+        status: "active",
+        createdAt: "2026-03-09T10:00:00.000Z",
+        clicks7d: 12,
+        lastClickedLink: "https://example.com/story",
+        preferences: [
+          { newsletterType: "news", enabled: true },
+          { newsletterType: "candidates", enabled: true },
+        ],
+      })
+    ).toEqual({
+      id: "sub_123",
+      email: "reader@example.com",
+      status: "active",
+      current: {
+        news: true,
+        jobs: false,
+        candidates: true,
+      },
+      draft: {
+        news: true,
+        jobs: false,
+        candidates: true,
+      },
+      clicks7d: 12,
+      lastClickedLink: "https://example.com/story",
+      createdAt: "2026-03-09T10:00:00.000Z",
+      saving: false,
+      error: null,
+    });
+  });
+});

--- a/tests/newsletter.test.ts
+++ b/tests/newsletter.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { computeViewTotals, dedupeNewsletterTypes } from "../src/lib/newsletter-utils";
+
+describe("newsletter helpers", () => {
+  test("dedupes and validates newsletter types", () => {
+    const types = dedupeNewsletterTypes(["jobs", "news", "jobs", "invalid", "candidates"]);
+    expect(types).toEqual(["jobs", "news", "candidates"]);
+  });
+
+  test("computes totals and period delta", () => {
+    expect(computeViewTotals(120, 80)).toEqual({ totalViews: 120, deltaViews: 40 });
+    expect(computeViewTotals(12, 20)).toEqual({ totalViews: 12, deltaViews: -8 });
+  });
+});

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import nextConfig from "../next.config";
+
+describe("next image config", () => {
+  test("allows the news grid image quality", () => {
+    const imageConfig = nextConfig.images;
+
+    expect(imageConfig).toBeDefined();
+    expect(Array.isArray(imageConfig?.qualities)).toBe(true);
+    expect(imageConfig?.qualities).toContain(90);
+  });
+});

--- a/tests/recommendations.test.ts
+++ b/tests/recommendations.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { getRecommendedLinks } from "../src/lib/recommendations";
+
+describe("getRecommendedLinks", () => {
+  test("includes The MEV Letter in the shared recommended links", () => {
+    const links = getRecommendedLinks();
+
+    expect(links).toContainEqual({
+      name: "The MEV Letter",
+      url: "https://collective.flashbots.net/tag/the-mev-letter",
+      description: "Flashbots' MEV research roundup covering papers, posts, and ecosystem updates",
+    });
+  });
+
+  test("can include newsletter-only extras", () => {
+    const links = getRecommendedLinks({ includeNewsletterExtras: true });
+
+    expect(links).toContainEqual({
+      name: "dcbuilder.dev/news",
+      url: "https://dcbuilder.dev/news",
+      description: "Older curated links and announcements",
+    });
+  });
+});


### PR DESCRIPTION
  ## Summary
  - add full newsletter backend schema + migration (subscribers, preferences, campaigns, recipients, send events, tokens)
  - implement subscription lifecycle APIs: subscribe, confirm, unsubscribe, preference updates
  - add jobs/candidates digest metrics with current-period vs previous-period deltas
  - add `/news` newsletter signup UI

  ## Validation
  - bun run lint
  - bun run test:unit
  - bunx tsc --noEmit

  Closes CON-14.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches database migration configuration and adds automated staging/prod migration workflows; mistakes could apply migrations to the wrong environment or impact deploy pipelines.
> 
> **Overview**
> Adds **explicit database environment targeting** for Drizzle migrations (runtime `DATABASE_URL` vs `DATABASE_URL_DEV|STAGING|PROD`), including updated `drizzle.config.ts`, `.env.example`, and setup docs to discourage `drizzle-kit push` in shared envs.
> 
> Updates CI to verify schema/migration sync and run `db:migrate:dev`, and introduces separate GitHub Actions workflows for *staging auto-migrate on `master`* and *production manual migrate with confirmation + pre-migration `pg_dump` backup artifact*. Also adds a scheduled workflow that calls `/api/cron/newsletter-issue-create` weekly.
> 
> Extends news ingestion tooling to support `curated_links.source_image` (script + docs) and bumps `next-mdx-remote` to v6.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29d4872b8abc2df788d450550ab3c5af33ca3284. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->