### PR TITLE
fix: avoid build-time db access for portfolio and sitemap

### DIFF
--- a/scripts/db/migrate.ts
+++ b/scripts/db/migrate.ts
@@ -1,4 +1,7 @@
-import { spawnSync } from "node:child_process";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import postgres from "postgres";
+import { createPreferredPostgresSocket, resolvePreferredPostgresTarget } from "../../src/db/postgres-connection";
 
 type TargetEnv = "dev" | "staging" | "prod";
 
@@ -43,7 +46,7 @@ function resolveUrl(targetEnv: TargetEnv): string {
   return prodUrl;
 }
 
-function run() {
+async function run() {
   const targetEnv = parseEnvArg(process.argv.slice(2));
 
   if (targetEnv === "prod" && process.env.ALLOW_PROD_MIGRATION !== "true") {
@@ -53,24 +56,30 @@ function run() {
   const databaseUrl = resolveUrl(targetEnv);
   console.log(`[db:migrate] Applying migrations to ${targetEnv}`);
 
-  const child = spawnSync("bunx", ["drizzle-kit", "migrate", "--config", "drizzle.config.ts"], {
-    stdio: "inherit",
-    env: {
-      ...process.env,
-      DRIZZLE_ENV: targetEnv,
-      DATABASE_URL: databaseUrl,
-    },
+  const target = await resolvePreferredPostgresTarget(databaseUrl);
+  if (target.tlsServername && target.connectHost !== target.tlsServername) {
+    console.log(
+      `[db:migrate] Using IPv4 connect target ${target.connectHost} for ${target.tlsServername}`
+    );
+  }
+
+  const sql = postgres(databaseUrl, {
+    max: 1,
+    socket: targetEnv === "dev"
+      ? undefined
+      : () => createPreferredPostgresSocket(databaseUrl),
   });
 
-  if (child.status !== 0) {
-    process.exit(child.status ?? 1);
+  try {
+    const db = drizzle(sql);
+    await migrate(db, { migrationsFolder: "drizzle" });
+  } finally {
+    await sql.end({ timeout: 5 });
   }
 }
 
-try {
-  run();
-} catch (error) {
+run().catch((error) => {
   const message = error instanceof Error ? error.message : "Unknown migration error";
   console.error(`[db:migrate] ${message}`);
   process.exit(1);
-}
+});

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -8,8 +8,8 @@ export const metadata = {
   title: "Portfolio",
 };
 
-// Use ISR with 5 minute revalidation instead of force-dynamic
-export const revalidate = 300;
+// Force runtime rendering since this page reads directly from Postgres.
+export const dynamic = "force-dynamic";
 
 const getInvestments = unstable_cache(
   async () => {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,6 +4,7 @@ import { blogPosts } from "@/db/schema";
 import { desc, eq } from "drizzle-orm";
 
 export const baseUrl = "https://dcbuilder.dev";
+export const dynamic = "force-dynamic";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const routes = [

--- a/src/db/postgres-connection.ts
+++ b/src/db/postgres-connection.ts
@@ -1,0 +1,83 @@
+import dns from "node:dns/promises";
+import net from "node:net";
+
+type LookupResult = {
+  address: string;
+  family: number;
+};
+
+export type LookupFn = (
+  hostname: string,
+  options: { family: 4; all: true }
+) => Promise<LookupResult[]>;
+
+export type PreferredPostgresTarget = {
+  connectHost: string;
+  port: number;
+  tlsServername: string | undefined;
+};
+
+type ConnectedSocket = net.Socket & {
+  host: string;
+  port: number;
+};
+
+export async function resolvePreferredPostgresTarget(
+  databaseUrl: string,
+  lookup: LookupFn = dns.lookup
+): Promise<PreferredPostgresTarget> {
+  const parsed = new URL(databaseUrl);
+  const hostname = parsed.hostname;
+  const port = parsed.port ? Number(parsed.port) : 5432;
+  const ipFamily = net.isIP(hostname);
+
+  if (ipFamily === 4 || ipFamily === 6) {
+    return {
+      connectHost: hostname,
+      port,
+      tlsServername: undefined,
+    };
+  }
+
+  try {
+    const addresses = await lookup(hostname, { family: 4, all: true });
+    const ipv4Address = addresses.find((address) => address.family === 4)?.address;
+
+    if (ipv4Address) {
+      return {
+        connectHost: ipv4Address,
+        port,
+        tlsServername: hostname,
+      };
+    }
+  } catch {
+    // Fall back to the original hostname if IPv4 lookup fails.
+  }
+
+  return {
+    connectHost: hostname,
+    port,
+    tlsServername: hostname,
+  };
+}
+
+export async function createPreferredPostgresSocket(
+  databaseUrl: string,
+  lookup?: LookupFn
+): Promise<ConnectedSocket> {
+  const target = await resolvePreferredPostgresTarget(databaseUrl, lookup);
+  const socket = new net.Socket() as ConnectedSocket;
+
+  await new Promise<void>((resolve, reject) => {
+    socket.once("error", reject);
+    socket.connect(target.port, target.connectHost, () => {
+      socket.off("error", reject);
+      resolve();
+    });
+  });
+
+  socket.host = target.tlsServername ?? target.connectHost;
+  socket.port = target.port;
+
+  return socket;
+}

--- a/tests/newsletter-admin-subscribers.test.ts
+++ b/tests/newsletter-admin-subscribers.test.ts
@@ -73,6 +73,7 @@ describe("adminUpdateSubscriberPreferences", () => {
   });
 
   test("updates subscriber status without auto-confirming pending subscribers", async () => {
+    const actualDb = await import("../src/db");
     const actualPosthog = await import("../src/services/posthog");
     const state: MockState = {
       subscriber: null,
@@ -84,6 +85,7 @@ describe("adminUpdateSubscriberPreferences", () => {
     const newsletterPreferences = { table: "newsletter_preferences" };
 
     mock.module("@/db", () => ({
+      ...actualDb,
       db: {
         select: () => ({
           from: (table: unknown) => ({

--- a/tests/newsletter-markdown-text.test.ts
+++ b/tests/newsletter-markdown-text.test.ts
@@ -6,8 +6,10 @@ describe("previewNewsletterCampaignDraft markdown text output", () => {
   });
 
   test("preserves links in rendered text output", async () => {
+    const actualDb = await import("../src/db");
     const actualPosthog = await import("../src/services/posthog");
     mock.module("@/db", () => ({
+      ...actualDb,
       db: {
         select: () => ({
           from: () => ({

--- a/tests/newsletter-send.test.ts
+++ b/tests/newsletter-send.test.ts
@@ -22,6 +22,7 @@ describe("sendDueNewsletterCampaigns", () => {
   });
 
   test("marks scheduled campaigns with zero recipients as failed", async () => {
+    const actualDb = await import("../src/db");
     const actualPosthog = await import("../src/services/posthog");
     const selectQueue = [
       [{ id: "camp-1" }],
@@ -44,6 +45,7 @@ describe("sendDueNewsletterCampaigns", () => {
     const updateCalls: Array<Record<string, unknown>> = [];
 
     mock.module("@/db", () => ({
+      ...actualDb,
       db: {
         select: () => ({
           from: () => ({

--- a/tests/portfolio-page-config.test.ts
+++ b/tests/portfolio-page-config.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+
+describe("portfolio page runtime mode", () => {
+  test("forces runtime rendering instead of build-time prerendering", async () => {
+    const pageModule = await import("../src/app/portfolio/page");
+    const revalidate =
+      "revalidate" in pageModule
+        ? (pageModule as { revalidate?: number }).revalidate
+        : undefined;
+
+    expect(pageModule.dynamic).toBe("force-dynamic");
+    expect(revalidate).toBeUndefined();
+  });
+});

--- a/tests/postgres-connection-target.test.ts
+++ b/tests/postgres-connection-target.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { resolvePreferredPostgresTarget } from "../src/db/postgres-connection";
+
+describe("resolvePreferredPostgresTarget", () => {
+  test("prefers an IPv4 connect target while preserving the hostname for TLS", async () => {
+    const result = await resolvePreferredPostgresTarget(
+      "postgresql://user:pass@db.example.com:5432/app",
+      async () => [{ address: "203.0.113.10", family: 4 }]
+    );
+
+    expect(result).toEqual({
+      connectHost: "203.0.113.10",
+      port: 5432,
+      tlsServername: "db.example.com",
+    });
+  });
+});

--- a/tests/sitemap-config.test.ts
+++ b/tests/sitemap-config.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+
+describe("sitemap runtime mode", () => {
+  test("forces runtime rendering instead of build-time prerendering", async () => {
+    const sitemapModule = await import("../src/app/sitemap");
+    const revalidate =
+      "revalidate" in sitemapModule
+        ? (sitemapModule as { revalidate?: number }).revalidate
+        : undefined;
+
+    expect(sitemapModule.dynamic).toBe("force-dynamic");
+    expect(revalidate).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Summary:
- force portfolio and sitemap.xml to render dynamically so Vercel builds do not query Postgres during prerender
- replace the staging migration CLI spawn with a programmatic Drizzle migration path that prefers IPv4 connect targets while preserving the hostname for TLS
- add regression tests for the portfolio page, sitemap, and preferred Postgres target resolution

Verification:
- bun run test:unit in a clean worktree
- bun run tsc --noEmit in a clean worktree
- DATABASE_URL set to localhost bun run build in a clean worktree
