### PR TITLE
Fix hosted newsletter archive on public news pages

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,11 +1,15 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { getPostgresClientOptions } from "./postgres-connection";
 import * as schema from "./schema";
 
 const connectionString = process.env.DATABASE_URL!;
 
 // For query purposes
-const queryClient = postgres(connectionString);
+const queryClient = postgres(
+  connectionString,
+  getPostgresClientOptions(connectionString) as Parameters<typeof postgres>[1]
+);
 export const db = drizzle(queryClient, { schema });
 
 // Re-export schema for convenience

--- a/src/db/postgres-connection.ts
+++ b/src/db/postgres-connection.ts
@@ -17,6 +17,10 @@ export type PreferredPostgresTarget = {
   tlsServername: string | undefined;
 };
 
+type PostgresClientOptions = {
+  socket?: () => Promise<ConnectedSocket>;
+};
+
 type ConnectedSocket = net.Socket & {
   host: string;
   port: number;
@@ -80,4 +84,36 @@ export async function createPreferredPostgresSocket(
   socket.port = target.port;
 
   return socket;
+}
+
+function isLoopbackHostname(hostname: string) {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]"
+  );
+}
+
+export function getPostgresClientOptions(
+  databaseUrl: string | undefined
+): PostgresClientOptions {
+  if (!databaseUrl) {
+    return {};
+  }
+
+  let hostname: string;
+  try {
+    hostname = new URL(databaseUrl).hostname;
+  } catch {
+    return {};
+  }
+
+  if (isLoopbackHostname(hostname)) {
+    return {};
+  }
+
+  return {
+    socket: () => createPreferredPostgresSocket(databaseUrl),
+  };
 }

--- a/tests/postgres-connection-target.test.ts
+++ b/tests/postgres-connection-target.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { resolvePreferredPostgresTarget } from "../src/db/postgres-connection";
+import {
+  getPostgresClientOptions,
+  resolvePreferredPostgresTarget,
+} from "../src/db/postgres-connection";
 
 describe("resolvePreferredPostgresTarget", () => {
   test("prefers an IPv4 connect target while preserving the hostname for TLS", async () => {
@@ -13,5 +16,23 @@ describe("resolvePreferredPostgresTarget", () => {
       port: 5432,
       tlsServername: "db.example.com",
     });
+  });
+});
+
+describe("getPostgresClientOptions", () => {
+  test("uses a preferred socket for hosted database URLs", () => {
+    const result = getPostgresClientOptions(
+      "postgresql://user:pass@db.example.com:5432/app"
+    );
+
+    expect(result.socket).toBeFunction();
+  });
+
+  test("leaves localhost connections on the default client path", () => {
+    const result = getPostgresClientOptions(
+      "postgresql://user:pass@127.0.0.1:5432/app"
+    );
+
+    expect(result.socket).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- route the runtime Postgres client through the hosted-Postgres preferred socket path for non-loopback `DATABASE_URL`s
- keep localhost and env-less test imports on the default path so existing test setup still works
- add regression coverage for hosted-vs-local runtime DB client options

## Root Cause
The merged newsletter stability work updated migration and cleanup scripts to use the IPv4/TLS-safe Postgres socket flow, but the live Next.js runtime still instantiated `postgres(process.env.DATABASE_URL)` directly. That left Vercel runtime requests on the old connection path, so `/news` could still fall back to the newsletter archive unavailable state even though the scripts had been fixed.

## Verification
- `bun test tests/postgres-connection-target.test.ts`
- `bunx tsc --noEmit`
- `bun run lint`
- `bun run test:unit`
- `bun run build`
- local Playwright check of `http://127.0.0.1:3000/news` showing `1 recent issues` and the latest issue card instead of the archive warning
