### PR TITLE
fix(api): restore admin news reads on pre-migration schema

### DIFF
--- a/src/app/api/v1/blog/[slug]/route.ts
+++ b/src/app/api/v1/blog/[slug]/route.ts
@@ -3,6 +3,7 @@ import { db, blogPosts } from "@/db";
 import { eq } from "drizzle-orm";
 import { requireAuth, validateApiKey } from "@/services/auth";
 import { validateEditorialRelevance } from "@/lib/news-relevance";
+import { getBlogPostBySlugCompat } from "@/lib/editorial-read-compat";
 
 function isValidDate(dateStr: string): boolean {
   const parsed = new Date(dateStr);
@@ -20,11 +21,7 @@ export async function GET(
     // Check if authenticated - if so, can view unpublished
     const auth = await validateApiKey(request, "admin:read");
 
-    const [post] = await db
-      .select()
-      .from(blogPosts)
-      .where(eq(blogPosts.slug, slug))
-      .limit(1);
+    const post = await getBlogPostBySlugCompat(slug);
 
     if (!post) {
       return NextResponse.json({ error: "Post not found", code: "NOT_FOUND" }, { status: 404 });
@@ -73,11 +70,7 @@ export async function PUT(
   // Check if post exists first (before parsing body)
   let existingPost;
   try {
-    const [existing] = await db
-      .select()
-      .from(blogPosts)
-      .where(eq(blogPosts.slug, slug))
-      .limit(1);
+    const existing = await getBlogPostBySlugCompat(slug);
 
     if (!existing) {
       return NextResponse.json({ error: "Post not found", code: "NOT_FOUND" }, { status: 404 });

--- a/src/app/api/v1/blog/route.ts
+++ b/src/app/api/v1/blog/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db, blogPosts } from "@/db";
-import { desc, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { requireAuth, validateApiKey } from "@/services/auth";
 import { validateEditorialRelevance } from "@/lib/news-relevance";
+import { listBlogPostsCompat } from "@/lib/editorial-read-compat";
 
 function isValidDate(dateStr: string): boolean {
   const parsed = new Date(dateStr);
@@ -15,11 +16,7 @@ export async function GET(request: NextRequest) {
     // Check if authenticated - if so, show all posts including unpublished
     const auth = await validateApiKey(request, "admin:read");
 
-    const query = auth.valid
-      ? db.select().from(blogPosts).orderBy(desc(blogPosts.date))
-      : db.select().from(blogPosts).where(eq(blogPosts.published, true)).orderBy(desc(blogPosts.date));
-
-    const posts = await query;
+    const posts = await listBlogPostsCompat(auth.valid);
 
     const data = posts.map((post) => ({
       slug: post.slug,

--- a/src/app/api/v1/news/announcements/[id]/route.ts
+++ b/src/app/api/v1/news/announcements/[id]/route.ts
@@ -3,6 +3,7 @@ import { db, announcements } from "@/db";
 import { eq } from "drizzle-orm";
 import { requireAuth } from "@/services/auth";
 import { validateEditorialRelevance } from "@/lib/news-relevance";
+import { getAnnouncementByIdCompat } from "@/lib/editorial-read-compat";
 
 // GET /api/v1/news/announcements/[id] - Get an announcement by ID
 export async function GET(
@@ -12,11 +13,7 @@ export async function GET(
   const { id } = await params;
 
   try {
-    const [announcement] = await db
-      .select()
-      .from(announcements)
-      .where(eq(announcements.id, id))
-      .limit(1);
+    const announcement = await getAnnouncementByIdCompat(id);
 
     if (!announcement) {
       return Response.json({ error: "Announcement not found", code: "NOT_FOUND" }, { status: 404 });

--- a/src/app/api/v1/news/announcements/route.ts
+++ b/src/app/api/v1/news/announcements/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest } from "next/server";
 import { db, announcements, NewAnnouncement } from "@/db";
-import { eq, desc, and, SQL } from "drizzle-orm";
+import { eq, and, SQL } from "drizzle-orm";
 import { requireAuth, parsePaginationParams } from "@/services/auth";
 import { validateEditorialRelevance } from "@/lib/news-relevance";
+import { listAnnouncementsCompat } from "@/lib/editorial-read-compat";
 
 // GET /api/v1/news/announcements - List announcements
 export async function GET(request: NextRequest) {
@@ -27,13 +28,7 @@ export async function GET(request: NextRequest) {
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
-    const data = await db
-      .select()
-      .from(announcements)
-      .where(whereClause)
-      .orderBy(desc(announcements.date))
-      .limit(limit)
-      .offset(offset);
+    const data = await listAnnouncementsCompat({ whereClause, limit, offset });
 
     return Response.json({
       data,

--- a/src/app/api/v1/news/curated/[id]/route.ts
+++ b/src/app/api/v1/news/curated/[id]/route.ts
@@ -3,6 +3,7 @@ import { db, curatedLinks } from "@/db";
 import { eq } from "drizzle-orm";
 import { requireAuth } from "@/services/auth";
 import { validateEditorialRelevance } from "@/lib/news-relevance";
+import { getCuratedLinkByIdCompat } from "@/lib/editorial-read-compat";
 
 // GET /api/v1/news/curated/[id] - Get a curated link by ID
 export async function GET(
@@ -12,11 +13,7 @@ export async function GET(
   const { id } = await params;
 
   try {
-    const [link] = await db
-      .select()
-      .from(curatedLinks)
-      .where(eq(curatedLinks.id, id))
-      .limit(1);
+    const link = await getCuratedLinkByIdCompat(id);
 
     if (!link) {
       return Response.json({ error: "Curated link not found", code: "NOT_FOUND" }, { status: 404 });

--- a/src/app/api/v1/news/curated/route.ts
+++ b/src/app/api/v1/news/curated/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest } from "next/server";
 import { db, curatedLinks, NewCuratedLink } from "@/db";
-import { eq, desc, and, SQL } from "drizzle-orm";
+import { eq, and, SQL } from "drizzle-orm";
 import { requireAuth, parsePaginationParams } from "@/services/auth";
 import { validateEditorialRelevance } from "@/lib/news-relevance";
+import { listCuratedLinksCompat } from "@/lib/editorial-read-compat";
 
 // GET /api/v1/news/curated - List curated links
 export async function GET(request: NextRequest) {
@@ -23,13 +24,7 @@ export async function GET(request: NextRequest) {
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
-    const data = await db
-      .select()
-      .from(curatedLinks)
-      .where(whereClause)
-      .orderBy(desc(curatedLinks.date))
-      .limit(limit)
-      .offset(offset);
+    const data = await listCuratedLinksCompat({ whereClause, limit, offset });
 
     return Response.json({
       data,

--- a/src/app/api/v1/news/route.ts
+++ b/src/app/api/v1/news/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest } from "next/server";
-import { db, curatedLinks, announcements } from "@/db";
-import { desc } from "drizzle-orm";
 import { parsePaginationParams } from "@/services/auth";
+import { listAnnouncementsCompat, listCuratedLinksCompat } from "@/lib/editorial-read-compat";
 
 // GET /api/v1/news - Get all news (curated links + announcements) combined
 export async function GET(request: NextRequest) {
@@ -10,16 +9,8 @@ export async function GET(request: NextRequest) {
 
   try {
     const [curated, announce] = await Promise.all([
-      db
-        .select()
-        .from(curatedLinks)
-        .orderBy(desc(curatedLinks.date))
-        .limit(limit),
-      db
-        .select()
-        .from(announcements)
-        .orderBy(desc(announcements.date))
-        .limit(limit),
+      listCuratedLinksCompat({ limit, offset: 0 }),
+      listAnnouncementsCompat({ limit, offset: 0 }),
     ]);
 
     // Transform and combine

--- a/src/lib/editorial-read-compat.ts
+++ b/src/lib/editorial-read-compat.ts
@@ -1,0 +1,282 @@
+import { announcements, blogPosts, curatedLinks, db } from "@/db";
+import { desc, eq, SQL } from "drizzle-orm";
+import { isMissingColumnError } from "@/lib/db-schema-compat";
+
+type WhereClause = SQL | undefined;
+
+export async function listCuratedLinksCompat(params: {
+  whereClause?: WhereClause;
+  limit: number;
+  offset: number;
+}) {
+  const { whereClause, limit, offset } = params;
+
+  try {
+    return await db
+      .select()
+      .from(curatedLinks)
+      .where(whereClause)
+      .orderBy(desc(curatedLinks.date))
+      .limit(limit)
+      .offset(offset);
+  } catch (error) {
+    if (!isMissingColumnError(error, "relevance")) {
+      throw error;
+    }
+
+    console.warn("[editorial-read-compat] curated_links.relevance missing, using compatibility fallback");
+
+    const rows = await db
+      .select({
+        id: curatedLinks.id,
+        title: curatedLinks.title,
+        url: curatedLinks.url,
+        source: curatedLinks.source,
+        sourceImage: curatedLinks.sourceImage,
+        date: curatedLinks.date,
+        description: curatedLinks.description,
+        category: curatedLinks.category,
+        featured: curatedLinks.featured,
+        createdAt: curatedLinks.createdAt,
+        updatedAt: curatedLinks.updatedAt,
+      })
+      .from(curatedLinks)
+      .where(whereClause)
+      .orderBy(desc(curatedLinks.date))
+      .limit(limit)
+      .offset(offset);
+
+    return rows.map((row) => ({
+      ...row,
+      relevance: 5,
+    }));
+  }
+}
+
+export async function getCuratedLinkByIdCompat(id: string) {
+  try {
+    const [link] = await db
+      .select()
+      .from(curatedLinks)
+      .where(eq(curatedLinks.id, id))
+      .limit(1);
+
+    return link ?? null;
+  } catch (error) {
+    if (!isMissingColumnError(error, "relevance")) {
+      throw error;
+    }
+
+    console.warn("[editorial-read-compat] curated_links.relevance missing on by-id read, using compatibility fallback");
+
+    const [link] = await db
+      .select({
+        id: curatedLinks.id,
+        title: curatedLinks.title,
+        url: curatedLinks.url,
+        source: curatedLinks.source,
+        sourceImage: curatedLinks.sourceImage,
+        date: curatedLinks.date,
+        description: curatedLinks.description,
+        category: curatedLinks.category,
+        featured: curatedLinks.featured,
+        createdAt: curatedLinks.createdAt,
+        updatedAt: curatedLinks.updatedAt,
+      })
+      .from(curatedLinks)
+      .where(eq(curatedLinks.id, id))
+      .limit(1);
+
+    return link
+      ? {
+          ...link,
+          relevance: 5,
+        }
+      : null;
+  }
+}
+
+export async function listAnnouncementsCompat(params: {
+  whereClause?: WhereClause;
+  limit: number;
+  offset: number;
+}) {
+  const { whereClause, limit, offset } = params;
+
+  try {
+    return await db
+      .select()
+      .from(announcements)
+      .where(whereClause)
+      .orderBy(desc(announcements.date))
+      .limit(limit)
+      .offset(offset);
+  } catch (error) {
+    if (!isMissingColumnError(error, "relevance")) {
+      throw error;
+    }
+
+    console.warn("[editorial-read-compat] announcements.relevance missing, using compatibility fallback");
+
+    const rows = await db
+      .select({
+        id: announcements.id,
+        title: announcements.title,
+        url: announcements.url,
+        company: announcements.company,
+        companyLogo: announcements.companyLogo,
+        platform: announcements.platform,
+        date: announcements.date,
+        description: announcements.description,
+        category: announcements.category,
+        featured: announcements.featured,
+        createdAt: announcements.createdAt,
+        updatedAt: announcements.updatedAt,
+      })
+      .from(announcements)
+      .where(whereClause)
+      .orderBy(desc(announcements.date))
+      .limit(limit)
+      .offset(offset);
+
+    return rows.map((row) => ({
+      ...row,
+      relevance: 5,
+    }));
+  }
+}
+
+export async function getAnnouncementByIdCompat(id: string) {
+  try {
+    const [announcement] = await db
+      .select()
+      .from(announcements)
+      .where(eq(announcements.id, id))
+      .limit(1);
+
+    return announcement ?? null;
+  } catch (error) {
+    if (!isMissingColumnError(error, "relevance")) {
+      throw error;
+    }
+
+    console.warn("[editorial-read-compat] announcements.relevance missing on by-id read, using compatibility fallback");
+
+    const [announcement] = await db
+      .select({
+        id: announcements.id,
+        title: announcements.title,
+        url: announcements.url,
+        company: announcements.company,
+        companyLogo: announcements.companyLogo,
+        platform: announcements.platform,
+        date: announcements.date,
+        description: announcements.description,
+        category: announcements.category,
+        featured: announcements.featured,
+        createdAt: announcements.createdAt,
+        updatedAt: announcements.updatedAt,
+      })
+      .from(announcements)
+      .where(eq(announcements.id, id))
+      .limit(1);
+
+    return announcement
+      ? {
+          ...announcement,
+          relevance: 5,
+        }
+      : null;
+  }
+}
+
+export async function listBlogPostsCompat(includeUnpublished: boolean) {
+  try {
+    if (includeUnpublished) {
+      return await db
+        .select()
+        .from(blogPosts)
+        .orderBy(desc(blogPosts.date));
+    }
+
+    return await db
+      .select()
+      .from(blogPosts)
+      .where(eq(blogPosts.published, true))
+      .orderBy(desc(blogPosts.date));
+  } catch (error) {
+    if (!isMissingColumnError(error, "relevance")) {
+      throw error;
+    }
+
+    console.warn("[editorial-read-compat] blog_posts.relevance missing, using compatibility fallback");
+
+    const baseQuery = db
+      .select({
+        slug: blogPosts.slug,
+        title: blogPosts.title,
+        description: blogPosts.description,
+        content: blogPosts.content,
+        date: blogPosts.date,
+        source: blogPosts.source,
+        sourceUrl: blogPosts.sourceUrl,
+        image: blogPosts.image,
+        published: blogPosts.published,
+        createdAt: blogPosts.createdAt,
+        updatedAt: blogPosts.updatedAt,
+      })
+      .from(blogPosts);
+
+    const rows = includeUnpublished
+      ? await baseQuery.orderBy(desc(blogPosts.date))
+      : await baseQuery.where(eq(blogPosts.published, true)).orderBy(desc(blogPosts.date));
+
+    return rows.map((row) => ({
+      ...row,
+      relevance: 5,
+    }));
+  }
+}
+
+export async function getBlogPostBySlugCompat(slug: string) {
+  try {
+    const [post] = await db
+      .select()
+      .from(blogPosts)
+      .where(eq(blogPosts.slug, slug))
+      .limit(1);
+
+    return post ?? null;
+  } catch (error) {
+    if (!isMissingColumnError(error, "relevance")) {
+      throw error;
+    }
+
+    console.warn("[editorial-read-compat] blog_posts.relevance missing on by-slug read, using compatibility fallback");
+
+    const [post] = await db
+      .select({
+        slug: blogPosts.slug,
+        title: blogPosts.title,
+        description: blogPosts.description,
+        content: blogPosts.content,
+        date: blogPosts.date,
+        source: blogPosts.source,
+        sourceUrl: blogPosts.sourceUrl,
+        image: blogPosts.image,
+        published: blogPosts.published,
+        createdAt: blogPosts.createdAt,
+        updatedAt: blogPosts.updatedAt,
+      })
+      .from(blogPosts)
+      .where(eq(blogPosts.slug, slug))
+      .limit(1);
+
+    return post
+      ? {
+          ...post,
+          relevance: 5,
+        }
+      : null;
+  }
+}

--- a/tests/editorial-read-compat.test.ts
+++ b/tests/editorial-read-compat.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+function createMissingRelevanceError(tableName: string) {
+  const cause = new Error(`column "${tableName}"."relevance" does not exist`) as Error & {
+    code?: string;
+  };
+  cause.code = "42703";
+
+  const error = new Error("Failed query") as Error & { cause?: Error };
+  error.cause = cause;
+  return error;
+}
+
+describe("editorial read compatibility", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("falls back for curated links, announcements, and blog posts when relevance is missing", async () => {
+    const curatedLinks = {
+      id: Symbol("curated.id"),
+      title: Symbol("curated.title"),
+      url: Symbol("curated.url"),
+      source: Symbol("curated.source"),
+      sourceImage: Symbol("curated.sourceImage"),
+      date: Symbol("curated.date"),
+      description: Symbol("curated.description"),
+      category: Symbol("curated.category"),
+      featured: Symbol("curated.featured"),
+      createdAt: Symbol("curated.createdAt"),
+      updatedAt: Symbol("curated.updatedAt"),
+    };
+
+    const announcements = {
+      id: Symbol("announcements.id"),
+      title: Symbol("announcements.title"),
+      url: Symbol("announcements.url"),
+      company: Symbol("announcements.company"),
+      companyLogo: Symbol("announcements.companyLogo"),
+      platform: Symbol("announcements.platform"),
+      date: Symbol("announcements.date"),
+      description: Symbol("announcements.description"),
+      category: Symbol("announcements.category"),
+      featured: Symbol("announcements.featured"),
+      createdAt: Symbol("announcements.createdAt"),
+      updatedAt: Symbol("announcements.updatedAt"),
+    };
+
+    const blogPosts = {
+      slug: Symbol("blog.slug"),
+      title: Symbol("blog.title"),
+      description: Symbol("blog.description"),
+      content: Symbol("blog.content"),
+      date: Symbol("blog.date"),
+      source: Symbol("blog.source"),
+      sourceUrl: Symbol("blog.sourceUrl"),
+      image: Symbol("blog.image"),
+      published: Symbol("blog.published"),
+      createdAt: Symbol("blog.createdAt"),
+      updatedAt: Symbol("blog.updatedAt"),
+    };
+
+    const curatedFallbackRows = [
+      {
+        id: "curated-1",
+        title: "Curated fallback",
+        url: "https://example.com/curated",
+        source: "Example",
+        sourceImage: null,
+        date: new Date("2026-04-08T00:00:00.000Z"),
+        description: "Curated summary",
+        category: "ai",
+        featured: false,
+        createdAt: new Date("2026-04-08T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-08T00:00:00.000Z"),
+      },
+    ];
+
+    const announcementFallbackRows = [
+      {
+        id: "announcement-1",
+        title: "Announcement fallback",
+        url: "https://example.com/announcement",
+        company: "Example Co",
+        companyLogo: null,
+        platform: "x",
+        date: new Date("2026-04-08T00:00:00.000Z"),
+        description: "Announcement summary",
+        category: "product",
+        featured: true,
+        createdAt: new Date("2026-04-08T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-08T00:00:00.000Z"),
+      },
+    ];
+
+    const blogFallbackRows = [
+      {
+        slug: "fallback-post",
+        title: "Fallback post",
+        description: "Blog summary",
+        content: "Hello world",
+        date: new Date("2026-04-08T00:00:00.000Z"),
+        source: null,
+        sourceUrl: null,
+        image: null,
+        published: true,
+        createdAt: new Date("2026-04-08T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-08T00:00:00.000Z"),
+      },
+    ];
+
+    const db = {
+      select: (selection?: Record<string, unknown>) => ({
+        from: (table: unknown) => {
+          if (table === blogPosts) {
+            return {
+              where: () => ({
+                limit: async () => {
+                  if (!selection) {
+                    throw createMissingRelevanceError("blog_posts");
+                  }
+
+                  return blogFallbackRows.slice(0, 1);
+                },
+                orderBy: async () => {
+                  if (!selection) {
+                    throw createMissingRelevanceError("blog_posts");
+                  }
+
+                  return blogFallbackRows;
+                },
+              }),
+              orderBy: async () => {
+                if (!selection) {
+                  throw createMissingRelevanceError("blog_posts");
+                }
+
+                return blogFallbackRows;
+              },
+              limit: async () => {
+                if (!selection) {
+                  throw createMissingRelevanceError("blog_posts");
+                }
+
+                return blogFallbackRows.slice(0, 1);
+              },
+            };
+          }
+
+          const fallbackRows =
+            table === curatedLinks ? curatedFallbackRows : announcementFallbackRows;
+          const tableName = table === curatedLinks ? "curated_links" : "announcements";
+
+          const makeListChain = () => ({
+            limit: () => ({
+              offset: async () => {
+                if (!selection) {
+                  throw createMissingRelevanceError(tableName);
+                }
+
+                return fallbackRows;
+              },
+            }),
+          });
+
+          return {
+            where: () => ({
+              orderBy: makeListChain,
+              limit: async () => {
+                if (!selection) {
+                  throw createMissingRelevanceError(tableName);
+                }
+
+                return fallbackRows.slice(0, 1);
+              },
+            }),
+            orderBy: makeListChain,
+          };
+        },
+      }),
+    };
+
+    mock.module("@/db", () => ({
+      db,
+      curatedLinks,
+      announcements,
+      blogPosts,
+    }));
+
+    const compat = await import(`../src/lib/editorial-read-compat?compat=${Date.now()}`);
+
+    const curated = await compat.listCuratedLinksCompat({ limit: 10, offset: 0 });
+    const announcementsList = await compat.listAnnouncementsCompat({ limit: 10, offset: 0 });
+    const posts = await compat.listBlogPostsCompat(true);
+    const curatedById = await compat.getCuratedLinkByIdCompat("curated-1");
+    const announcementById = await compat.getAnnouncementByIdCompat("announcement-1");
+    const postBySlug = await compat.getBlogPostBySlugCompat("fallback-post");
+
+    expect(curated[0]).toMatchObject({ id: "curated-1", relevance: 5 });
+    expect(announcementsList[0]).toMatchObject({ id: "announcement-1", relevance: 5 });
+    expect(posts[0]).toMatchObject({ slug: "fallback-post", relevance: 5 });
+    expect(curatedById).toMatchObject({ id: "curated-1", relevance: 5 });
+    expect(announcementById).toMatchObject({ id: "announcement-1", relevance: 5 });
+    expect(postBySlug).toMatchObject({ slug: "fallback-post", relevance: 5 });
+  });
+});

--- a/tests/news-relevance-routes.test.ts
+++ b/tests/news-relevance-routes.test.ts
@@ -30,6 +30,27 @@ async function installNewsRouteMocks() {
     select: () => ({
       from: (table: unknown) => ({
         where: () => ({
+          orderBy: async () => {
+            if (table === tables.blogPosts) {
+              return [
+                {
+                  slug: "editorial-post",
+                  title: "Editorial post",
+                  date: new Date("2026-04-08T00:00:00.000Z"),
+                  description: "Post description",
+                  source: null,
+                  sourceUrl: null,
+                  image: null,
+                  content: "Hello world",
+                  published: true,
+                  relevance: 8,
+                  createdAt: new Date("2026-04-08T00:00:00.000Z"),
+                  updatedAt: new Date("2026-04-08T00:00:00.000Z"),
+                },
+              ];
+            }
+            return [];
+          },
           limit: async () => {
             if (table === tables.blogPosts) {
               return [];


### PR DESCRIPTION
## Summary
- add shared compatibility helpers for editorial read APIs when the relevance column is absent
- restore admin news and blog read routes by falling back to explicit column lists with default relevance
- cover the compatibility layer with regression tests and env-backed route checks

## Verification
- bun run test:unit
- bun x tsc --noEmit
- bun run lint
- bunx dotenv -e /Users/dcbuilder/Code/projects/dcbuilder.dev/.env.local -- bun -e 'import("next/server").then(async ({ NextRequest }) => { const { GET: getCurated } = await import("./src/app/api/v1/news/curated/route"); const { GET: getAnnouncements } = await import("./src/app/api/v1/news/announcements/route"); const curatedRes = await getCurated(new NextRequest("https://dcbuilder.dev/api/v1/news/curated?limit=2") as never); const announcementsRes = await getAnnouncements(new NextRequest("https://dcbuilder.dev/api/v1/news/announcements?limit=2") as never); console.log(JSON.stringify({ curatedStatus: curatedRes.status, curatedBody: await curatedRes.json(), announcementsStatus: announcementsRes.status, announcementsBody: await announcementsRes.json() }, null, 2)); process.exit(0); })'