### PR TITLE
Fix newsletter schema fallbacks and isolate local worktrees

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+root = "tests"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,11 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Ignore sibling/local worktrees and generated deployment artifacts.
+    "worktrees/**",
+    ".worktrees/**",
+    "test-results/**",
+    ".vercel/**",
   ]),
 ]);
 

--- a/src/app/api/v1/newsletter/campaigns/route.ts
+++ b/src/app/api/v1/newsletter/campaigns/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest } from "next/server";
 import { requireAuth } from "@/services/auth";
 import { createNewsletterCampaign, listNewsletterCampaigns } from "@/services/newsletter";
+import {
+  getNewsletterAvailabilityMeta,
+  isMissingNewsletterSchemaError,
+  NEWSLETTER_DB_UNAVAILABLE_ERROR,
+} from "@/services/newsletter-schema";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAuth(request, "admin:read");
@@ -8,8 +13,21 @@ export async function GET(request: NextRequest) {
 
   const url = new URL(request.url);
   const limit = parseInt(url.searchParams.get("limit") || "50", 10);
-  const campaigns = await listNewsletterCampaigns(Number.isNaN(limit) ? 50 : limit);
-  return Response.json({ data: campaigns });
+  try {
+    const campaigns = await listNewsletterCampaigns(Number.isNaN(limit) ? 50 : limit);
+    return Response.json({ data: campaigns });
+  } catch (error) {
+    console.error("[api/newsletter/campaigns] GET failed:", error);
+
+    if (isMissingNewsletterSchemaError(error)) {
+      return Response.json({
+        data: [],
+        meta: getNewsletterAvailabilityMeta(),
+      });
+    }
+
+    return Response.json({ error: "Failed to load newsletter campaigns" }, { status: 500 });
+  }
 }
 
 export async function POST(request: NextRequest) {
@@ -34,18 +52,30 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const result = await createNewsletterCampaign({
-    newsletterType: body.newsletterType || "",
-    subject: body.subject || "",
-    previewText: body.previewText,
-    periodDays: body.periodDays,
-    scheduledAt: body.scheduledAt,
-    createdBy: body.createdBy,
-    contentMode: body.contentMode,
-    markdownContent: body.markdownContent,
-    manualHtml: body.manualHtml,
-    manualText: body.manualText,
-  });
+  let result;
+  try {
+    result = await createNewsletterCampaign({
+      newsletterType: body.newsletterType || "",
+      subject: body.subject || "",
+      previewText: body.previewText,
+      periodDays: body.periodDays,
+      scheduledAt: body.scheduledAt,
+      createdBy: body.createdBy,
+      contentMode: body.contentMode,
+      markdownContent: body.markdownContent,
+      manualHtml: body.manualHtml,
+      manualText: body.manualText,
+    });
+  } catch (error) {
+    console.error("[api/newsletter/campaigns] POST failed:", error);
+    if (isMissingNewsletterSchemaError(error)) {
+      return Response.json(
+        { error: NEWSLETTER_DB_UNAVAILABLE_ERROR, meta: getNewsletterAvailabilityMeta() },
+        { status: 503 }
+      );
+    }
+    return Response.json({ error: "Failed to create newsletter campaign" }, { status: 500 });
+  }
 
   if (!result.ok) {
     return Response.json({ error: result.error }, { status: result.status });

--- a/src/app/api/v1/newsletter/subscribers/route.ts
+++ b/src/app/api/v1/newsletter/subscribers/route.ts
@@ -3,6 +3,10 @@ import { requireAuth } from "@/services/auth";
 import { db, newsletterSubscribers, newsletterPreferences } from "@/db";
 import { count, desc, eq, inArray } from "drizzle-orm";
 import { getEmailClicksLast7Days } from "@/services/posthog";
+import {
+  getNewsletterAvailabilityMeta,
+  isMissingNewsletterSchemaError,
+} from "@/services/newsletter-schema";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAuth(request, "admin:read");
@@ -18,71 +22,86 @@ export async function GET(request: NextRequest) {
   // Build where condition
   const where = status ? eq(newsletterSubscribers.status, status) : undefined;
 
-  // Fetch subscribers and total count in parallel
-  const [subscribers, [totalRow]] = await Promise.all([
-    db
-      .select()
-      .from(newsletterSubscribers)
-      .where(where)
-      .orderBy(desc(newsletterSubscribers.createdAt))
-      .limit(limit)
-      .offset(offset),
-    db
-      .select({ total: count() })
-      .from(newsletterSubscribers)
-      .where(where),
-  ]);
+  try {
+    // Fetch subscribers and total count in parallel
+    const [subscribers, [totalRow]] = await Promise.all([
+      db
+        .select()
+        .from(newsletterSubscribers)
+        .where(where)
+        .orderBy(desc(newsletterSubscribers.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db
+        .select({ total: count() })
+        .from(newsletterSubscribers)
+        .where(where),
+    ]);
 
-  // Fetch preferences for the returned subscribers
-  const subscriberIds = subscribers.map((s) => s.id);
-  const preferences =
-    subscriberIds.length > 0
-      ? await db
-          .select()
-          .from(newsletterPreferences)
-          .where(inArray(newsletterPreferences.subscriberId, subscriberIds))
-      : [];
+    // Fetch preferences for the returned subscribers
+    const subscriberIds = subscribers.map((s) => s.id);
+    const preferences =
+      subscriberIds.length > 0
+        ? await db
+            .select()
+            .from(newsletterPreferences)
+            .where(inArray(newsletterPreferences.subscriberId, subscriberIds))
+        : [];
 
-  // Fetch click analytics from PostHog
-  const clickResult = await getEmailClicksLast7Days();
+    // Fetch click analytics from PostHog
+    const clickResult = await getEmailClicksLast7Days();
 
-  // Group preferences by subscriber ID
-  const preferencesBySubscriber = new Map<string, typeof preferences>();
-  for (const pref of preferences) {
-    const existing = preferencesBySubscriber.get(pref.subscriberId);
-    if (existing) {
-      existing.push(pref);
-    } else {
-      preferencesBySubscriber.set(pref.subscriberId, [pref]);
+    // Group preferences by subscriber ID
+    const preferencesBySubscriber = new Map<string, typeof preferences>();
+    for (const pref of preferences) {
+      const existing = preferencesBySubscriber.get(pref.subscriberId);
+      if (existing) {
+        existing.push(pref);
+      } else {
+        preferencesBySubscriber.set(pref.subscriberId, [pref]);
+      }
     }
-  }
 
-  // Build click data map keyed by email
-  const clicksByEmail = new Map<string, { clicks7d: number; lastClickedLink: string }>();
-  if (clickResult.success) {
-    for (const row of clickResult.data) {
-      clicksByEmail.set(row.email, {
-        clicks7d: row.count,
-        lastClickedLink: row.lastClickedLink,
+    // Build click data map keyed by email
+    const clicksByEmail = new Map<string, { clicks7d: number; lastClickedLink: string }>();
+    if (clickResult.success) {
+      for (const row of clickResult.data) {
+        clicksByEmail.set(row.email, {
+          clicks7d: row.count,
+          lastClickedLink: row.lastClickedLink,
+        });
+      }
+    }
+
+    // Merge subscribers with their preferences and click analytics
+    const data = subscribers.map((subscriber) => {
+      const clickData = clicksByEmail.get(subscriber.email);
+      return {
+        ...subscriber,
+        preferences: preferencesBySubscriber.get(subscriber.id) || [],
+        clicks7d: clickData?.clicks7d ?? 0,
+        lastClickedLink: clickData?.lastClickedLink ?? null,
+      };
+    });
+
+    return Response.json({
+      data,
+      total: totalRow?.total ?? 0,
+      limit,
+      offset,
+    });
+  } catch (error) {
+    console.error("[api/newsletter/subscribers] GET failed:", error);
+    if (isMissingNewsletterSchemaError(error)) {
+      return Response.json({
+        data: [],
+        total: 0,
+        limit,
+        offset,
+        meta: getNewsletterAvailabilityMeta(),
       });
     }
+
+    return Response.json({ error: "Failed to load newsletter subscribers" }, { status: 500 });
   }
-
-  // Merge subscribers with their preferences and click analytics
-  const data = subscribers.map((subscriber) => {
-    const clickData = clicksByEmail.get(subscriber.email);
-    return {
-      ...subscriber,
-      preferences: preferencesBySubscriber.get(subscriber.id) || [],
-      clicks7d: clickData?.clicks7d ?? 0,
-      lastClickedLink: clickData?.lastClickedLink ?? null,
-    };
-  });
-
-  return Response.json({
-    data,
-    total: totalRow?.total ?? 0,
-    limit,
-    offset,
-  });
 }

--- a/src/app/api/v1/newsletter/templates/route.ts
+++ b/src/app/api/v1/newsletter/templates/route.ts
@@ -1,13 +1,29 @@
 import { NextRequest } from "next/server";
 import { requireAuth } from "@/services/auth";
 import { listNewsletterTemplates, upsertNewsletterTemplate } from "@/services/newsletter";
+import {
+  getNewsletterAvailabilityMeta,
+  isMissingNewsletterSchemaError,
+  NEWSLETTER_DB_UNAVAILABLE_ERROR,
+} from "@/services/newsletter-schema";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAuth(request, "admin:read");
   if (auth instanceof Response) return auth;
 
-  const templates = await listNewsletterTemplates();
-  return Response.json({ data: templates });
+  try {
+    const templates = await listNewsletterTemplates();
+    return Response.json({ data: templates });
+  } catch (error) {
+    console.error("[api/newsletter/templates] GET failed:", error);
+    if (isMissingNewsletterSchemaError(error)) {
+      return Response.json({
+        data: [],
+        meta: getNewsletterAvailabilityMeta(),
+      });
+    }
+    return Response.json({ error: "Failed to load newsletter templates" }, { status: 500 });
+  }
 }
 
 export async function PUT(request: NextRequest) {
@@ -28,13 +44,25 @@ export async function PUT(request: NextRequest) {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const result = await upsertNewsletterTemplate({
-    newsletterType: body.newsletterType || "",
-    subjectTemplate: body.subjectTemplate || "",
-    htmlTemplate: body.htmlTemplate || "",
-    textTemplate: body.textTemplate || "",
-    markdownTemplate: body.markdownTemplate || "",
-  });
+  let result;
+  try {
+    result = await upsertNewsletterTemplate({
+      newsletterType: body.newsletterType || "",
+      subjectTemplate: body.subjectTemplate || "",
+      htmlTemplate: body.htmlTemplate || "",
+      textTemplate: body.textTemplate || "",
+      markdownTemplate: body.markdownTemplate || "",
+    });
+  } catch (error) {
+    console.error("[api/newsletter/templates] PUT failed:", error);
+    if (isMissingNewsletterSchemaError(error)) {
+      return Response.json(
+        { error: NEWSLETTER_DB_UNAVAILABLE_ERROR, meta: getNewsletterAvailabilityMeta() },
+        { status: 503 }
+      );
+    }
+    return Response.json({ error: "Failed to save newsletter template" }, { status: 500 });
+  }
 
   if (!result.ok) {
     return Response.json({ error: result.error }, { status: result.status });

--- a/src/app/newsletters/[id]/page.tsx
+++ b/src/app/newsletters/[id]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { Navbar } from "@/components/Navbar";
 import { NewsletterIframe } from "@/components/NewsletterIframe";
-import { getSentNewsletterCampaignForArchive } from "@/services/newsletter";
+import { loadPublicNewsletterCampaign } from "@/lib/newsletter-archive";
 
 export const dynamic = "force-dynamic";
 
@@ -10,7 +10,11 @@ type Props = { params: Promise<{ id: string }> };
 
 export async function generateMetadata({ params }: Props) {
   const { id } = await params;
-  const campaign = await getSentNewsletterCampaignForArchive(id);
+  const { available, campaign } = await loadPublicNewsletterCampaign(id);
+
+  if (!available) {
+    return { title: "Newsletter Archive Unavailable" };
+  }
 
   if (!campaign) {
     return { title: "Newsletter Not Found" };
@@ -24,7 +28,31 @@ export async function generateMetadata({ params }: Props) {
 
 export default async function NewsletterViewPage({ params }: Props) {
   const { id } = await params;
-  const campaign = await getSentNewsletterCampaignForArchive(id);
+  const { available, campaign } = await loadPublicNewsletterCampaign(id);
+
+  if (!available) {
+    return (
+      <>
+        <Navbar />
+        <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-6">
+          <div className="max-w-4xl mx-auto py-8 sm:py-12">
+            <div className="mb-6">
+              <Link
+                href="/newsletters"
+                className="text-sm text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
+              >
+                &larr; All Newsletters
+              </Link>
+            </div>
+            <div className="rounded-2xl border border-amber-200 bg-amber-50 px-5 py-6 text-sm text-amber-900 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-100">
+              Newsletter archive is temporarily unavailable. Try again after the
+              newsletter database is available again.
+            </div>
+          </div>
+        </main>
+      </>
+    );
+  }
 
   if (!campaign) {
     notFound();

--- a/src/app/newsletters/page.tsx
+++ b/src/app/newsletters/page.tsx
@@ -1,8 +1,6 @@
 import Link from "next/link";
 import { Navbar } from "@/components/Navbar";
-import {
-  listSentNewsletterCampaigns,
-} from "@/services/newsletter";
+import { loadPublicNewsletterArchive } from "@/lib/newsletter-archive";
 
 export const metadata = {
   title: "Newsletter Archive",
@@ -25,7 +23,7 @@ const TYPE_COLORS: Record<string, string> = {
 };
 
 export default async function NewslettersPage() {
-  const campaigns = await listSentNewsletterCampaigns();
+  const { available, campaigns } = await loadPublicNewsletterArchive();
 
   return (
     <>
@@ -50,7 +48,13 @@ export default async function NewslettersPage() {
             </p>
           </div>
 
-          {campaigns.length === 0 ? (
+          {!available ? (
+            <div className="rounded-2xl border border-amber-200 bg-amber-50 px-5 py-6 text-sm text-amber-900 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-100">
+              Newsletter archive is temporarily unavailable. This usually means the
+              newsletter database schema has not been applied yet or the archive
+              is offline.
+            </div>
+          ) : campaigns.length === 0 ? (
             <p className="text-center text-neutral-500 py-12">
               No newsletters have been sent yet. Check back soon!
             </p>

--- a/src/components/NewsTools.tsx
+++ b/src/components/NewsTools.tsx
@@ -1,11 +1,12 @@
-import { listSentNewsletterCampaigns } from "@/services/newsletter";
+import { loadPublicNewsletterArchive } from "@/lib/newsletter-archive";
 import { NewsToolsClient } from "@/components/NewsToolsClient";
 
 export async function NewsTools() {
-  const campaigns = await listSentNewsletterCampaigns(4);
+  const { available, campaigns } = await loadPublicNewsletterArchive(4);
 
   return (
     <NewsToolsClient
+      archiveAvailable={available}
       campaigns={campaigns.map((campaign) => ({
         id: campaign.id,
         subject: campaign.subject,

--- a/src/components/NewsToolsClient.tsx
+++ b/src/components/NewsToolsClient.tsx
@@ -21,6 +21,7 @@ type ArchiveCampaignPreview = {
 
 type NewsToolsClientProps = {
   campaigns: ArchiveCampaignPreview[];
+  archiveAvailable?: boolean;
 };
 
 const TAB_LABELS: Record<NewsToolsTab, { title: string; blurb: string }> = {
@@ -66,7 +67,23 @@ function formatShortDate(value: string | null) {
   });
 }
 
-function ArchivePanel({ campaigns }: { campaigns: ArchiveCampaignPreview[] }) {
+function ArchivePanel({
+  campaigns,
+  archiveAvailable,
+}: {
+  campaigns: ArchiveCampaignPreview[];
+  archiveAvailable: boolean;
+}) {
+  if (!archiveAvailable) {
+    return (
+      <div className="rounded-[1.5rem] border border-dashed border-amber-300/80 bg-amber-50/80 px-4 py-5 text-sm text-amber-900 dark:border-amber-900/80 dark:bg-amber-950/40 dark:text-amber-100">
+        Newsletter archive is temporarily unavailable. The rest of the news page
+        still works, but newsletter history is offline until the newsletter
+        database is available again.
+      </div>
+    );
+  }
+
   if (campaigns.length === 0) {
     return (
       <div className="rounded-[1.5rem] border border-dashed border-neutral-300/80 bg-white/70 px-4 py-5 text-sm text-neutral-500 dark:border-neutral-700 dark:bg-neutral-950/60 dark:text-neutral-400">
@@ -339,7 +356,10 @@ function RecommendationsPanel() {
   );
 }
 
-export function NewsToolsClient({ campaigns }: NewsToolsClientProps) {
+export function NewsToolsClient({
+  campaigns,
+  archiveAvailable = true,
+}: NewsToolsClientProps) {
   const [activeTab, setActiveTab] = useState<NewsToolsTab>("archive");
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const panelId = useId();
@@ -418,7 +438,12 @@ export function NewsToolsClient({ campaigns }: NewsToolsClientProps) {
             </div>
           </div>
 
-          {activeTab === "archive" && <ArchivePanel campaigns={campaigns} />}
+          {activeTab === "archive" && (
+            <ArchivePanel
+              campaigns={campaigns}
+              archiveAvailable={archiveAvailable}
+            />
+          )}
           {activeTab === "subscribe" && <SubscribePanel />}
           {activeTab === "recommendations" && <RecommendationsPanel />}
         </div>

--- a/src/components/NewsletterArchivePreview.tsx
+++ b/src/components/NewsletterArchivePreview.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { listSentNewsletterCampaigns } from "@/services/newsletter";
+import { loadPublicNewsletterArchive } from "@/lib/newsletter-archive";
 
 const TYPE_LABELS: Record<string, string> = {
   news: "News",
@@ -14,7 +14,11 @@ const TYPE_COLORS: Record<string, string> = {
 };
 
 export async function NewsletterArchivePreview() {
-  const campaigns = await listSentNewsletterCampaigns(3);
+  const { available, campaigns } = await loadPublicNewsletterArchive(3);
+
+  if (!available) {
+    return null;
+  }
 
   if (campaigns.length === 0) {
     return null;

--- a/src/components/admin/NewsletterStudio.tsx
+++ b/src/components/admin/NewsletterStudio.tsx
@@ -22,6 +22,10 @@ type NewsletterType = "news" | "jobs" | "candidates";
 type NewsletterContentMode = "template" | "markdown" | "manual";
 type CampaignStatus = "draft" | "scheduled" | "sending" | "sent" | "failed";
 type WorkspaceView = "editor" | "split" | "preview";
+type AvailabilityMeta = {
+  newsletterUnavailable?: boolean;
+  reason?: string;
+};
 
 type Mode = "compose" | "queue" | "subscribers" | "templates";
 type PreviewTab = "subject" | "html" | "text" | "starter";
@@ -255,6 +259,14 @@ function formatLocalInputFromIso(iso: string | null): string {
   return `${yyyy}-${mm}-${dd}T${hh}:${min}`;
 }
 
+function getAvailabilityReason(meta: Record<string, unknown> | null): string | null {
+  const candidate = meta as AvailabilityMeta | null;
+  if (!candidate?.newsletterUnavailable) return null;
+  return typeof candidate.reason === "string" && candidate.reason.trim()
+    ? candidate.reason
+    : "Newsletter database is temporarily unavailable.";
+}
+
 function StatusPill({ status }: { status: CampaignStatus }) {
   const styles = {
     draft: "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200",
@@ -462,6 +474,7 @@ export function NewsletterStudio() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+  const [availabilityError, setAvailabilityError] = useState<string | null>(null);
 
   const [campaigns, setCampaigns] = useState<NewsletterCampaign[]>([]);
   const [templates, setTemplates] = useState<Record<NewsletterType, NewsletterTemplate> | null>(null);
@@ -545,12 +558,18 @@ export function NewsletterStudio() {
 
   const refreshData = useCallback(async () => {
     setError(null);
+    setAvailabilityError(null);
 
     const headers = { "x-api-key": getAdminApiKey() };
     const [campaignsResult, templatesResult] = await Promise.all([
       adminFetch<NewsletterCampaign[]>("/api/v1/newsletter/campaigns?limit=100", { headers }),
       adminFetch<NewsletterTemplate[]>("/api/v1/newsletter/templates", { headers }),
     ]);
+
+    const availabilityReason =
+      getAvailabilityReason(campaignsResult.meta) ||
+      getAvailabilityReason(templatesResult.meta);
+    setAvailabilityError(availabilityReason);
 
     if (campaignsResult.error) {
       setError(campaignsResult.error);
@@ -580,6 +599,11 @@ export function NewsletterStudio() {
 
     setSubscribersLoading(false);
 
+    const availabilityReason = getAvailabilityReason(result.meta);
+    if (availabilityReason) {
+      setAvailabilityError(availabilityReason);
+    }
+
     if (result.error) {
       setError(result.error);
       return;
@@ -588,6 +612,12 @@ export function NewsletterStudio() {
     setSubscribers((result.data || []).map((subscriber) => toSubscriberDraftRow(subscriber)));
     setSubscribersLoaded(true);
   }, []);
+
+  const ensureNewsletterWritable = useCallback(() => {
+    if (!availabilityError) return true;
+    setError(availabilityError);
+    return false;
+  }, [availabilityError]);
 
   useEffect(() => {
     const load = async () => {
@@ -755,6 +785,7 @@ export function NewsletterStudio() {
   );
 
   const createCampaign = async () => {
+    if (!ensureNewsletterWritable()) return;
     if (!composeForm.subject.trim()) {
       setError("Subject is required");
       return;
@@ -806,6 +837,7 @@ export function NewsletterStudio() {
   };
 
   const autoCreateWeekly = async () => {
+    if (!ensureNewsletterWritable()) return;
     setSaving(true);
     setError(null);
 
@@ -840,6 +872,7 @@ export function NewsletterStudio() {
   };
 
   const scheduleCampaign = async (campaignId: string) => {
+    if (!ensureNewsletterWritable()) return;
     const localValue = scheduleDrafts[campaignId];
     if (!localValue) {
       setError("Pick a schedule date/time first");
@@ -870,6 +903,7 @@ export function NewsletterStudio() {
   };
 
   const sendNow = async (campaignId: string) => {
+    if (!ensureNewsletterWritable()) return;
     setSaving(true);
     setError(null);
 
@@ -890,6 +924,7 @@ export function NewsletterStudio() {
   };
 
   const deleteCampaign = async (campaign: NewsletterCampaign) => {
+    if (!ensureNewsletterWritable()) return;
     if (!MUTABLE_STATUSES.has(campaign.status)) return;
     const ok = confirm(`Delete draft \"${campaign.subject}\"? This cannot be undone.`);
     if (!ok) return;
@@ -918,6 +953,7 @@ export function NewsletterStudio() {
   };
 
   const openCampaignEditor = async (campaignId: string) => {
+    if (!ensureNewsletterWritable()) return;
     if (editingCampaignId && isEditDirty) {
       const confirmed = confirm("You have unsaved campaign edits. Continue and discard them?");
       if (!confirmed) return;
@@ -958,6 +994,7 @@ export function NewsletterStudio() {
   };
 
   const saveCampaignEdit = async () => {
+    if (!ensureNewsletterWritable()) return;
     if (!editingCampaignId || !editForm) return;
 
     setSaving(true);
@@ -1021,6 +1058,7 @@ export function NewsletterStudio() {
   }, [mode, editForm, renderEditPreview]);
 
   const saveTemplate = async () => {
+    if (!ensureNewsletterWritable()) return;
     if (!templateDraft) return;
 
     setSaving(true);
@@ -1411,6 +1449,7 @@ export function NewsletterStudio() {
   };
 
   const saveSubscriberDraft = async (subscriberId: string) => {
+    if (!ensureNewsletterWritable()) return;
     const subscriber = subscribers.find((row) => row.id === subscriberId);
     if (!subscriber) return;
 
@@ -1478,6 +1517,14 @@ export function NewsletterStudio() {
 
   return (
     <div className="space-y-4">
+      {availabilityError && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-100">
+          {availabilityError} Read-only fallbacks are enabled where possible, but
+          queue and subscriber write actions stay disabled until migrations are
+          applied.
+        </div>
+      )}
+
       {error && (
         <ErrorAlert
           message={error}

--- a/src/lib/admin-utils.ts
+++ b/src/lib/admin-utils.ts
@@ -14,6 +14,7 @@ export function getAdminApiKey(): string {
 export interface FetchResult<T> {
   data: T | null;
   error: string | null;
+  meta: Record<string, unknown> | null;
 }
 
 /**
@@ -36,22 +37,23 @@ export async function adminFetch<T>(
 
       // Special handling for auth errors
       if (res.status === 401) {
-        return { data: null, error: "Invalid or missing API key" };
+        return { data: null, error: "Invalid or missing API key", meta: errorBody.meta ?? null };
       }
       if (res.status === 403) {
-        return { data: null, error: "Access denied" };
+        return { data: null, error: "Access denied", meta: errorBody.meta ?? null };
       }
 
-      return { data: null, error: errorMessage };
+      return { data: null, error: errorMessage, meta: errorBody.meta ?? null };
     }
 
     const json = await res.json();
-    return { data: json.data ?? json, error: null };
+    return { data: json.data ?? json, error: null, meta: json.meta ?? null };
   } catch (error) {
     console.error(`Fetch error for ${url}:`, error);
     return {
       data: null,
       error: "Network error. Please check your connection and try again.",
+      meta: null,
     };
   }
 }

--- a/src/lib/newsletter-archive.ts
+++ b/src/lib/newsletter-archive.ts
@@ -1,0 +1,52 @@
+import {
+  getSentNewsletterCampaignForArchive,
+  listSentNewsletterCampaigns,
+} from "@/services/newsletter";
+
+type PublicNewsletterArchiveResult = {
+  available: boolean;
+  campaigns: Awaited<ReturnType<typeof listSentNewsletterCampaigns>>;
+};
+
+type PublicNewsletterCampaignResult = {
+  available: boolean;
+  campaign: Awaited<ReturnType<typeof getSentNewsletterCampaignForArchive>>;
+};
+
+function logArchiveFailure(operation: string, error: unknown) {
+  console.error(`[newsletter-archive] ${operation} failed`, error);
+}
+
+export async function loadPublicNewsletterArchive(
+  limit: number = 50
+): Promise<PublicNewsletterArchiveResult> {
+  try {
+    return {
+      available: true,
+      campaigns: await listSentNewsletterCampaigns(limit),
+    };
+  } catch (error) {
+    logArchiveFailure("list archive campaigns", error);
+    return {
+      available: false,
+      campaigns: [],
+    };
+  }
+}
+
+export async function loadPublicNewsletterCampaign(
+  id: string
+): Promise<PublicNewsletterCampaignResult> {
+  try {
+    return {
+      available: true,
+      campaign: await getSentNewsletterCampaignForArchive(id),
+    };
+  } catch (error) {
+    logArchiveFailure(`load archive campaign ${id}`, error);
+    return {
+      available: false,
+      campaign: null,
+    };
+  }
+}

--- a/src/services/newsletter-schema.ts
+++ b/src/services/newsletter-schema.ts
@@ -1,0 +1,50 @@
+export const NEWSLETTER_DB_UNAVAILABLE_ERROR =
+  "Newsletter database is temporarily unavailable. Run the newsletter migrations and try again.";
+
+export type NewsletterAvailabilityMeta = {
+  newsletterUnavailable: true;
+  reason: string;
+};
+
+function collectErrorMessages(error: unknown, depth: number = 0): string[] {
+  if (!error || depth > 3) return [];
+
+  if (typeof error === "string") return [error];
+
+  if (error instanceof Error) {
+    const messages = [error.message];
+    const cause = "cause" in error ? (error as Error & { cause?: unknown }).cause : undefined;
+    return [...messages, ...collectErrorMessages(cause, depth + 1)];
+  }
+
+  if (typeof error === "object") {
+    const values = Object.values(error as Record<string, unknown>);
+    return values.flatMap((value) => collectErrorMessages(value, depth + 1));
+  }
+
+  return [];
+}
+
+export function isMissingNewsletterSchemaError(error: unknown): boolean {
+  const haystack = collectErrorMessages(error)
+    .join("\n")
+    .toLowerCase();
+
+  const mentionsNewsletter =
+    haystack.includes("newsletter_") || haystack.includes("newsletter ");
+  const mentionsMissingSchema =
+    haystack.includes("does not exist") ||
+    haystack.includes("undefined column") ||
+    haystack.includes("unknown column") ||
+    haystack.includes("no such table") ||
+    haystack.includes("relation");
+
+  return mentionsNewsletter && mentionsMissingSchema;
+}
+
+export function getNewsletterAvailabilityMeta(): NewsletterAvailabilityMeta {
+  return {
+    newsletterUnavailable: true,
+    reason: NEWSLETTER_DB_UNAVAILABLE_ERROR,
+  };
+}

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -29,6 +29,7 @@ import {
   normalizeNewsletterContentMode,
 } from "@/lib/newsletter-utils";
 import { getRecommendedLinks, OTHER_CONTENT_I_LIKE } from "@/lib/recommendations";
+import { isMissingNewsletterSchemaError } from "@/services/newsletter-schema";
 
 type SendResult = { success: true; messageId: string } | { success: false; error: string };
 
@@ -135,6 +136,26 @@ const DEFAULT_NEWSLETTER_TEMPLATES: Record<NewsletterType, NewsletterTemplatePay
     markdownTemplate: "{{default_markdown_body}}",
   },
 };
+
+function getDefaultNewsletterTemplate(newsletterType: NewsletterType): NewsletterTemplatePayload {
+  return DEFAULT_NEWSLETTER_TEMPLATES[newsletterType];
+}
+
+export function getDefaultNewsletterTemplates(): NewsletterTemplatePayload[] {
+  return NEWSLETTER_TYPES.map((newsletterType) => getDefaultNewsletterTemplate(newsletterType));
+}
+
+async function loadStoredNewsletterTemplates() {
+  try {
+    return await db.select().from(newsletterTemplates);
+  } catch (error) {
+    if (isMissingNewsletterSchemaError(error)) {
+      console.error("[newsletter] templates table unavailable, using defaults", error);
+      return null;
+    }
+    throw error;
+  }
+}
 
 const LEGACY_NEWS_HTML_TEMPLATE = "{{default_html_body}}<hr /><h3>Recent News</h3><ul>{{recent_news_html}}</ul>";
 const LEGACY_NEWS_TEXT_TEMPLATE = "{{default_text_body}}\n\nRecent News:\n{{recent_news_text}}";
@@ -1333,14 +1354,15 @@ function renderRecentNewsText(recentNews: Awaited<ReturnType<typeof getRecentNew
 }
 
 async function getNewsletterTemplatePayload(newsletterType: NewsletterType): Promise<NewsletterTemplatePayload> {
-  const [stored] = await db
-    .select()
-    .from(newsletterTemplates)
-    .where(eq(newsletterTemplates.newsletterType, newsletterType))
-    .limit(1);
+  const templates = await loadStoredNewsletterTemplates();
+  if (!templates) {
+    return getDefaultNewsletterTemplate(newsletterType);
+  }
+
+  const stored = templates.find((template) => template.newsletterType === newsletterType);
 
   if (!stored) {
-    return DEFAULT_NEWSLETTER_TEMPLATES[newsletterType];
+    return getDefaultNewsletterTemplate(newsletterType);
   }
 
   return normalizeLegacyTemplatePayload({
@@ -1551,13 +1573,17 @@ function resolveCampaignRenderContent(params: {
 }
 
 export async function listNewsletterTemplates() {
-  const templates = await db.select().from(newsletterTemplates);
+  const templates = await loadStoredNewsletterTemplates();
+  if (!templates) {
+    return getDefaultNewsletterTemplates();
+  }
+
   const byType = new Map(templates.map((template) => [template.newsletterType, template]));
 
   return NEWSLETTER_TYPES.map((type) => {
     const stored = byType.get(type);
     if (!stored) {
-      return DEFAULT_NEWSLETTER_TEMPLATES[type];
+      return getDefaultNewsletterTemplate(type);
     }
     return normalizeLegacyTemplatePayload({
       newsletterType: type,

--- a/tests/newsletter-archive.test.ts
+++ b/tests/newsletter-archive.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("public newsletter archive loaders", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("returns an unavailable archive state when listing campaigns throws", async () => {
+    const originalConsoleError = console.error;
+    console.error = (() => {}) as typeof console.error;
+    mock.module("@/services/newsletter", () => ({
+      listSentNewsletterCampaigns: async () => {
+        throw new Error('relation "newsletter_campaigns" does not exist');
+      },
+      getSentNewsletterCampaignForArchive: async () => null,
+    }));
+
+    const { loadPublicNewsletterArchive } = await import(
+      `../src/lib/newsletter-archive?newsletter-archive-list=${Date.now()}`
+    );
+    const result = await loadPublicNewsletterArchive(4);
+
+    expect(result).toEqual({
+      available: false,
+      campaigns: [],
+    });
+
+    console.error = originalConsoleError;
+  });
+
+  test("returns an unavailable campaign state when reading a campaign throws", async () => {
+    const originalConsoleError = console.error;
+    console.error = (() => {}) as typeof console.error;
+    mock.module("@/services/newsletter", () => ({
+      listSentNewsletterCampaigns: async () => [],
+      getSentNewsletterCampaignForArchive: async () => {
+        throw new Error('relation "newsletter_campaigns" does not exist');
+      },
+    }));
+
+    const { loadPublicNewsletterCampaign } = await import(
+      `../src/lib/newsletter-archive?newsletter-archive-campaign=${Date.now()}`
+    );
+    const result = await loadPublicNewsletterCampaign("camp_123");
+
+    expect(result).toEqual({
+      available: false,
+      campaign: null,
+    });
+
+    console.error = originalConsoleError;
+  });
+
+  test("passes through sent campaigns when the archive query succeeds", async () => {
+    const campaigns = [
+      {
+        id: "camp_123",
+        subject: "Weekly News Digest",
+        previewText: "Top updates",
+        newsletterType: "news",
+        sentAt: new Date("2026-03-11T08:00:00.000Z"),
+      },
+    ];
+
+    mock.module("@/services/newsletter", () => ({
+      listSentNewsletterCampaigns: async () => campaigns,
+      getSentNewsletterCampaignForArchive: async () => campaigns[0],
+    }));
+
+    const { loadPublicNewsletterArchive, loadPublicNewsletterCampaign } = await import(
+      `../src/lib/newsletter-archive?newsletter-archive-success=${Date.now()}`
+    );
+
+    await expect(loadPublicNewsletterArchive(1)).resolves.toEqual({
+      available: true,
+      campaigns,
+    });
+    await expect(loadPublicNewsletterCampaign("camp_123")).resolves.toEqual({
+      available: true,
+      campaign: campaigns[0],
+    });
+  });
+});

--- a/tests/newsletter-campaigns-route.test.ts
+++ b/tests/newsletter-campaigns-route.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("GET /api/v1/newsletter/campaigns", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("returns an unavailable fallback instead of 500 when the campaigns table is missing", async () => {
+    mock.module("@/services/auth", () => ({
+      requireAuth: async () => ({ valid: true as const, keyId: "key_123", name: "Admin" }),
+    }));
+    mock.module("@/services/newsletter", () => ({
+      listNewsletterCampaigns: async () => {
+        throw new Error('relation "newsletter_campaigns" does not exist');
+      },
+      createNewsletterCampaign: async () => ({ ok: true as const, data: null }),
+    }));
+
+    const { GET } = await import("../src/app/api/v1/newsletter/campaigns/route");
+    const response = await GET(
+      new Request("https://dcbuilder.dev/api/v1/newsletter/campaigns?limit=25") as never
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual([]);
+    expect(body.meta.newsletterUnavailable).toBe(true);
+    expect(body.meta.reason).toContain("temporarily unavailable");
+  });
+});

--- a/tests/newsletter-markdown-text.test.ts
+++ b/tests/newsletter-markdown-text.test.ts
@@ -14,6 +14,8 @@ describe("previewNewsletterCampaignDraft markdown text output", () => {
             where: () => ({
               limit: async () => [],
             }),
+            then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
+              Promise.resolve([]).then(resolve, reject),
           }),
         }),
       },

--- a/tests/newsletter-subscribers-get-route.test.ts
+++ b/tests/newsletter-subscribers-get-route.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("GET /api/v1/newsletter/subscribers", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("returns an unavailable fallback instead of 500 when subscriber tables are missing", async () => {
+    const actualDb = await import("../src/db");
+
+    mock.module("@/services/auth", () => ({
+      requireAuth: async () => ({ valid: true as const, keyId: "key_123", name: "Admin" }),
+    }));
+    mock.module("@/db", () => ({
+      ...actualDb,
+      db: {
+        select: () => ({
+          from: () => {
+            throw new Error('relation "newsletter_subscribers" does not exist');
+          },
+        }),
+      },
+    }));
+    mock.module("@/services/posthog", () => ({
+      getEmailClicksLast7Days: async () => ({ success: true as const, data: [] }),
+    }));
+
+    const { GET } = await import("../src/app/api/v1/newsletter/subscribers/route");
+    const response = await GET(
+      new Request("https://dcbuilder.dev/api/v1/newsletter/subscribers?limit=50") as never
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual([]);
+    expect(body.total).toBe(0);
+    expect(body.meta.newsletterUnavailable).toBe(true);
+  });
+});

--- a/tests/newsletter-templates-fallback.test.ts
+++ b/tests/newsletter-templates-fallback.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("newsletter template fallbacks", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("uses default templates when the newsletter templates table is missing", async () => {
+    const actualDb = await import("../src/db");
+
+    mock.module("@/db", () => ({
+      ...actualDb,
+      db: {
+        select: () => ({
+          from: () => {
+            throw new Error('relation "newsletter_templates" does not exist');
+          },
+        }),
+      },
+    }));
+
+    const { listNewsletterTemplates } = await import(
+      `../src/services/newsletter?newsletter-templates-fallback=${Date.now()}`
+    );
+    const templates = await listNewsletterTemplates();
+
+    expect(templates).toHaveLength(3);
+    expect(templates.map((template) => template.newsletterType)).toEqual([
+      "news",
+      "jobs",
+      "candidates",
+    ]);
+    expect(templates.every((template) => template.markdownTemplate.length > 0)).toBe(true);
+  });
+});

--- a/tests/newsletter-templates-fallback.test.ts
+++ b/tests/newsletter-templates-fallback.test.ts
@@ -22,14 +22,19 @@ describe("newsletter template fallbacks", () => {
     const { listNewsletterTemplates } = await import(
       `../src/services/newsletter?newsletter-templates-fallback=${Date.now()}`
     );
-    const templates = await listNewsletterTemplates();
+    const templates: Awaited<ReturnType<typeof listNewsletterTemplates>> =
+      await listNewsletterTemplates();
 
     expect(templates).toHaveLength(3);
-    expect(templates.map((template) => template.newsletterType)).toEqual([
+    expect(
+      templates.map((template: { newsletterType: string }) => template.newsletterType)
+    ).toEqual([
       "news",
       "jobs",
       "candidates",
     ]);
-    expect(templates.every((template) => template.markdownTemplate.length > 0)).toBe(true);
+    expect(
+      templates.every((template: { markdownTemplate: string }) => template.markdownTemplate.length > 0)
+    ).toBe(true);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,5 +31,12 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "scripts"]
+  "exclude": [
+    "node_modules",
+    "scripts",
+    "worktrees",
+    ".worktrees",
+    "test-results",
+    ".vercel"
+  ]
 }


### PR DESCRIPTION
## Summary
- fail closed for public newsletter archive and news surfaces when newsletter tables are missing
- make admin newsletter studio degrade into a readable warning state instead of throwing 500s
- isolate Bun unit tests to the repo root tests directory and keep local worktree artifacts out of repo tooling

## Verification
- bun run lint
- bun run test:unit
- bun run build
