### PR TITLE
fix(news): tolerate missing relevance column drift

### DIFF
--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,5 +1,6 @@
 import { db, blogPosts } from "@/db";
 import { and, desc, eq } from "drizzle-orm";
+import { isMissingColumnError } from "@/lib/db-schema-compat";
 
 const FALLBACK_DATE = "1970-01-01";
 
@@ -82,6 +83,42 @@ export async function getAllPosts(): Promise<BlogPostMeta[]> {
       relevance: post.relevance,
     }));
   } catch (error) {
+    if (isMissingColumnError(error, "relevance")) {
+      console.warn("[blog] blog_posts.relevance missing, using compatibility fallback");
+
+      try {
+        const posts = await db
+          .select({
+            slug: blogPosts.slug,
+            title: blogPosts.title,
+            date: blogPosts.date,
+            description: blogPosts.description,
+            content: blogPosts.content,
+            source: blogPosts.source,
+            sourceUrl: blogPosts.sourceUrl,
+            image: blogPosts.image,
+          })
+          .from(blogPosts)
+          .where(eq(blogPosts.published, true))
+          .orderBy(desc(blogPosts.date));
+
+        return posts.map((post) => ({
+          slug: post.slug,
+          title: post.title,
+          date: formatDateString(post.date, post.slug),
+          description: post.description || "",
+          source: post.source || undefined,
+          sourceUrl: post.sourceUrl || undefined,
+          readingTime: calculateReadingTime(post.content),
+          image: post.image || undefined,
+          relevance: 5,
+        }));
+      } catch (fallbackError) {
+        console.error("[blog] Compatibility fallback failed:", fallbackError);
+        return [];
+      }
+    }
+
     console.error("[blog] Failed to fetch all posts:", error);
     return [];
   }

--- a/src/lib/db-schema-compat.ts
+++ b/src/lib/db-schema-compat.ts
@@ -1,0 +1,11 @@
+export function isMissingColumnError(error: unknown, columnName: string): boolean {
+  const message =
+    error instanceof Error ? error.message : typeof error === "string" ? error : "";
+
+  if (!message) return false;
+
+  return (
+    message.includes("does not exist") &&
+    (message.includes(`"${columnName}"`) || message.includes(`.${columnName}`))
+  );
+}

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -32,31 +32,37 @@ async function getCuratedLinksWithFallback() {
       .from(curatedLinksTable)
       .orderBy(desc(curatedLinksTable.date));
   } catch (error) {
-    if (!isMissingColumnError(error, "relevance")) {
-      throw error;
+    if (isMissingColumnError(error, "relevance")) {
+      console.warn("[news] curated_links.relevance missing, using compatibility fallback");
+
+      try {
+        const rows = await db
+          .select({
+            id: curatedLinksTable.id,
+            title: curatedLinksTable.title,
+            url: curatedLinksTable.url,
+            source: curatedLinksTable.source,
+            sourceImage: curatedLinksTable.sourceImage,
+            date: curatedLinksTable.date,
+            description: curatedLinksTable.description,
+            category: curatedLinksTable.category,
+            featured: curatedLinksTable.featured,
+          })
+          .from(curatedLinksTable)
+          .orderBy(desc(curatedLinksTable.date));
+
+        return rows.map((row) => ({
+          ...row,
+          relevance: 5,
+        }));
+      } catch (fallbackError) {
+        console.error("[news] Curated links compatibility fallback failed:", fallbackError);
+        return [];
+      }
     }
 
-    console.warn("[news] curated_links.relevance missing, using compatibility fallback");
-
-    const rows = await db
-      .select({
-        id: curatedLinksTable.id,
-        title: curatedLinksTable.title,
-        url: curatedLinksTable.url,
-        source: curatedLinksTable.source,
-        sourceImage: curatedLinksTable.sourceImage,
-        date: curatedLinksTable.date,
-        description: curatedLinksTable.description,
-        category: curatedLinksTable.category,
-        featured: curatedLinksTable.featured,
-      })
-      .from(curatedLinksTable)
-      .orderBy(desc(curatedLinksTable.date));
-
-    return rows.map((row) => ({
-      ...row,
-      relevance: 5,
-    }));
+    console.error("[news] Failed to fetch curated links:", error);
+    return [];
   }
 }
 
@@ -67,32 +73,38 @@ async function getAnnouncementsWithFallback() {
       .from(announcementsTable)
       .orderBy(desc(announcementsTable.date));
   } catch (error) {
-    if (!isMissingColumnError(error, "relevance")) {
-      throw error;
+    if (isMissingColumnError(error, "relevance")) {
+      console.warn("[news] announcements.relevance missing, using compatibility fallback");
+
+      try {
+        const rows = await db
+          .select({
+            id: announcementsTable.id,
+            title: announcementsTable.title,
+            url: announcementsTable.url,
+            company: announcementsTable.company,
+            companyLogo: announcementsTable.companyLogo,
+            platform: announcementsTable.platform,
+            date: announcementsTable.date,
+            description: announcementsTable.description,
+            category: announcementsTable.category,
+            featured: announcementsTable.featured,
+          })
+          .from(announcementsTable)
+          .orderBy(desc(announcementsTable.date));
+
+        return rows.map((row) => ({
+          ...row,
+          relevance: 5,
+        }));
+      } catch (fallbackError) {
+        console.error("[news] Announcements compatibility fallback failed:", fallbackError);
+        return [];
+      }
     }
 
-    console.warn("[news] announcements.relevance missing, using compatibility fallback");
-
-    const rows = await db
-      .select({
-        id: announcementsTable.id,
-        title: announcementsTable.title,
-        url: announcementsTable.url,
-        company: announcementsTable.company,
-        companyLogo: announcementsTable.companyLogo,
-        platform: announcementsTable.platform,
-        date: announcementsTable.date,
-        description: announcementsTable.description,
-        category: announcementsTable.category,
-        featured: announcementsTable.featured,
-      })
-      .from(announcementsTable)
-      .orderBy(desc(announcementsTable.date));
-
-    return rows.map((row) => ({
-      ...row,
-      relevance: 5,
-    }));
+    console.error("[news] Failed to fetch announcements:", error);
+    return [];
   }
 }
 

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -3,6 +3,7 @@ import { db } from "@/db";
 import { curatedLinks as curatedLinksTable, announcements as announcementsTable } from "@/db/schema";
 import { desc } from "drizzle-orm";
 import { NewsCategory } from "@/data/news";
+import { isMissingColumnError } from "@/lib/db-schema-compat";
 
 export interface AggregatedNewsItem {
   id: string;
@@ -24,12 +25,83 @@ export interface AggregatedNewsItem {
   image?: string; // For blog posts
 }
 
+async function getCuratedLinksWithFallback() {
+  try {
+    return await db
+      .select()
+      .from(curatedLinksTable)
+      .orderBy(desc(curatedLinksTable.date));
+  } catch (error) {
+    if (!isMissingColumnError(error, "relevance")) {
+      throw error;
+    }
+
+    console.warn("[news] curated_links.relevance missing, using compatibility fallback");
+
+    const rows = await db
+      .select({
+        id: curatedLinksTable.id,
+        title: curatedLinksTable.title,
+        url: curatedLinksTable.url,
+        source: curatedLinksTable.source,
+        sourceImage: curatedLinksTable.sourceImage,
+        date: curatedLinksTable.date,
+        description: curatedLinksTable.description,
+        category: curatedLinksTable.category,
+        featured: curatedLinksTable.featured,
+      })
+      .from(curatedLinksTable)
+      .orderBy(desc(curatedLinksTable.date));
+
+    return rows.map((row) => ({
+      ...row,
+      relevance: 5,
+    }));
+  }
+}
+
+async function getAnnouncementsWithFallback() {
+  try {
+    return await db
+      .select()
+      .from(announcementsTable)
+      .orderBy(desc(announcementsTable.date));
+  } catch (error) {
+    if (!isMissingColumnError(error, "relevance")) {
+      throw error;
+    }
+
+    console.warn("[news] announcements.relevance missing, using compatibility fallback");
+
+    const rows = await db
+      .select({
+        id: announcementsTable.id,
+        title: announcementsTable.title,
+        url: announcementsTable.url,
+        company: announcementsTable.company,
+        companyLogo: announcementsTable.companyLogo,
+        platform: announcementsTable.platform,
+        date: announcementsTable.date,
+        description: announcementsTable.description,
+        category: announcementsTable.category,
+        featured: announcementsTable.featured,
+      })
+      .from(announcementsTable)
+      .orderBy(desc(announcementsTable.date));
+
+    return rows.map((row) => ({
+      ...row,
+      relevance: 5,
+    }));
+  }
+}
+
 export async function getAllNews(): Promise<AggregatedNewsItem[]> {
   // Fetch all data sources in parallel
   const [blogPosts, dbCuratedLinks, dbAnnouncements] = await Promise.all([
     getAllPosts(),
-    db.select().from(curatedLinksTable).orderBy(desc(curatedLinksTable.date)),
-    db.select().from(announcementsTable).orderBy(desc(announcementsTable.date)),
+    getCuratedLinksWithFallback(),
+    getAnnouncementsWithFallback(),
   ]);
 
   // Map blog posts

--- a/tests/blog-relevance-fallback.test.ts
+++ b/tests/blog-relevance-fallback.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("getAllPosts relevance fallback", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("falls back to default relevance when blog_posts.relevance is missing", async () => {
+    const blogPosts = {
+      __table: "blog_posts",
+      published: Symbol("published"),
+      date: Symbol("date"),
+    };
+
+    mock.module("@/db", () => ({
+      db: {
+        select: (selection?: Record<string, unknown>) => ({
+          from: (table: { __table: string }) => ({
+            where: () => ({
+              orderBy: async () => {
+                if (!selection) {
+                  throw new Error(`column "${table.__table}.relevance" does not exist`);
+                }
+
+                return [
+                  {
+                    slug: "fallback-post",
+                    title: "Fallback Post",
+                    date: new Date("2026-04-10T00:00:00.000Z"),
+                    description: "Fallback summary",
+                    content: "word ".repeat(300),
+                    source: null,
+                    sourceUrl: null,
+                    image: null,
+                    published: true,
+                  },
+                ];
+              },
+            }),
+          }),
+        }),
+      },
+      blogPosts,
+    }));
+
+    const { getAllPosts } = await import(`../src/lib/blog?blog-relevance-fallback=${Date.now()}`);
+    const posts = await getAllPosts();
+
+    expect(posts).toEqual([
+      {
+        slug: "fallback-post",
+        title: "Fallback Post",
+        date: "2026-04-10",
+        description: "Fallback summary",
+        source: undefined,
+        sourceUrl: undefined,
+        readingTime: 2,
+        image: undefined,
+        relevance: 5,
+      },
+    ]);
+  });
+});

--- a/tests/news-aggregation-relevance.test.ts
+++ b/tests/news-aggregation-relevance.test.ts
@@ -173,4 +173,67 @@ describe("getAllNews relevance mapping", () => {
       relevance: 9,
     });
   });
+
+  test("keeps rendering available sources when one news table is unavailable", async () => {
+    const curatedLinks = { __table: "curated_links" };
+    const announcements = { __table: "announcements" };
+
+    mock.module("../src/lib/blog", () => ({
+      getAllPosts: async () => ([
+        {
+          slug: "blog-still-visible",
+          title: "Blog Still Visible",
+          date: "2026-04-09",
+          description: "Blog summary",
+          content: "word ".repeat(300),
+          readingTime: 2,
+          image: null,
+          relevance: 6,
+        },
+      ]),
+    }));
+
+    mock.module("@/db/schema", () => ({
+      curatedLinks,
+      announcements,
+    }));
+
+    mock.module("@/db", () => ({
+      db: {
+        select: () => ({
+          from: (table: { __table: string }) => ({
+            orderBy: async () => {
+              if (table.__table === "curated_links") {
+                return [
+                  {
+                    id: "curated-still-visible",
+                    title: "Curated Still Visible",
+                    url: "https://example.com/curated-still-visible",
+                    source: "Example Source",
+                    sourceImage: null,
+                    date: new Date("2026-04-08T00:00:00.000Z"),
+                    description: "Curated summary",
+                    category: "ai",
+                    featured: false,
+                    relevance: 7,
+                  },
+                ];
+              }
+
+              throw new Error('relation "announcements" does not exist');
+            },
+          }),
+        }),
+      },
+    }));
+
+    const { getAllNews } = await import(`../src/lib/news?news-source-fallback=${Date.now()}`);
+    const news = await getAllNews();
+
+    expect(news).toHaveLength(2);
+    expect(news.map((item: { id: string }) => item.id)).toEqual([
+      "blog-blog-still-visible",
+      "curated-still-visible",
+    ]);
+  });
 });

--- a/tests/news-aggregation-relevance.test.ts
+++ b/tests/news-aggregation-relevance.test.ts
@@ -89,4 +89,88 @@ describe("getAllNews relevance mapping", () => {
       relevance: 5,
     });
   });
+
+  test("falls back to default relevance when production tables are missing the relevance column", async () => {
+    const curatedLinks = { __table: "curated_links" };
+    const announcements = { __table: "announcements" };
+
+    mock.module("../src/lib/blog", () => ({
+      getAllPosts: async () => ([
+        {
+          slug: "existing-post",
+          title: "Existing Post",
+          date: "2026-04-09",
+          description: "Blog summary",
+          content: "word ".repeat(300),
+          readingTime: 2,
+          image: null,
+          relevance: 9,
+        },
+      ]),
+    }));
+
+    mock.module("@/db/schema", () => ({
+      curatedLinks,
+      announcements,
+    }));
+
+    mock.module("@/db", () => ({
+      db: {
+        select: (selection?: Record<string, unknown>) => ({
+          from: (table: { __table: string }) => ({
+            orderBy: async () => {
+              if (!selection) {
+                throw new Error(`column "${table.__table}.relevance" does not exist`);
+              }
+
+              if (table.__table === "curated_links") {
+                return [
+                  {
+                    id: "curated-fallback",
+                    title: "Curated Fallback",
+                    url: "https://example.com/curated-fallback",
+                    source: "Example Source",
+                    sourceImage: null,
+                    date: new Date("2026-04-08T00:00:00.000Z"),
+                    description: "Curated summary",
+                    category: "ai",
+                    featured: false,
+                  },
+                ];
+              }
+
+              return [
+                {
+                  id: "announcement-fallback",
+                  title: "Announcement Fallback",
+                  url: "https://example.com/announcement-fallback",
+                  company: "Example Co",
+                  companyLogo: null,
+                  platform: "x",
+                  date: new Date("2026-04-07T00:00:00.000Z"),
+                  description: "Announcement summary",
+                  category: "product",
+                  featured: false,
+                },
+              ];
+            },
+          }),
+        }),
+      },
+    }));
+
+    const { getAllNews } = await import(`../src/lib/news?news-relevance-fallback=${Date.now()}`);
+    const news = await getAllNews();
+
+    expect(news).toHaveLength(3);
+    expect(news.find((item: { id: string }) => item.id === "curated-fallback")).toMatchObject({
+      relevance: 5,
+    });
+    expect(news.find((item: { id: string }) => item.id === "announcement-fallback")).toMatchObject({
+      relevance: 5,
+    });
+    expect(news.find((item: { id: string }) => item.id === "blog-existing-post")).toMatchObject({
+      relevance: 9,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- keep /news rendering when production is missing the new relevance columns
- retry blog, curated link, and announcement reads with compatibility selects and default relevance 5
- add regression tests covering the missing-column fallback path

## Testing
- bun test tests/news-aggregation-relevance.test.ts
- bun test tests/blog-relevance-fallback.test.ts
- bun run test:unit
- bun run lint
- bun x tsc --noEmit