### PR TITLE
fix(newsletter): stop admin studio 500 on pre-migration schema

### DIFF
--- a/src/services/newsletter-schema.ts
+++ b/src/services/newsletter-schema.ts
@@ -6,6 +6,27 @@ export type NewsletterAvailabilityMeta = {
   reason: string;
 };
 
+const NEWSLETTER_SCHEMA_COLUMN_HINTS = [
+  "content_mode",
+  "markdown_content",
+  "manual_html",
+  "manual_text",
+  "rendered_html",
+  "rendered_text",
+  "archive_subject",
+  "archive_preview_text",
+  "archive_content_mode",
+  "archive_markdown_content",
+  "archive_manual_html",
+  "archive_manual_text",
+  "archive_rendered_html",
+  "archive_rendered_text",
+  "archive_corrected_at",
+  "archive_corrected_by",
+  "timeframe_preset",
+  "minimum_relevance",
+] as const;
+
 function collectErrorMessages(error: unknown, depth: number = 0): string[] {
   if (!error || depth > 3) return [];
 
@@ -31,8 +52,11 @@ export function isMissingNewsletterSchemaError(error: unknown): boolean {
     .toLowerCase();
 
   const mentionsNewsletter =
-    haystack.includes("newsletter_") || haystack.includes("newsletter ");
+    haystack.includes("newsletter_") ||
+    haystack.includes("newsletter ") ||
+    NEWSLETTER_SCHEMA_COLUMN_HINTS.some((columnName) => haystack.includes(columnName));
   const mentionsMissingSchema =
+    haystack.includes("column") && haystack.includes("does not exist") ||
     haystack.includes("relation") && haystack.includes("does not exist") ||
     haystack.includes("undefined column") ||
     haystack.includes("unknown column") ||

--- a/tests/newsletter-campaigns-route.test.ts
+++ b/tests/newsletter-campaigns-route.test.ts
@@ -1,11 +1,22 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
+function createMissingNewsletterCampaignColumnError(columnName: string) {
+  const cause = new Error(`column "${columnName}" does not exist`) as Error & {
+    code?: string;
+  };
+  cause.code = "42703";
+
+  const error = new Error("Failed query") as Error & { cause?: Error };
+  error.cause = cause;
+  return error;
+}
+
 describe("GET /api/v1/newsletter/campaigns", () => {
   afterEach(() => {
     mock.restore();
   });
 
-  test("returns an unavailable fallback instead of 500 when the campaigns table is missing", async () => {
+  test("returns an unavailable fallback instead of 500 when campaign reads hit a missing schema column", async () => {
     const actualAuth = await import("../src/services/auth");
 
     mock.module("@/services/auth", () => ({
@@ -14,7 +25,7 @@ describe("GET /api/v1/newsletter/campaigns", () => {
     }));
     mock.module("@/services/newsletter", () => ({
       listNewsletterCampaigns: async () => {
-        throw new Error('relation "newsletter_campaigns" does not exist');
+        throw createMissingNewsletterCampaignColumnError("timeframe_preset");
       },
       createNewsletterCampaign: async () => ({ ok: true as const, data: null }),
       previewNewsletterCampaignDraft: async () => ({

--- a/tests/newsletter-schema.test.ts
+++ b/tests/newsletter-schema.test.ts
@@ -11,6 +11,18 @@ describe("isMissingNewsletterSchemaError", () => {
     ).toBe(true);
   });
 
+  test("matches wrapped missing-column errors for known newsletter campaign fields", () => {
+    const cause = new Error('column "timeframe_preset" does not exist') as Error & {
+      code?: string;
+    };
+    cause.code = "42703";
+
+    const error = new Error("Failed query") as Error & { cause?: Error };
+    error.cause = cause;
+
+    expect(isMissingNewsletterSchemaError(error)).toBe(true);
+  });
+
   test("does not treat permission errors as missing schema", () => {
     expect(
       isMissingNewsletterSchemaError(new Error("permission denied for relation newsletter_campaigns"))


### PR DESCRIPTION
## Summary
- treat wrapped missing-column errors for known newsletter campaign fields as newsletter schema-compat failures
- let `/api/v1/newsletter/campaigns` return the existing availability fallback instead of a 500 when prod is missing newer campaign columns
- add regression tests for the wrapped `timeframe_preset` error shape seen against the live database

## Verification
- bun test tests/newsletter-schema.test.ts
- bun test tests/newsletter-campaigns-route.test.ts
- bun x tsc --noEmit
- bun run lint
- bunx dotenv -e /Users/dcbuilder/Code/projects/dcbuilder.dev/.env.local -- bun -e 'const { GET } = await import("./src/app/api/v1/newsletter/campaigns/route"); const req = new Request("https://dcbuilder.dev/api/v1/newsletter/campaigns?limit=5", { headers: { "x-api-key": process.env.ADMIN_API_KEY ?? "" } }); const res = await GET(req as never); console.log(`STATUS ${res.status}`); console.log(await res.text());'