### PR TITLE
fix(db): constrain serverless postgres sessions

### DIFF
--- a/src/db/postgres-connection.ts
+++ b/src/db/postgres-connection.ts
@@ -19,12 +19,27 @@ export type PreferredPostgresTarget = {
 
 type PostgresClientOptions = {
   socket?: () => Promise<ConnectedSocket>;
+  max?: number;
+  idle_timeout?: number;
+  connect_timeout?: number;
 };
 
 type ConnectedSocket = net.Socket & {
   host: string;
   port: number;
 };
+
+const DEFAULT_POOL_MAX = 1;
+const DEFAULT_IDLE_TIMEOUT_SECONDS = 20;
+const DEFAULT_CONNECT_TIMEOUT_SECONDS = 10;
+
+function readPositiveIntegerEnv(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (!value) return fallback;
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 export async function resolvePreferredPostgresTarget(
   databaseUrl: string,
@@ -98,22 +113,35 @@ function isLoopbackHostname(hostname: string) {
 export function getPostgresClientOptions(
   databaseUrl: string | undefined
 ): PostgresClientOptions {
+  const poolOptions: PostgresClientOptions = {
+    max: readPositiveIntegerEnv("POSTGRES_POOL_MAX", DEFAULT_POOL_MAX),
+    idle_timeout: readPositiveIntegerEnv(
+      "POSTGRES_IDLE_TIMEOUT_SECONDS",
+      DEFAULT_IDLE_TIMEOUT_SECONDS
+    ),
+    connect_timeout: readPositiveIntegerEnv(
+      "POSTGRES_CONNECT_TIMEOUT_SECONDS",
+      DEFAULT_CONNECT_TIMEOUT_SECONDS
+    ),
+  };
+
   if (!databaseUrl) {
-    return {};
+    return poolOptions;
   }
 
   let hostname: string;
   try {
     hostname = new URL(databaseUrl).hostname;
   } catch {
-    return {};
+    return poolOptions;
   }
 
   if (isLoopbackHostname(hostname)) {
-    return {};
+    return poolOptions;
   }
 
   return {
+    ...poolOptions,
     socket: () => createPreferredPostgresSocket(databaseUrl),
   };
 }

--- a/tests/postgres-client-options.test.ts
+++ b/tests/postgres-client-options.test.ts
@@ -2,15 +2,39 @@ import { describe, expect, test } from "bun:test";
 import { getPostgresClientOptions } from "../src/db/postgres-connection";
 
 describe("getPostgresClientOptions", () => {
-  test("keeps localhost connections direct", () => {
+  test("keeps localhost connections direct with a constrained pool", () => {
     const options = getPostgresClientOptions("postgresql://user:pass@localhost:5432/app");
 
-    expect(options).toEqual({});
+    expect(options.socket).toBeUndefined();
+    expect(options.max).toBe(1);
+    expect(options.idle_timeout).toBe(20);
+    expect(options.connect_timeout).toBe(10);
   });
 
-  test("uses the preferred socket helper for hosted postgres connections", () => {
+  test("uses the preferred socket helper with a constrained pool for hosted postgres", () => {
     const options = getPostgresClientOptions("postgresql://user:pass@db.example.com:5432/app");
 
     expect(typeof options.socket).toBe("function");
+    expect(options.max).toBe(1);
+    expect(options.idle_timeout).toBe(20);
+    expect(options.connect_timeout).toBe(10);
+  });
+
+  test("allows positive pool overrides from the environment", () => {
+    process.env.POSTGRES_POOL_MAX = "2";
+    process.env.POSTGRES_IDLE_TIMEOUT_SECONDS = "30";
+    process.env.POSTGRES_CONNECT_TIMEOUT_SECONDS = "5";
+
+    try {
+      const options = getPostgresClientOptions("postgresql://user:pass@db.example.com:5432/app");
+
+      expect(options.max).toBe(2);
+      expect(options.idle_timeout).toBe(30);
+      expect(options.connect_timeout).toBe(5);
+    } finally {
+      delete process.env.POSTGRES_POOL_MAX;
+      delete process.env.POSTGRES_IDLE_TIMEOUT_SECONDS;
+      delete process.env.POSTGRES_CONNECT_TIMEOUT_SECONDS;
+    }
   });
 });

--- a/tests/postgres-connection-target.test.ts
+++ b/tests/postgres-connection-target.test.ts
@@ -28,11 +28,14 @@ describe("getPostgresClientOptions", () => {
     expect(result.socket).toBeFunction();
   });
 
-  test("leaves localhost connections on the default client path", () => {
+  test("leaves localhost connections on the direct socket path with a constrained pool", () => {
     const result = getPostgresClientOptions(
       "postgresql://user:pass@127.0.0.1:5432/app"
     );
 
     expect(result.socket).toBeUndefined();
+    expect(result.max).toBe(1);
+    expect(result.idle_timeout).toBe(20);
+    expect(result.connect_timeout).toBe(10);
   });
 });


### PR DESCRIPTION
## Summary
- Cap the runtime Postgres client pool to one session per serverless instance.
- Preserve the existing hosted IPv4 socket path for non-local database URLs.
- Add tests for default limits and positive environment overrides.

## Why
Production `/candidates` failures were caused by `EMAXCONNSESSION`, where
concurrent Vercel serverless instances exceeded the database session pool. The
new defaults reduce connection pressure while allowing controlled tuning through
`POSTGRES_POOL_MAX`, `POSTGRES_IDLE_TIMEOUT_SECONDS`, and
`POSTGRES_CONNECT_TIMEOUT_SECONDS`.

## Tests
- `bun test tests/postgres-client-options.test.ts tests/postgres-connection-target.test.ts`
- `bun run lint`
- `bunx tsc --noEmit`
