### PR TITLE
fix: allow sourceImage updates on curated links PUT

### DIFF
--- a/src/app/api/v1/news/curated/[id]/route.ts
+++ b/src/app/api/v1/news/curated/[id]/route.ts
@@ -50,6 +50,7 @@ export async function PUT(
     if (body.title !== undefined) updateData.title = body.title;
     if (body.url !== undefined) updateData.url = body.url;
     if (body.source !== undefined) updateData.source = body.source;
+    if (body.sourceImage !== undefined) updateData.sourceImage = body.sourceImage;
     if (body.date !== undefined) updateData.date = new Date(body.date);
     if (body.description !== undefined) updateData.description = body.description;
     if (body.category !== undefined) updateData.category = body.category;


### PR DESCRIPTION
## Summary
- Added `sourceImage` to the allowed update fields in curated links PUT handler
- Field was silently ignored on updates, preventing logo/icon assignment via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)