### PR TITLE
Sort news by posted date

### DIFF
--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -3,18 +3,28 @@
 import { useState, useMemo, useDeferredValue, useCallback } from "react";
 import Image from "next/image";
 import { AggregatedNewsItem } from "@/lib/news";
+import {
+	compareNewsByDateAndRelevance,
+	compareNewsByPostedAtAndRelevance,
+} from "@/lib/news-sorting";
 import { NewsCategory, categoryLabels } from "@/data/news";
 import { CustomSelect } from "./CustomSelect";
 import { trackNewsClick } from "@/lib/posthog";
 import { useNewsClicks } from "@/hooks/useNewsClicks";
 
 type NewsType = "all" | "blog" | "curated" | "announcement";
+type NewsSortMode = "posted" | "content";
 
 const typeLabels: Record<NewsType, string> = {
 	all: "All",
 	blog: "Blog Posts",
 	curated: "Curated Links",
 	announcement: "Announcements",
+};
+
+const sortModeLabels: Record<NewsSortMode, string> = {
+	posted: "Date I posted",
+	content: "Date content posted",
 };
 
 const NEWS_THUMBNAIL_SIZE = 56;
@@ -44,8 +54,10 @@ interface NewsGridProps {
 export function NewsGrid({ news }: NewsGridProps) {
 	const [typeFilter, setTypeFilter] = useState<NewsType>("all");
 	const [categoryFilter, setCategoryFilter] = useState<"all" | NewsCategory>("all");
+	const [sortMode, setSortMode] = useState<NewsSortMode>("posted");
 	const [minimumRelevance, setMinimumRelevance] = useState(0);
 	const [searchQuery, setSearchQuery] = useState("");
+	const [expandedDescriptionIds, setExpandedDescriptionIds] = useState<Set<string>>(() => new Set());
 	const [failedImageKeys, setFailedImageKeys] = useState<Record<string, true>>({});
 	const { getClickCount, isPopular, loaded: clicksLoaded } = useNewsClicks();
 	const deferredSearchQuery = useDeferredValue(searchQuery);
@@ -56,6 +68,18 @@ export function NewsGrid({ news }: NewsGridProps) {
 				month: "short",
 				day: "numeric",
 				timeZone: "UTC",
+			}),
+		[],
+	);
+	const postedAtFormatter = useMemo(
+		() =>
+			new Intl.DateTimeFormat("en-US", {
+				year: "numeric",
+				month: "short",
+				day: "numeric",
+				hour: "numeric",
+				minute: "2-digit",
+				timeZoneName: "short",
 			}),
 		[],
 	);
@@ -107,12 +131,23 @@ export function NewsGrid({ news }: NewsGridProps) {
 
 			return true;
 		});
-		}, [news, typeFilter, categoryFilter, minimumRelevance, deferredSearchQuery, newsSearchIndex]);
+	}, [news, typeFilter, categoryFilter, minimumRelevance, deferredSearchQuery, newsSearchIndex]);
+
+	const sortedNews = useMemo(() => {
+		const comparator =
+			sortMode === "posted" ? compareNewsByPostedAtAndRelevance : compareNewsByDateAndRelevance;
+		return [...filteredNews].sort(comparator);
+	}, [filteredNews, sortMode]);
 
 	// Format date for display
 	const formatDate = (dateString: string) => {
 		const date = new Date(dateString);
 		return dateFormatter.format(date);
+	};
+
+	const formatPostedAt = (dateString: string) => {
+		const date = new Date(dateString);
+		return postedAtFormatter.format(date);
 	};
 
 	const renderCommaSeparatedTokens = (value: string | undefined, keyPrefix: string) => {
@@ -138,6 +173,18 @@ export function NewsGrid({ news }: NewsGridProps) {
 
 	const markImageFailed = useCallback((key: string) => {
 		setFailedImageKeys((prev) => (prev[key] ? prev : { ...prev, [key]: true }));
+	}, []);
+
+	const toggleDescription = useCallback((itemId: string) => {
+		setExpandedDescriptionIds((current) => {
+			const next = new Set(current);
+			if (next.has(itemId)) {
+				next.delete(itemId);
+			} else {
+				next.add(itemId);
+			}
+			return next;
+		});
 	}, []);
 
 	const getBlogImageUrl = useCallback((rawUrl: string) => {
@@ -337,6 +384,26 @@ export function NewsGrid({ news }: NewsGridProps) {
 						/>
 					</div>
 
+					{/* Sort Mode */}
+					<div className="flex items-center gap-2">
+						<label
+							htmlFor="sort-mode"
+							className="text-sm text-neutral-600 dark:text-neutral-400 whitespace-nowrap"
+						>
+							Order:
+						</label>
+						<CustomSelect
+							id="sort-mode"
+							value={sortMode}
+							onChange={(value) => setSortMode(value as NewsSortMode)}
+							options={Object.entries(sortModeLabels).map(([value, label]) => ({
+								value,
+								label,
+							}))}
+							className="flex-1 sm:flex-none sm:min-w-[180px]"
+						/>
+					</div>
+
 					{/* Relevance Filter */}
 					<div className="flex items-center gap-2 sm:ml-1">
 						<label
@@ -411,23 +478,32 @@ export function NewsGrid({ news }: NewsGridProps) {
 						No news found matching your criteria.
 					</p>
 				) : (
-					filteredNews.map((item) => (
-						<a
-							key={item.id}
-							href={item.url}
-							target={isExternalLink(item) ? "_blank" : undefined}
-							rel={isExternalLink(item) ? "noopener noreferrer" : undefined}
-							onClick={() => handleNewsClick(item)}
-							className="group block p-4 rounded-xl border border-neutral-200 dark:border-neutral-800 hover:border-neutral-400 dark:hover:border-neutral-600 transition-colors"
-						>
-							<div className="flex items-center gap-4">
-								{/* Icon */}
-								<div className="flex-shrink-0 w-14 h-14 flex items-center justify-center">
-									{getTypeIcon(item)}
-								</div>
+					sortedNews.map((item) => {
+						const isDescriptionExpanded = expandedDescriptionIds.has(item.id);
 
-								{/* Content */}
-								<div className="flex-1 min-w-0">
+						return (
+							<div
+								key={item.id}
+								className="group relative block p-4 rounded-xl border border-neutral-200 dark:border-neutral-800 hover:border-neutral-400 dark:hover:border-neutral-600 transition-colors"
+							>
+								<a
+									href={item.url}
+									target={isExternalLink(item) ? "_blank" : undefined}
+									rel={isExternalLink(item) ? "noopener noreferrer" : undefined}
+									onClick={() => handleNewsClick(item)}
+									className="absolute inset-0 z-0 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 dark:focus-visible:ring-neutral-600"
+									aria-label={`Open ${item.title}`}
+								>
+									<span className="sr-only">Open {item.title}</span>
+								</a>
+								<div className="relative z-10 flex items-start gap-4 pointer-events-none">
+									{/* Icon */}
+									<div className="flex-shrink-0 w-14 h-14 flex items-center justify-center">
+										{getTypeIcon(item)}
+									</div>
+
+									{/* Content */}
+									<div className="flex-1 min-w-0">
 									{/* Title */}
 									<h3 className="font-semibold group-hover:text-neutral-600 dark:group-hover:text-neutral-300 transition-colors flex items-center gap-2">
 										<span className="truncate">{item.title}</span>
@@ -460,14 +536,30 @@ export function NewsGrid({ news }: NewsGridProps) {
 
 									{/* Description */}
 									{item.description && (
-										<p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400 line-clamp-2">
+										<p
+											className={`mt-1 text-sm leading-6 text-neutral-600 dark:text-neutral-400 ${
+												isDescriptionExpanded ? "" : "line-clamp-3 sm:line-clamp-2"
+											}`}
+										>
 											{item.description}
 										</p>
 									)}
 
+									{item.description && (
+										<button
+											type="button"
+											onClick={() => toggleDescription(item.id)}
+											className="pointer-events-auto mt-2 inline-flex items-center text-xs font-medium text-neutral-700 underline decoration-neutral-300 underline-offset-4 transition-colors hover:text-neutral-950 dark:text-neutral-300 dark:decoration-neutral-700 dark:hover:text-neutral-50 sm:hidden"
+											aria-expanded={isDescriptionExpanded}
+										>
+											{isDescriptionExpanded ? "Show less" : "Show more"}
+										</button>
+									)}
+
 									{/* Meta info */}
 									<div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-neutral-500">
-										<span>{formatDate(item.date)}</span>
+										<span>Published {formatDate(item.date)}</span>
+										<span>Added {formatPostedAt(item.postedAt)}</span>
 										{clicksLoaded && getClickCount(item.id) > 0 && (
 											<span>{getClickCount(item.id)} clicks</span>
 										)}
@@ -497,9 +589,10 @@ export function NewsGrid({ news }: NewsGridProps) {
 										</span>
 									</div>
 								</div>
+								</div>
 							</div>
-						</a>
-					))
+						);
+					})
 				)}
 			</div>
 		</div>

--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -23,7 +23,7 @@ const typeLabels: Record<NewsType, string> = {
 };
 
 const sortModeLabels: Record<NewsSortMode, string> = {
-	posted: "Date I posted",
+	posted: "Date DC posted",
 	content: "Date content posted",
 };
 

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -9,6 +9,7 @@ export interface BlogPostView {
   slug: string;
   title: string;
   date: string;
+  createdAt: string;
   description: string;
   content: string;
   source?: string;
@@ -22,6 +23,7 @@ export interface BlogPostMeta {
   slug: string;
   title: string;
   date: string;
+  createdAt: string;
   description: string;
   source?: string;
   sourceUrl?: string;
@@ -45,6 +47,10 @@ function formatDateString(date: Date | null, slug?: string): string {
     return FALLBACK_DATE;
   }
   return date.toISOString().split("T")[0];
+}
+
+function formatDateTimeString(date: Date | null | undefined): string {
+  return (date ?? new Date(0)).toISOString();
 }
 
 export function formatBlogDate(dateString: string): string {
@@ -79,6 +85,7 @@ export async function getAllPosts(): Promise<BlogPostMeta[]> {
       slug: post.slug,
       title: post.title,
       date: formatDateString(post.date, post.slug),
+      createdAt: formatDateTimeString(post.createdAt),
       description: post.description || "",
       source: post.source || undefined,
       sourceUrl: post.sourceUrl || undefined,
@@ -101,6 +108,7 @@ export async function getAllPosts(): Promise<BlogPostMeta[]> {
             source: blogPosts.source,
             sourceUrl: blogPosts.sourceUrl,
             image: blogPosts.image,
+            createdAt: blogPosts.createdAt,
           })
           .from(blogPosts)
           .where(eq(blogPosts.published, true))
@@ -110,6 +118,7 @@ export async function getAllPosts(): Promise<BlogPostMeta[]> {
           slug: post.slug,
           title: post.title,
           date: formatDateString(post.date, post.slug),
+          createdAt: formatDateTimeString(post.createdAt),
           description: post.description || "",
           source: post.source || undefined,
           sourceUrl: post.sourceUrl || undefined,
@@ -142,6 +151,7 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
       slug: post.slug,
       title: post.title,
       date: formatDateString(post.date, post.slug),
+      createdAt: formatDateTimeString(post.createdAt),
       description: post.description || "",
       content: post.content,
       source: post.source || undefined,

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -49,8 +49,8 @@ function formatDateString(date: Date | null, slug?: string): string {
   return date.toISOString().split("T")[0];
 }
 
-function formatDateTimeString(date: Date | null | undefined): string {
-  return (date ?? new Date(0)).toISOString();
+function formatDateTimeString(date: Date | null | undefined, fallback?: Date | null): string {
+  return (date ?? fallback ?? new Date(0)).toISOString();
 }
 
 export function formatBlogDate(dateString: string): string {
@@ -85,7 +85,7 @@ export async function getAllPosts(): Promise<BlogPostMeta[]> {
       slug: post.slug,
       title: post.title,
       date: formatDateString(post.date, post.slug),
-      createdAt: formatDateTimeString(post.createdAt),
+      createdAt: formatDateTimeString(post.createdAt, post.date),
       description: post.description || "",
       source: post.source || undefined,
       sourceUrl: post.sourceUrl || undefined,
@@ -118,7 +118,7 @@ export async function getAllPosts(): Promise<BlogPostMeta[]> {
           slug: post.slug,
           title: post.title,
           date: formatDateString(post.date, post.slug),
-          createdAt: formatDateTimeString(post.createdAt),
+          createdAt: formatDateTimeString(post.createdAt, post.date),
           description: post.description || "",
           source: post.source || undefined,
           sourceUrl: post.sourceUrl || undefined,
@@ -151,7 +151,7 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
       slug: post.slug,
       title: post.title,
       date: formatDateString(post.date, post.slug),
-      createdAt: formatDateTimeString(post.createdAt),
+      createdAt: formatDateTimeString(post.createdAt, post.date),
       description: post.description || "",
       content: post.content,
       source: post.source || undefined,

--- a/src/lib/news-sorting.ts
+++ b/src/lib/news-sorting.ts
@@ -7,6 +7,10 @@ export interface NewsSortItem {
   relevance?: number | null;
 }
 
+export interface NewsPostedSortItem extends NewsSortItem {
+  postedAt?: string | Date | null | undefined;
+}
+
 function getUtcDayTimestamp(date: string | Date | null | undefined): number | null {
   if (!date) return null;
 
@@ -62,6 +66,25 @@ export function compareNewsByDateAndRelevance<T extends NewsSortItem>(
   );
 
   if (exactDateComparison !== 0) return exactDateComparison;
+
+  return (a.title ?? a.id ?? "").localeCompare(b.title ?? b.id ?? "");
+}
+
+export function compareNewsByPostedAtAndRelevance<T extends NewsPostedSortItem>(
+  a: T,
+  b: T,
+  direction: NewsSortDirection = "desc"
+) {
+  const postedComparison = compareNullableTimestamps(
+    getExactTimestamp(a.postedAt ?? a.date),
+    getExactTimestamp(b.postedAt ?? b.date),
+    direction
+  );
+
+  if (postedComparison !== 0) return postedComparison;
+
+  const relevanceComparison = (b.relevance ?? 0) - (a.relevance ?? 0);
+  if (relevanceComparison !== 0) return relevanceComparison;
 
   return (a.title ?? a.id ?? "").localeCompare(b.title ?? b.id ?? "");
 }

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -12,6 +12,7 @@ export interface AggregatedNewsItem {
   title: string;
   url: string;
   date: string;
+  postedAt: string;
   description?: string;
   category: NewsCategory;
   featured?: boolean;
@@ -48,6 +49,7 @@ async function getCuratedLinksWithFallback() {
             description: curatedLinksTable.description,
             category: curatedLinksTable.category,
             featured: curatedLinksTable.featured,
+            createdAt: curatedLinksTable.createdAt,
           })
           .from(curatedLinksTable)
           .orderBy(desc(curatedLinksTable.date));
@@ -90,6 +92,7 @@ async function getAnnouncementsWithFallback() {
             description: announcementsTable.description,
             category: announcementsTable.category,
             featured: announcementsTable.featured,
+            createdAt: announcementsTable.createdAt,
           })
           .from(announcementsTable)
           .orderBy(desc(announcementsTable.date));
@@ -124,6 +127,7 @@ export async function getAllNews(): Promise<AggregatedNewsItem[]> {
     title: post.title,
     url: `/blog/${post.slug}`,
     date: post.date,
+    postedAt: post.createdAt,
     description: post.description,
     category: "general" as NewsCategory,
     readingTime: `${post.readingTime} min read`,
@@ -138,6 +142,7 @@ export async function getAllNews(): Promise<AggregatedNewsItem[]> {
     title: link.title,
     url: link.url,
     date: link.date.toISOString().split("T")[0],
+    postedAt: link.createdAt.toISOString(),
     description: link.description || undefined,
     category: link.category as NewsCategory,
     featured: link.featured || false,
@@ -153,6 +158,7 @@ export async function getAllNews(): Promise<AggregatedNewsItem[]> {
     title: ann.title,
     url: ann.url,
     date: ann.date.toISOString().split("T")[0],
+    postedAt: ann.createdAt.toISOString(),
     description: ann.description || undefined,
     category: ann.category as NewsCategory,
     featured: ann.featured || false,

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -27,6 +27,11 @@ export interface AggregatedNewsItem {
   image?: string; // For blog posts
 }
 
+function toIsoDateTime(date: string | Date | null | undefined, fallback?: string | Date | null): string {
+  const parsed = new Date(date ?? fallback ?? 0);
+  return Number.isNaN(parsed.getTime()) ? new Date(0).toISOString() : parsed.toISOString();
+}
+
 async function getCuratedLinksWithFallback() {
   try {
     return await db
@@ -127,7 +132,7 @@ export async function getAllNews(): Promise<AggregatedNewsItem[]> {
     title: post.title,
     url: `/blog/${post.slug}`,
     date: post.date,
-    postedAt: post.createdAt,
+    postedAt: toIsoDateTime(post.createdAt, post.date),
     description: post.description,
     category: "general" as NewsCategory,
     readingTime: `${post.readingTime} min read`,
@@ -142,7 +147,7 @@ export async function getAllNews(): Promise<AggregatedNewsItem[]> {
     title: link.title,
     url: link.url,
     date: link.date.toISOString().split("T")[0],
-    postedAt: link.createdAt.toISOString(),
+    postedAt: toIsoDateTime(link.createdAt, link.date),
     description: link.description || undefined,
     category: link.category as NewsCategory,
     featured: link.featured || false,
@@ -158,7 +163,7 @@ export async function getAllNews(): Promise<AggregatedNewsItem[]> {
     title: ann.title,
     url: ann.url,
     date: ann.date.toISOString().split("T")[0],
-    postedAt: ann.createdAt.toISOString(),
+    postedAt: toIsoDateTime(ann.createdAt, ann.date),
     description: ann.description || undefined,
     category: ann.category as NewsCategory,
     featured: ann.featured || false,

--- a/tests/blog-relevance-fallback.test.ts
+++ b/tests/blog-relevance-fallback.test.ts
@@ -61,6 +61,7 @@ describe("getAllPosts relevance fallback", () => {
         slug: "fallback-post",
         title: "Fallback Post",
         date: "2026-04-10",
+        createdAt: "2026-04-10T00:00:00.000Z",
         description: "Fallback summary",
         source: undefined,
         sourceUrl: undefined,

--- a/tests/news-sorting.test.ts
+++ b/tests/news-sorting.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { compareNewsByDateAndRelevance } from "../src/lib/news-sorting";
+import {
+  compareNewsByDateAndRelevance,
+  compareNewsByPostedAtAndRelevance,
+} from "../src/lib/news-sorting";
 
 describe("compareNewsByDateAndRelevance", () => {
   test("sorts newer days first, then same-day items by relevance", () => {
@@ -28,5 +31,48 @@ describe("compareNewsByDateAndRelevance", () => {
     expect(
       items.sort((a, b) => compareNewsByDateAndRelevance(a, b, "asc")).map((item) => item.id)
     ).toEqual(["older-high", "older-low", "newer"]);
+  });
+});
+
+describe("compareNewsByPostedAtAndRelevance", () => {
+  test("sorts by the exact posted timestamp before source content date", () => {
+    const items = [
+      {
+        id: "newer-content",
+        date: "2026-04-29",
+        postedAt: "2026-04-29T08:00:00.000Z",
+        relevance: 10,
+      },
+      {
+        id: "newer-posted",
+        date: "2026-04-20",
+        postedAt: "2026-04-29T09:00:00.000Z",
+        relevance: 1,
+      },
+      {
+        id: "older-posted",
+        date: "2026-04-30",
+        postedAt: "2026-04-28T23:00:00.000Z",
+        relevance: 10,
+      },
+    ];
+
+    expect(items.sort(compareNewsByPostedAtAndRelevance).map((item) => item.id)).toEqual([
+      "newer-posted",
+      "newer-content",
+      "older-posted",
+    ]);
+  });
+
+  test("falls back to relevance when posted timestamps match", () => {
+    const items = [
+      { id: "low", date: "2026-04-29", postedAt: "2026-04-29T08:00:00.000Z", relevance: 1 },
+      { id: "high", date: "2026-04-28", postedAt: "2026-04-29T08:00:00.000Z", relevance: 9 },
+    ];
+
+    expect(items.sort(compareNewsByPostedAtAndRelevance).map((item) => item.id)).toEqual([
+      "high",
+      "low",
+    ]);
   });
 });

--- a/tests/newsletter-markdown-text.test.ts
+++ b/tests/newsletter-markdown-text.test.ts
@@ -19,6 +19,10 @@ function makeDbMock() {
   };
 }
 
+function dateDaysAgo(daysAgo: number): string {
+  return new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString().split("T")[0];
+}
+
 describe("previewNewsletterCampaignDraft markdown text output", () => {
   afterEach(() => {
     mock.restore();
@@ -40,7 +44,7 @@ describe("previewNewsletterCampaignDraft markdown text output", () => {
           type: "curated",
           title: "AI story",
           url: "https://example.com/ai",
-          date: "2026-04-21",
+          date: dateDaysAgo(1),
           category: "ai",
           source: "Example AI",
         },
@@ -49,7 +53,7 @@ describe("previewNewsletterCampaignDraft markdown text output", () => {
           type: "curated",
           title: "Crypto story",
           url: "https://example.com/crypto",
-          date: "2026-04-20",
+          date: dateDaysAgo(2),
           category: "crypto",
           source: "Example Crypto",
         },
@@ -58,7 +62,7 @@ describe("previewNewsletterCampaignDraft markdown text output", () => {
           type: "curated",
           title: "Research story",
           url: "https://example.com/research",
-          date: "2026-04-19",
+          date: dateDaysAgo(3),
           category: "research",
           source: "Example Research",
         },
@@ -102,7 +106,7 @@ describe("previewNewsletterCampaignDraft markdown text output", () => {
           type: "curated",
           title: "High signal quarterly item",
           url: "https://example.com/high-signal",
-          date: "2026-03-12",
+          date: dateDaysAgo(30),
           category: "ai",
           source: "Example AI",
           relevance: 8,
@@ -112,7 +116,7 @@ describe("previewNewsletterCampaignDraft markdown text output", () => {
           type: "curated",
           title: "Low relevance weekly filler",
           url: "https://example.com/low-signal",
-          date: "2026-03-10",
+          date: dateDaysAgo(31),
           category: "crypto",
           source: "Example Crypto",
           relevance: 4,


### PR DESCRIPTION
## Summary
- Adds `postedAt` to the aggregated news view model using existing `created_at` timestamps.
- Adds a public news order control for `Date I posted` vs `Date content posted`.
- Shows both published and added dates on news cards.
- Expands mobile descriptions from three lines and adds per-item `Show more` / `Show less` controls.
- Adds focused tests for posted-date sorting.

## Validation
- `bunx tsc --noEmit`
- `bun run lint`
- `bun test tests/news-sorting.test.ts`
- `bun run build`
