### PR TITLE
Add canonical public slugs for newsletter archives

### DIFF
--- a/drizzle/0011_newsletter_campaign_public_slug.sql
+++ b/drizzle/0011_newsletter_campaign_public_slug.sql
@@ -1,0 +1,44 @@
+ALTER TABLE "newsletter_campaigns"
+  ADD COLUMN IF NOT EXISTS "public_slug" text;
+
+WITH prepared_campaign_slugs AS (
+  SELECT
+    "id",
+    CONCAT(
+      COALESCE(
+        NULLIF(
+          TRIM(BOTH '-' FROM REGEXP_REPLACE(LOWER("subject"), '[^a-z0-9]+', '-', 'g')),
+          ''
+        ),
+        'newsletter'
+      ),
+      '-',
+      TO_CHAR(TIMEZONE('UTC', COALESCE("sent_at", "scheduled_at", "created_at")), 'YYYY-MM-DD')
+    ) AS "base_slug",
+    COALESCE("sent_at", "scheduled_at", "created_at") AS "anchor_at"
+  FROM "newsletter_campaigns"
+  WHERE "public_slug" IS NULL
+),
+ranked_campaign_slugs AS (
+  SELECT
+    "id",
+    "base_slug",
+    ROW_NUMBER() OVER (
+      PARTITION BY "base_slug"
+      ORDER BY "anchor_at", "id"
+    ) AS "slug_rank"
+  FROM prepared_campaign_slugs
+)
+UPDATE "newsletter_campaigns" AS "campaigns"
+SET "public_slug" = CASE
+  WHEN ranked_campaign_slugs."slug_rank" = 1 THEN ranked_campaign_slugs."base_slug"
+  ELSE CONCAT(ranked_campaign_slugs."base_slug", '-', ranked_campaign_slugs."slug_rank")
+END
+FROM ranked_campaign_slugs
+WHERE "campaigns"."id" = ranked_campaign_slugs."id";
+
+ALTER TABLE "newsletter_campaigns"
+  ALTER COLUMN "public_slug" SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "newsletter_campaigns_public_slug_uidx"
+  ON "newsletter_campaigns" USING btree ("public_slug");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,20 @@
       "when": 1773316800000,
       "tag": "0009_archive_newsletter_corrections",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1773403200000,
+      "tag": "0010_news_relevance_and_summary_controls",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1773792000000,
+      "tag": "0011_newsletter_campaign_public_slug",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/newsletters/[id]/page.tsx
+++ b/src/app/newsletters/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import Link from "next/link";
 import { Navbar } from "@/components/Navbar";
 import { NewsletterIframe } from "@/components/NewsletterIframe";
@@ -10,10 +10,14 @@ type Props = { params: Promise<{ id: string }> };
 
 export async function generateMetadata({ params }: Props) {
   const { id } = await params;
-  const { available, campaign } = await loadPublicNewsletterCampaign(id);
+  const { available, campaign, redirectTo } = await loadPublicNewsletterCampaign(id);
 
   if (!available) {
     return { title: "Newsletter Archive Unavailable" };
+  }
+
+  if (redirectTo) {
+    permanentRedirect(redirectTo);
   }
 
   if (!campaign) {
@@ -28,7 +32,7 @@ export async function generateMetadata({ params }: Props) {
 
 export default async function NewsletterViewPage({ params }: Props) {
   const { id } = await params;
-  const { available, campaign } = await loadPublicNewsletterCampaign(id);
+  const { available, campaign, redirectTo } = await loadPublicNewsletterCampaign(id);
 
   if (!available) {
     return (
@@ -52,6 +56,10 @@ export default async function NewsletterViewPage({ params }: Props) {
         </main>
       </>
     );
+  }
+
+  if (redirectTo) {
+    permanentRedirect(redirectTo);
   }
 
   if (!campaign) {

--- a/src/app/newsletters/page.tsx
+++ b/src/app/newsletters/page.tsx
@@ -63,7 +63,7 @@ export default async function NewslettersPage() {
               {campaigns.map((campaign) => (
                 <Link
                   key={campaign.id}
-                  href={`/newsletters/${campaign.id}`}
+                  href={`/newsletters/${campaign.publicSlug}`}
                   className="block rounded-xl border border-neutral-200 dark:border-neutral-800 p-4 sm:p-5 hover:border-neutral-400 dark:hover:border-neutral-600 hover:bg-neutral-50 dark:hover:bg-neutral-900/40 transition-colors"
                 >
                   <div className="flex items-start justify-between gap-3">

--- a/src/components/NewsTools.tsx
+++ b/src/components/NewsTools.tsx
@@ -9,6 +9,7 @@ export async function NewsTools() {
       archiveAvailable={available}
       campaigns={campaigns.map((campaign) => ({
         id: campaign.id,
+        publicSlug: campaign.publicSlug,
         subject: campaign.subject,
         previewText: campaign.previewText ?? null,
         newsletterType: campaign.newsletterType,

--- a/src/components/NewsToolsClient.tsx
+++ b/src/components/NewsToolsClient.tsx
@@ -13,6 +13,7 @@ type NewsToolsTab = "archive" | "subscribe" | "recommendations";
 
 type ArchiveCampaignPreview = {
   id: string;
+  publicSlug: string;
   subject: string;
   previewText: string | null;
   newsletterType: string;
@@ -97,7 +98,7 @@ function ArchivePanel({
   return (
     <div className="grid gap-3 lg:grid-cols-[minmax(0,1.45fr)_minmax(16rem,0.95fr)]">
       <Link
-        href={`/newsletters/${lead.id}`}
+        href={`/newsletters/${lead.publicSlug}`}
         className="group rounded-[1.5rem] border border-neutral-900 bg-neutral-950 px-4 py-4 text-white transition-transform duration-200 hover:-translate-y-0.5 dark:border-neutral-200 dark:bg-white dark:text-neutral-950"
       >
         <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/60 dark:text-neutral-500">
@@ -120,7 +121,7 @@ function ArchivePanel({
         {rest.map((campaign) => (
           <Link
             key={campaign.id}
-            href={`/newsletters/${campaign.id}`}
+            href={`/newsletters/${campaign.publicSlug}`}
             className="group rounded-[1.25rem] border border-neutral-200 bg-white/80 px-3.5 py-3 transition-colors hover:border-neutral-300 hover:bg-white dark:border-neutral-800 dark:bg-neutral-950/60 dark:hover:border-neutral-700 dark:hover:bg-neutral-950"
           >
             <div className="flex items-start justify-between gap-3">

--- a/src/components/NewsletterArchivePreview.tsx
+++ b/src/components/NewsletterArchivePreview.tsx
@@ -46,7 +46,7 @@ export async function NewsletterArchivePreview() {
         {campaigns.map((campaign) => (
           <Link
             key={campaign.id}
-            href={`/newsletters/${campaign.id}`}
+            href={`/newsletters/${campaign.publicSlug}`}
             className="group flex items-start gap-3 rounded-lg border border-neutral-200 dark:border-neutral-700/60 p-3 hover:border-neutral-400 dark:hover:border-neutral-500 hover:bg-neutral-100/50 dark:hover:bg-neutral-800/40 transition-colors"
           >
             <div className="min-w-0 flex-1">

--- a/src/db/schema/newsletter.ts
+++ b/src/db/schema/newsletter.ts
@@ -46,6 +46,7 @@ export const newsletterCampaigns = pgTable(
     id: text("id")
       .primaryKey()
       .$defaultFn(() => createId()),
+    publicSlug: text("public_slug").notNull(),
     newsletterType: text("newsletter_type").notNull(), // news | jobs | candidates
     subject: text("subject").notNull(),
     previewText: text("preview_text"),
@@ -77,6 +78,7 @@ export const newsletterCampaigns = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
   (table) => [
+    uniqueIndex("newsletter_campaigns_public_slug_uidx").on(table.publicSlug),
     index("newsletter_campaigns_status_idx").on(table.status),
     index("newsletter_campaigns_type_idx").on(table.newsletterType),
     index("newsletter_campaigns_scheduled_idx").on(table.scheduledAt),

--- a/src/lib/newsletter-archive.ts
+++ b/src/lib/newsletter-archive.ts
@@ -1,5 +1,5 @@
 import {
-  getSentNewsletterCampaignForArchive,
+  findSentNewsletterCampaignForArchive,
   listSentNewsletterCampaigns,
 } from "@/services/newsletter";
 
@@ -10,7 +10,8 @@ type PublicNewsletterArchiveResult = {
 
 type PublicNewsletterCampaignResult = {
   available: boolean;
-  campaign: Awaited<ReturnType<typeof getSentNewsletterCampaignForArchive>>;
+  campaign: Awaited<ReturnType<typeof findSentNewsletterCampaignForArchive>>["campaign"];
+  redirectTo: string | null;
 };
 
 function logArchiveFailure(operation: string, error: unknown) {
@@ -38,15 +39,22 @@ export async function loadPublicNewsletterCampaign(
   id: string
 ): Promise<PublicNewsletterCampaignResult> {
   try {
+    const result = await findSentNewsletterCampaignForArchive(id);
+
     return {
       available: true,
-      campaign: await getSentNewsletterCampaignForArchive(id),
+      campaign: result.campaign,
+      redirectTo:
+        result.campaign && result.matchedByLegacyId
+          ? `/newsletters/${result.campaign.publicSlug}`
+          : null,
     };
   } catch (error) {
     logArchiveFailure(`load archive campaign ${id}`, error);
     return {
       available: false,
       campaign: null,
+      redirectTo: null,
     };
   }
 }

--- a/src/lib/newsletter-slug.ts
+++ b/src/lib/newsletter-slug.ts
@@ -1,0 +1,62 @@
+type NewsletterSlugDateAnchorInput = {
+  sentAt?: Date | null;
+  scheduledAt?: Date | null;
+  createdAt?: Date | null;
+};
+
+function padDatePart(value: number) {
+  return String(value).padStart(2, "0");
+}
+
+function formatUtcDate(value: Date) {
+  return [
+    value.getUTCFullYear(),
+    padDatePart(value.getUTCMonth() + 1),
+    padDatePart(value.getUTCDate()),
+  ].join("-");
+}
+
+function normalizeNewsletterSlugSubject(subject: string) {
+  const normalized = subject
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return normalized || "newsletter";
+}
+
+export function deriveNewsletterSlugDateAnchor(input: NewsletterSlugDateAnchorInput) {
+  return input.sentAt ?? input.scheduledAt ?? input.createdAt ?? new Date();
+}
+
+export function buildNewsletterPublicSlug(subject: string, publishDate: Date) {
+  return `${normalizeNewsletterSlugSubject(subject)}-${formatUtcDate(publishDate)}`;
+}
+
+export function ensureUniqueNewsletterPublicSlug(
+  baseSlug: string,
+  existingSlugs: string[],
+) {
+  const existing = new Set(existingSlugs);
+  if (!existing.has(baseSlug)) {
+    return baseSlug;
+  }
+
+  let highestSuffix = 1;
+  const suffixPattern = new RegExp(`^${baseSlug.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-([0-9]+)$`);
+
+  for (const slug of existingSlugs) {
+    const match = slug.match(suffixPattern);
+    if (!match) {
+      continue;
+    }
+
+    const suffix = Number.parseInt(match[1], 10);
+    if (!Number.isNaN(suffix) && suffix > highestSuffix) {
+      highestSuffix = suffix;
+    }
+  }
+
+  return `${baseSlug}-${highestSuffix + 1}`;
+}

--- a/src/services/newsletter-schema.ts
+++ b/src/services/newsletter-schema.ts
@@ -25,6 +25,7 @@ const NEWSLETTER_SCHEMA_COLUMN_HINTS = [
   "archive_corrected_by",
   "timeframe_preset",
   "minimum_relevance",
+  "public_slug",
 ] as const;
 
 function collectErrorMessages(error: unknown, depth: number = 0): string[] {

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "crypto";
-import { and, desc, eq, gt, inArray, isNull, lte } from "drizzle-orm";
+import { and, desc, eq, gt, inArray, isNull, like, lte, ne, or } from "drizzle-orm";
 import {
   db,
   jobs,
@@ -29,6 +29,11 @@ import {
   computeViewTotals,
   normalizeNewsletterContentMode,
 } from "@/lib/newsletter-utils";
+import {
+  buildNewsletterPublicSlug,
+  deriveNewsletterSlugDateAnchor,
+  ensureUniqueNewsletterPublicSlug,
+} from "@/lib/newsletter-slug";
 import { getRecommendedLinks, OTHER_CONTENT_I_LIKE } from "@/lib/recommendations";
 import {
   NEWSLETTER_TIMEFRAME_PRESETS,
@@ -1934,6 +1939,40 @@ function formatUtcDay(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
+async function resolveUniqueNewsletterPublicSlug(params: {
+  subject: string;
+  sentAt?: Date | null;
+  scheduledAt?: Date | null;
+  createdAt?: Date | null;
+  excludeCampaignId?: string;
+}) {
+  const baseSlug = buildNewsletterPublicSlug(
+    params.subject,
+    deriveNewsletterSlugDateAnchor({
+      sentAt: params.sentAt,
+      scheduledAt: params.scheduledAt,
+      createdAt: params.createdAt,
+    }),
+  );
+  const slugCondition = or(
+    eq(newsletterCampaigns.publicSlug, baseSlug),
+    like(newsletterCampaigns.publicSlug, `${baseSlug}-%`),
+  );
+  const whereClause = params.excludeCampaignId
+    ? and(slugCondition, ne(newsletterCampaigns.id, params.excludeCampaignId))
+    : slugCondition;
+
+  const existingSlugs = await db
+    .select({ publicSlug: newsletterCampaigns.publicSlug })
+    .from(newsletterCampaigns)
+    .where(whereClause);
+
+  return ensureUniqueNewsletterPublicSlug(
+    baseSlug,
+    existingSlugs.map((campaign) => campaign.publicSlug),
+  );
+}
+
 export async function createWeeklyNewsCampaignIssue(input?: {
   timeframePreset?: string;
   periodDays?: number;
@@ -2070,18 +2109,26 @@ export async function createNewsletterCampaign(input: {
   if (scheduledAt === "invalid") {
     return { ok: false as const, status: 400, error: "Invalid scheduledAt value" };
   }
+  const subject = input.subject.trim();
+  const now = new Date();
   const content = normalizeCampaignContentByMode({
     contentMode,
     markdownContent: input.markdownContent,
     manualHtml: input.manualHtml,
     manualText: input.manualText,
   });
+  const publicSlug = await resolveUniqueNewsletterPublicSlug({
+    subject,
+    scheduledAt,
+    createdAt: now,
+  });
 
   const [campaign] = await db
     .insert(newsletterCampaigns)
     .values({
+      publicSlug,
       newsletterType: input.newsletterType as NewsletterType,
-      subject: input.subject.trim(),
+      subject,
       previewText: input.previewText || null,
       contentMode,
       markdownContent: content.markdownContent,
@@ -2093,6 +2140,8 @@ export async function createNewsletterCampaign(input: {
       status: scheduledAt ? "scheduled" : "draft",
       scheduledAt,
       createdBy: input.createdBy || null,
+      createdAt: now,
+      updatedAt: now,
     })
     .returning();
 
@@ -2112,10 +2161,17 @@ export async function scheduleNewsletterCampaign(campaignId: string, scheduledAt
   if (scheduledAt === "invalid") {
     return { ok: false as const, status: 400, error: "Invalid scheduledAt value" };
   }
+  const publicSlug = await resolveUniqueNewsletterPublicSlug({
+    subject: existing.data.subject,
+    scheduledAt,
+    createdAt: existing.data.createdAt,
+    excludeCampaignId: campaignId,
+  });
 
   const [campaign] = await db
     .update(newsletterCampaigns)
     .set({
+      publicSlug,
       status: "scheduled",
       scheduledAt,
       updatedAt: new Date(),
@@ -2208,10 +2264,17 @@ export async function updateNewsletterCampaign(campaignId: string, input: {
     manualHtml: input.manualHtml ?? current.data.manualHtml,
     manualText: input.manualText ?? current.data.manualText,
   });
+  const publicSlug = await resolveUniqueNewsletterPublicSlug({
+    subject,
+    scheduledAt,
+    createdAt: current.data.createdAt,
+    excludeCampaignId: campaignId,
+  });
 
   const [updated] = await db
     .update(newsletterCampaigns)
     .set({
+      publicSlug,
       newsletterType,
       subject,
       previewText: input.previewText === undefined ? current.data.previewText : (input.previewText || null),
@@ -2756,11 +2819,23 @@ async function sendCampaignInternal(campaignId: string, force: boolean) {
     });
   }
 
+  const completedAt = failedCount > 0 ? null : new Date();
+  const publicSlug = completedAt
+    ? await resolveUniqueNewsletterPublicSlug({
+      subject: sendingCampaign.subject,
+      sentAt: completedAt,
+      scheduledAt: sendingCampaign.scheduledAt,
+      createdAt: sendingCampaign.createdAt,
+      excludeCampaignId: sendingCampaign.id,
+    })
+    : sendingCampaign.publicSlug;
+
   await db
     .update(newsletterCampaigns)
     .set({
       status: failedCount > 0 ? "failed" : "sent",
-      sentAt: failedCount > 0 ? null : new Date(),
+      sentAt: completedAt,
+      publicSlug,
       failureReason: failedCount > 0 ? `${failedCount} recipients failed` : null,
       updatedAt: new Date(),
     })
@@ -2818,6 +2893,7 @@ export async function listSentNewsletterCampaigns(limit: number = 50) {
   const campaigns = await db
     .select({
       id: newsletterCampaigns.id,
+      publicSlug: newsletterCampaigns.publicSlug,
       subject: newsletterCampaigns.subject,
       previewText: newsletterCampaigns.previewText,
       newsletterType: newsletterCampaigns.newsletterType,
@@ -2835,9 +2911,14 @@ export async function listSentNewsletterCampaigns(limit: number = 50) {
 }
 
 export async function getSentNewsletterCampaignForArchive(id: string) {
+  return (await findSentNewsletterCampaignForArchive(id)).campaign;
+}
+
+async function getSentNewsletterCampaignForArchiveByPublicSlug(publicSlug: string) {
   const [campaign] = await db
     .select({
       id: newsletterCampaigns.id,
+      publicSlug: newsletterCampaigns.publicSlug,
       subject: newsletterCampaigns.subject,
       previewText: newsletterCampaigns.previewText,
       newsletterType: newsletterCampaigns.newsletterType,
@@ -2851,7 +2932,7 @@ export async function getSentNewsletterCampaignForArchive(id: string) {
     .from(newsletterCampaigns)
     .where(
       and(
-        eq(newsletterCampaigns.id, id),
+        eq(newsletterCampaigns.publicSlug, publicSlug),
         eq(newsletterCampaigns.status, "sent")
       )
     )
@@ -2869,8 +2950,55 @@ export async function getSentNewsletterCampaignForArchive(id: string) {
   return resolved;
 }
 
+export async function findSentNewsletterCampaignForArchive(identifier: string) {
+  const slugMatch = await getSentNewsletterCampaignForArchiveByPublicSlug(identifier);
+  if (slugMatch) {
+    return {
+      campaign: slugMatch,
+      matchedByLegacyId: false,
+    };
+  }
+
+  const [campaign] = await db
+    .select({
+      id: newsletterCampaigns.id,
+      publicSlug: newsletterCampaigns.publicSlug,
+      subject: newsletterCampaigns.subject,
+      previewText: newsletterCampaigns.previewText,
+      newsletterType: newsletterCampaigns.newsletterType,
+      sentAt: newsletterCampaigns.sentAt,
+      renderedHtml: newsletterCampaigns.renderedHtml,
+      archiveSubject: newsletterCampaigns.archiveSubject,
+      archivePreviewText: newsletterCampaigns.archivePreviewText,
+      archiveRenderedHtml: newsletterCampaigns.archiveRenderedHtml,
+      archiveCorrectedAt: newsletterCampaigns.archiveCorrectedAt,
+    })
+    .from(newsletterCampaigns)
+    .where(
+      and(
+        eq(newsletterCampaigns.id, identifier),
+        eq(newsletterCampaigns.status, "sent")
+      )
+    )
+    .limit(1);
+
+  const resolved = campaign ? resolveArchiveCampaignDetail(campaign) : null;
+  if (!resolved?.renderedHtml) {
+    return {
+      campaign: null,
+      matchedByLegacyId: false,
+    };
+  }
+
+  return {
+    campaign: resolved,
+    matchedByLegacyId: true,
+  };
+}
+
 function resolveArchiveCampaignSummary(campaign: {
   id: string;
+  publicSlug: string;
   subject: string;
   previewText: string | null;
   newsletterType: string;
@@ -2881,6 +3009,7 @@ function resolveArchiveCampaignSummary(campaign: {
 }) {
   return {
     id: campaign.id,
+    publicSlug: campaign.publicSlug,
     subject: campaign.archiveSubject || campaign.subject,
     previewText: campaign.archivePreviewText ?? campaign.previewText,
     newsletterType: campaign.newsletterType,
@@ -2891,6 +3020,7 @@ function resolveArchiveCampaignSummary(campaign: {
 
 function resolveArchiveCampaignDetail(campaign: {
   id: string;
+  publicSlug: string;
   subject: string;
   previewText: string | null;
   newsletterType: string;
@@ -2903,6 +3033,7 @@ function resolveArchiveCampaignDetail(campaign: {
 }) {
   return {
     id: campaign.id,
+    publicSlug: campaign.publicSlug,
     subject: campaign.archiveSubject || campaign.subject,
     previewText: campaign.archivePreviewText ?? campaign.previewText,
     newsletterType: campaign.newsletterType,

--- a/tests/newsletter-archive-corrections.test.ts
+++ b/tests/newsletter-archive-corrections.test.ts
@@ -3,6 +3,7 @@ import { createPosthogModuleMock } from "./helpers/posthog-module-mock";
 
 type NewsletterCampaignRecord = {
   id: string;
+  publicSlug?: string | null;
   newsletterType: string;
   subject: string;
   previewText: string | null;
@@ -178,6 +179,7 @@ describe("newsletter archive corrections", () => {
     await installNewsletterDbMock({
       selectQueue: [[{
         id: "camp_sent_1",
+        publicSlug: "weekly-news-digest-2026-03-12",
         subject: "Original subject",
         previewText: "Original preview",
         newsletterType: "news",
@@ -197,6 +199,7 @@ describe("newsletter archive corrections", () => {
 
     expect(campaign).toEqual({
       id: "camp_sent_1",
+      publicSlug: "weekly-news-digest-2026-03-12",
       subject: "Corrected archive subject",
       previewText: "Corrected archive preview",
       newsletterType: "news",

--- a/tests/newsletter-archive.test.ts
+++ b/tests/newsletter-archive.test.ts
@@ -15,6 +15,7 @@ describe("public newsletter archive loaders", () => {
         throw new Error('relation "newsletter_campaigns" does not exist');
       },
       getSentNewsletterCampaignForArchive: async () => null,
+      findSentNewsletterCampaignForArchive: async () => ({ campaign: null, matchedByLegacyId: false }),
     }));
 
     const { loadPublicNewsletterArchive } = await import(
@@ -37,7 +38,8 @@ describe("public newsletter archive loaders", () => {
     mock.module("@/services/newsletter", () => ({
       ...actualNewsletter,
       listSentNewsletterCampaigns: async () => [],
-      getSentNewsletterCampaignForArchive: async () => {
+      getSentNewsletterCampaignForArchive: async () => null,
+      findSentNewsletterCampaignForArchive: async () => {
         throw new Error('relation "newsletter_campaigns" does not exist');
       },
     }));
@@ -50,6 +52,7 @@ describe("public newsletter archive loaders", () => {
     expect(result).toEqual({
       available: false,
       campaign: null,
+      redirectTo: null,
     });
 
     console.error = originalConsoleError;
@@ -60,6 +63,7 @@ describe("public newsletter archive loaders", () => {
     const campaigns = [
       {
         id: "camp_123",
+        publicSlug: "weekly-news-digest-2026-03-11",
         subject: "Weekly News Digest",
         previewText: "Top updates",
         newsletterType: "news",
@@ -71,6 +75,10 @@ describe("public newsletter archive loaders", () => {
       ...actualNewsletter,
       listSentNewsletterCampaigns: async () => campaigns,
       getSentNewsletterCampaignForArchive: async () => campaigns[0],
+      findSentNewsletterCampaignForArchive: async (identifier: string) => ({
+        campaign: campaigns[0],
+        matchedByLegacyId: identifier === campaigns[0].id,
+      }),
     }));
 
     const { loadPublicNewsletterArchive, loadPublicNewsletterCampaign } = await import(
@@ -81,9 +89,15 @@ describe("public newsletter archive loaders", () => {
       available: true,
       campaigns,
     });
+    await expect(loadPublicNewsletterCampaign(campaigns[0].publicSlug)).resolves.toEqual({
+      available: true,
+      campaign: campaigns[0],
+      redirectTo: null,
+    });
     await expect(loadPublicNewsletterCampaign("camp_123")).resolves.toEqual({
       available: true,
       campaign: campaigns[0],
+      redirectTo: `/newsletters/${campaigns[0].publicSlug}`,
     });
   });
 });

--- a/tests/newsletter-public-route.test.ts
+++ b/tests/newsletter-public-route.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+describe("newsletter public archive routes", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("permanently redirects legacy ids to the canonical public slug", async () => {
+    mock.module("@/lib/newsletter-archive", () => ({
+      loadPublicNewsletterCampaign: async () => ({
+        available: true,
+        campaign: {
+          id: "camp_123",
+          publicSlug: "weekly-news-digest-2026-03-11",
+          subject: "Weekly News Digest",
+          previewText: "Top updates",
+          newsletterType: "news",
+          sentAt: new Date("2026-03-11T08:00:00.000Z"),
+          renderedHtml: "<p>Body</p>",
+        },
+        redirectTo: "/newsletters/weekly-news-digest-2026-03-11",
+      }),
+    }));
+    mock.module("@/components/Navbar", () => ({
+      Navbar: () => createElement("nav"),
+    }));
+    mock.module("@/components/NewsletterIframe", () => ({
+      NewsletterIframe: ({ html }: { html: string }) => createElement("iframe", { srcDoc: html }),
+    }));
+    mock.module("next/navigation", () => ({
+      notFound: () => {
+        throw new Error("NEXT_NOT_FOUND");
+      },
+      permanentRedirect: (url: string) => {
+        throw new Error(`NEXT_REDIRECT:${url}`);
+      },
+    }));
+
+    const { default: NewsletterViewPage } = await import(
+      `../src/app/newsletters/[id]/page?newsletter-public-route=${Date.now()}`
+    );
+
+    await expect(
+      NewsletterViewPage({ params: Promise.resolve({ id: "camp_123" }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/newsletters/weekly-news-digest-2026-03-11");
+  });
+
+  test("renders the canonical public slug route without redirecting", async () => {
+    mock.module("@/lib/newsletter-archive", () => ({
+      loadPublicNewsletterCampaign: async () => ({
+        available: true,
+        campaign: {
+          id: "camp_123",
+          publicSlug: "weekly-news-digest-2026-03-11",
+          subject: "Weekly News Digest",
+          previewText: "Top updates",
+          newsletterType: "news",
+          sentAt: new Date("2026-03-11T08:00:00.000Z"),
+          renderedHtml: "<p>Body</p>",
+        },
+        redirectTo: null,
+      }),
+    }));
+    mock.module("@/components/Navbar", () => ({
+      Navbar: () => createElement("nav"),
+    }));
+    mock.module("@/components/NewsletterIframe", () => ({
+      NewsletterIframe: ({ html }: { html: string }) => createElement("iframe", { srcDoc: html }),
+    }));
+    mock.module("next/link", () => ({
+      default: ({
+        href,
+        children,
+        ...props
+      }: {
+        href: string;
+        children: ReactNode;
+      }) => createElement("a", { href, ...props }, children),
+    }));
+    mock.module("next/navigation", () => ({
+      notFound: () => {
+        throw new Error("NEXT_NOT_FOUND");
+      },
+      permanentRedirect: (url: string) => {
+        throw new Error(`NEXT_REDIRECT:${url}`);
+      },
+    }));
+
+    const { default: NewsletterViewPage } = await import(
+      `../src/app/newsletters/[id]/page?newsletter-public-render=${Date.now()}`
+    );
+    const markup = renderToStaticMarkup(
+      await NewsletterViewPage({
+        params: Promise.resolve({ id: "weekly-news-digest-2026-03-11" }),
+      }),
+    );
+
+    expect(markup).toContain("Weekly News Digest");
+    expect(markup).toContain("Body");
+  });
+});

--- a/tests/newsletter-public-slug-service.test.ts
+++ b/tests/newsletter-public-slug-service.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+type DbMockOptions = {
+  selectQueue?: unknown[];
+  onInsert?: (values: Record<string, unknown> | Array<Record<string, unknown>>) => unknown[];
+  onUpdate?: (values: Record<string, unknown>) => unknown[];
+};
+
+function makeQueryResult<T>(value: T) {
+  return {
+    limit: async () => value,
+    orderBy: () => ({
+      limit: async () => value,
+    }),
+    then: (resolve: (result: T) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(value).then(resolve, reject),
+  };
+}
+
+async function installNewsletterDbMock({
+  selectQueue = [],
+  onInsert,
+  onUpdate,
+}: DbMockOptions) {
+  const actualDb = await import("../src/db");
+
+  mock.module("@/db", () => ({
+    ...actualDb,
+    db: {
+      select: () => ({
+        from: () => ({
+          then: (resolve: (result: unknown) => unknown, reject?: (reason: unknown) => unknown) =>
+            Promise.resolve(selectQueue.shift() ?? []).then(resolve, reject),
+          where: () => makeQueryResult(selectQueue.shift() ?? []),
+          orderBy: () => ({
+            limit: async () => selectQueue.shift() ?? [],
+          }),
+          limit: async () => selectQueue.shift() ?? [],
+        }),
+      }),
+      insert: () => ({
+        values: (values: Record<string, unknown> | Array<Record<string, unknown>>) => ({
+          returning: async () => onInsert?.(values) ?? [],
+        }),
+      }),
+      update: () => ({
+        set: (values: Record<string, unknown>) => ({
+          where: () => ({
+            returning: async () => onUpdate?.(values) ?? [],
+          }),
+        }),
+      }),
+    },
+  }));
+}
+
+describe("newsletter public slug services", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("stores a derived public slug when creating a scheduled campaign", async () => {
+    const insertCalls: Array<Record<string, unknown>> = [];
+    await installNewsletterDbMock({
+      onInsert: (values) => {
+        const record = values as Record<string, unknown>;
+        insertCalls.push(record);
+        return [record];
+      },
+    });
+
+    const newsletter = await import(
+      `../src/services/newsletter?newsletter-public-slug-create=${Date.now()}`
+    );
+    const result = await newsletter.createNewsletterCampaign({
+      newsletterType: "news",
+      subject: "Weekly News Digest",
+      previewText: "Top updates",
+      scheduledAt: "2026-03-18T12:00:00.000Z",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0]).toMatchObject({
+      subject: "Weekly News Digest",
+      status: "scheduled",
+      publicSlug: "weekly-news-digest-2026-03-18",
+    });
+  });
+
+  test("recomputes the public slug when a mutable campaign title or schedule changes", async () => {
+    const updateCalls: Array<Record<string, unknown>> = [];
+    await installNewsletterDbMock({
+      selectQueue: [[{
+        id: "camp_draft_1",
+        publicSlug: "weekly-news-digest-2026-03-11",
+        newsletterType: "news",
+        subject: "Weekly News Digest",
+        previewText: "Top updates",
+        contentMode: "template",
+        markdownContent: null,
+        manualHtml: null,
+        manualText: null,
+        status: "scheduled",
+        periodDays: 7,
+        scheduledAt: new Date("2026-03-11T08:00:00.000Z"),
+        sentAt: null,
+        failureReason: null,
+        createdBy: "admin_user",
+        createdAt: new Date("2026-03-10T18:30:00.000Z"),
+        updatedAt: new Date("2026-03-10T18:30:00.000Z"),
+      }]],
+      onUpdate: (values) => {
+        updateCalls.push(values);
+        return [{
+          id: "camp_draft_1",
+          ...values,
+        }];
+      },
+    });
+
+    const newsletter = await import(
+      `../src/services/newsletter?newsletter-public-slug-update=${Date.now()}`
+    );
+    const result = await newsletter.updateNewsletterCampaign("camp_draft_1", {
+      subject: "Weekly Market Digest",
+      scheduledAt: "2026-03-18T12:00:00.000Z",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]).toMatchObject({
+      subject: "Weekly Market Digest",
+      status: "scheduled",
+      publicSlug: "weekly-market-digest-2026-03-18",
+    });
+  });
+
+  test("includes public slugs in sent archive summaries", async () => {
+    await installNewsletterDbMock({
+      selectQueue: [[{
+        id: "camp_sent_1",
+        publicSlug: "weekly-news-digest-2026-03-11",
+        subject: "Original subject",
+        previewText: "Original preview",
+        newsletterType: "news",
+        sentAt: new Date("2026-03-11T08:00:00.000Z"),
+        archiveSubject: "Corrected archive subject",
+        archivePreviewText: "Corrected archive preview",
+        archiveCorrectedAt: new Date("2026-03-11T09:00:00.000Z"),
+      }]],
+    });
+
+    const { listSentNewsletterCampaigns } = await import(
+      `../src/services/newsletter?newsletter-public-slug-list=${Date.now()}`
+    );
+    const campaigns = await listSentNewsletterCampaigns(10);
+
+    expect(campaigns).toEqual([{
+      id: "camp_sent_1",
+      publicSlug: "weekly-news-digest-2026-03-11",
+      subject: "Corrected archive subject",
+      previewText: "Corrected archive preview",
+      newsletterType: "news",
+      sentAt: new Date("2026-03-11T08:00:00.000Z"),
+      archiveCorrectedAt: new Date("2026-03-11T09:00:00.000Z"),
+    }]);
+  });
+
+  test("finds sent archive campaigns by slug first and falls back to legacy ids", async () => {
+    await installNewsletterDbMock({
+      selectQueue: [
+        [{
+          id: "camp_sent_1",
+          publicSlug: "weekly-news-digest-2026-03-11",
+          subject: "Weekly News Digest",
+          previewText: "Top updates",
+          newsletterType: "news",
+          sentAt: new Date("2026-03-11T08:00:00.000Z"),
+          renderedHtml: "<p>Body</p>",
+          archiveSubject: null,
+          archivePreviewText: null,
+          archiveRenderedHtml: null,
+          archiveCorrectedAt: null,
+        }],
+        [],
+        [{
+          id: "camp_sent_1",
+          publicSlug: "weekly-news-digest-2026-03-11",
+          subject: "Weekly News Digest",
+          previewText: "Top updates",
+          newsletterType: "news",
+          sentAt: new Date("2026-03-11T08:00:00.000Z"),
+          renderedHtml: "<p>Body</p>",
+          archiveSubject: null,
+          archivePreviewText: null,
+          archiveRenderedHtml: null,
+          archiveCorrectedAt: null,
+        }],
+      ],
+    });
+
+    const { findSentNewsletterCampaignForArchive } = await import(
+      `../src/services/newsletter?newsletter-public-slug-find=${Date.now()}`
+    );
+
+    await expect(
+      findSentNewsletterCampaignForArchive("weekly-news-digest-2026-03-11")
+    ).resolves.toEqual({
+      campaign: {
+        id: "camp_sent_1",
+        publicSlug: "weekly-news-digest-2026-03-11",
+        subject: "Weekly News Digest",
+        previewText: "Top updates",
+        newsletterType: "news",
+        sentAt: new Date("2026-03-11T08:00:00.000Z"),
+        renderedHtml: "<p>Body</p>",
+        archiveCorrectedAt: null,
+      },
+      matchedByLegacyId: false,
+    });
+
+    await expect(findSentNewsletterCampaignForArchive("camp_sent_1")).resolves.toEqual({
+      campaign: {
+        id: "camp_sent_1",
+        publicSlug: "weekly-news-digest-2026-03-11",
+        subject: "Weekly News Digest",
+        previewText: "Top updates",
+        newsletterType: "news",
+        sentAt: new Date("2026-03-11T08:00:00.000Z"),
+        renderedHtml: "<p>Body</p>",
+        archiveCorrectedAt: null,
+      },
+      matchedByLegacyId: true,
+    });
+  });
+});

--- a/tests/newsletter-schema.test.ts
+++ b/tests/newsletter-schema.test.ts
@@ -23,6 +23,12 @@ describe("isMissingNewsletterSchemaError", () => {
     expect(isMissingNewsletterSchemaError(error)).toBe(true);
   });
 
+  test("matches missing public slug errors", () => {
+    expect(
+      isMissingNewsletterSchemaError(new Error('column "public_slug" does not exist'))
+    ).toBe(true);
+  });
+
   test("does not treat permission errors as missing schema", () => {
     expect(
       isMissingNewsletterSchemaError(new Error("permission denied for relation newsletter_campaigns"))

--- a/tests/newsletter-slug.test.ts
+++ b/tests/newsletter-slug.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildNewsletterPublicSlug,
+  deriveNewsletterSlugDateAnchor,
+  ensureUniqueNewsletterPublicSlug,
+} from "../src/lib/newsletter-slug";
+
+describe("newsletter public slug helpers", () => {
+  test("builds a slug from subject and UTC publish date", () => {
+    expect(
+      buildNewsletterPublicSlug(
+        "Weekly News Digest",
+        new Date("2026-02-27T22:43:41.179Z"),
+      ),
+    ).toBe("weekly-news-digest-2026-02-27");
+  });
+
+  test("normalizes punctuation and collapses separators", () => {
+    expect(
+      buildNewsletterPublicSlug(
+        "  AI & Crypto: Weekly / Digest!!!  ",
+        new Date("2026-02-27T22:43:41.179Z"),
+      ),
+    ).toBe("ai-crypto-weekly-digest-2026-02-27");
+  });
+
+  test("uses sentAt as the publish date anchor when available", () => {
+    expect(
+      deriveNewsletterSlugDateAnchor({
+        sentAt: new Date("2026-02-27T22:43:41.179Z"),
+        scheduledAt: new Date("2026-02-28T08:00:00.000Z"),
+        createdAt: new Date("2026-02-26T18:00:00.000Z"),
+      }).toISOString(),
+    ).toBe("2026-02-27T22:43:41.179Z");
+  });
+
+  test("falls back to scheduledAt and then createdAt", () => {
+    expect(
+      deriveNewsletterSlugDateAnchor({
+        scheduledAt: new Date("2026-03-01T08:00:00.000Z"),
+        createdAt: new Date("2026-02-26T18:00:00.000Z"),
+      }).toISOString(),
+    ).toBe("2026-03-01T08:00:00.000Z");
+
+    expect(
+      deriveNewsletterSlugDateAnchor({
+        createdAt: new Date("2026-02-26T18:00:00.000Z"),
+      }).toISOString(),
+    ).toBe("2026-02-26T18:00:00.000Z");
+  });
+
+  test("appends numeric suffixes when the base slug already exists", () => {
+    expect(
+      ensureUniqueNewsletterPublicSlug("weekly-news-digest-2026-02-27", []),
+    ).toBe("weekly-news-digest-2026-02-27");
+
+    expect(
+      ensureUniqueNewsletterPublicSlug("weekly-news-digest-2026-02-27", [
+        "weekly-news-digest-2026-02-27",
+      ]),
+    ).toBe("weekly-news-digest-2026-02-27-2");
+
+    expect(
+      ensureUniqueNewsletterPublicSlug("weekly-news-digest-2026-02-27", [
+        "weekly-news-digest-2026-02-27",
+        "weekly-news-digest-2026-02-27-2",
+        "weekly-news-digest-2026-02-27-3",
+      ]),
+    ).toBe("weekly-news-digest-2026-02-27-4");
+  });
+});


### PR DESCRIPTION
## Summary
- rebuild the old newsletter slug PR on current `master`
- add backend-owned `public_slug` generation/backfill for newsletter campaigns and use slugs for public archive URLs
- preserve legacy internal-ID archive URLs with permanent redirects to canonical slug URLs
- register the existing current-master `0010` migration and add a fresh `0011_newsletter_campaign_public_slug` migration
- add regression coverage for slug generation, archive lookup, legacy redirects, and missing-schema fallback

## Verification
- `bun test tests/newsletter-slug.test.ts tests/newsletter-public-slug-service.test.ts tests/newsletter-public-route.test.ts tests/newsletter-archive.test.ts tests/newsletter-archive-corrections.test.ts tests/newsletter-schema.test.ts`
- `bun run db:check:migrations`
- `bunx tsc --noEmit`
- `bun run lint`
- `bun run test:unit`
- `bun run build`