### PR TITLE
fix(news): detect wrapped missing-column errors

### DIFF
--- a/src/lib/db-schema-compat.ts
+++ b/src/lib/db-schema-compat.ts
@@ -1,11 +1,68 @@
+type ErrorLike = {
+  cause?: unknown;
+  code?: unknown;
+  message?: unknown;
+  query?: unknown;
+};
+
+function collectErrorMetadata(error: unknown) {
+  const texts: string[] = [];
+  const codes: string[] = [];
+  const queue: unknown[] = [error];
+  const seen = new Set<unknown>();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+
+    if (!current || seen.has(current)) {
+      continue;
+    }
+
+    if (typeof current === "string") {
+      texts.push(current);
+      continue;
+    }
+
+    if (typeof current !== "object") {
+      continue;
+    }
+
+    seen.add(current);
+
+    const candidate = current as ErrorLike;
+
+    if (typeof candidate.message === "string") {
+      texts.push(candidate.message);
+    }
+
+    if (typeof candidate.query === "string") {
+      texts.push(candidate.query);
+    }
+
+    if (typeof candidate.code === "string") {
+      codes.push(candidate.code);
+    }
+
+    if (candidate.cause) {
+      queue.push(candidate.cause);
+    }
+  }
+
+  return { texts, codes };
+}
+
 export function isMissingColumnError(error: unknown, columnName: string): boolean {
-  const message =
-    error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  const { texts, codes } = collectErrorMetadata(error);
 
-  if (!message) return false;
-
-  return (
-    message.includes("does not exist") &&
-    (message.includes(`"${columnName}"`) || message.includes(`.${columnName}`))
+  const referencesColumn = texts.some(
+    (text) =>
+      text.includes(`"${columnName}"`) ||
+      text.includes(`.${columnName}`) ||
+      text.includes(`"${columnName}" does not exist`)
   );
+
+  const missingColumn =
+    codes.includes("42703") || texts.some((text) => text.includes("does not exist"));
+
+  return missingColumn && referencesColumn;
 }

--- a/tests/blog-relevance-fallback.test.ts
+++ b/tests/blog-relevance-fallback.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
+function createMissingRelevanceError(tableName: string) {
+  const error = new Error("Failed query");
+  (error as Error & { cause?: Error }).cause = new Error(
+    `column "${tableName}"."relevance" does not exist`
+  );
+  return error;
+}
+
 describe("getAllPosts relevance fallback", () => {
   afterEach(() => {
     mock.restore();
@@ -19,7 +27,7 @@ describe("getAllPosts relevance fallback", () => {
             where: () => ({
               orderBy: async () => {
                 if (!selection) {
-                  throw new Error(`column "${table.__table}.relevance" does not exist`);
+                  throw createMissingRelevanceError(table.__table);
                 }
 
                 return [

--- a/tests/news-aggregation-relevance.test.ts
+++ b/tests/news-aggregation-relevance.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
+function createMissingRelevanceError(tableName: string) {
+  const error = new Error("Failed query");
+  (error as Error & { cause?: Error }).cause = new Error(
+    `column "${tableName}"."relevance" does not exist`
+  );
+  return error;
+}
+
 describe("getAllNews relevance mapping", () => {
   afterEach(() => {
     mock.restore();
@@ -120,7 +128,7 @@ describe("getAllNews relevance mapping", () => {
           from: (table: { __table: string }) => ({
             orderBy: async () => {
               if (!selection) {
-                throw new Error(`column "${table.__table}.relevance" does not exist`);
+                throw createMissingRelevanceError(table.__table);
               }
 
               if (table.__table === "curated_links") {


### PR DESCRIPTION
## Summary
- fix missing-column detection for Drizzle-wrapped Postgres errors
- restore relevance fallback queries for news and blog sources in production
- cover the production wrapped-error shape in fallback tests

## Verification
- bun test tests/blog-relevance-fallback.test.ts
- bun test tests/news-aggregation-relevance.test.ts
- bun run lint
- bun x tsc --noEmit
- bun run test:unit
- bunx dotenv -e /Users/dcbuilder/Code/projects/dcbuilder.dev/.env.local -- bun -e 'import("./src/lib/news").then(async (m) => { const news = await m.getAllNews(); console.log(JSON.stringify({count: news.length, first: news[0] ?? null}, null, 2)); process.exit(0); })'