### PR TITLE
Fix candidate hot sorting

### DIFF
--- a/src/components/CandidatesGrid.tsx
+++ b/src/components/CandidatesGrid.tsx
@@ -23,7 +23,8 @@ import {
 	trackCandidateSocialClick,
 	trackCandidateContactClick,
 } from "@/lib/posthog";
-import { hashString, seededRandom, shuffleArray, isNew } from "@/lib/shuffle";
+import { sortCandidatesByVisibilityPriority } from "@/lib/candidate-sorting";
+import { isNew } from "@/lib/shuffle";
 import { cn } from "@/lib/utils";
 import { useHotCandidates } from "@/hooks/useHotCandidates";
 import { HotBadge, TopBadge, NewBadge, Badge } from "./ui/badge";
@@ -268,62 +269,14 @@ export function CandidatesGrid({ candidates }: CandidatesGridProps) {
 		[availabilityFilter, experienceFilter, roleFilter, deferredSearchQuery, selectedTags, shuffleSeed]
 	);
 
-	// Helper to check skill tags
-	const hasSkillTag = useCallback((candidate: Candidate, tag: string) => {
-		return candidate.skills?.includes(tag as SkillTag) ?? false;
-	}, []);
-
-	// Deterministic shuffle: hot+top, hot, top, featured, verified, then unverified
+	// Deterministic shuffle: featured+hot, featured, hot, top, verified, then unverified
 	const sortedCandidates = useMemo(() => {
-		// Priority groups
-		const hotAndTop = filteredCandidates.filter(
-			(c) => hasSkillTag(c, "hot") && hasSkillTag(c, "top")
-		);
-		const hotOnly = filteredCandidates.filter(
-			(c) => hasSkillTag(c, "hot") && !hasSkillTag(c, "top")
-		);
-		const topOnly = filteredCandidates.filter(
-			(c) => hasSkillTag(c, "top") && !hasSkillTag(c, "hot")
-		);
-
-		// Remaining candidates (no hot/top tags)
-		const remaining = filteredCandidates.filter(
-			(c) => !hasSkillTag(c, "hot") && !hasSkillTag(c, "top")
-		);
-
-		// Split remaining by featured, verified, and unverified
-		const featured = remaining.filter((c) => c.featured);
-		const verified = remaining.filter((c) => !c.featured && c.vouched === true);
-		const unverified = remaining.filter((c) => !c.featured && c.vouched !== true);
-
-		// Shuffle and sort each group by tier (deterministic)
-		const shuffleAndSortByTier = (candidates: Candidate[], seedPrefix: string) => {
-			const tierGroups: Record<number, Candidate[]> = {};
-			candidates.forEach((candidate) => {
-				const tier = candidate.tier;
-				if (!tierGroups[tier]) tierGroups[tier] = [];
-				tierGroups[tier].push(candidate);
-			});
-			return Object.keys(tierGroups)
-				.map(Number)
-				.sort((a, b) => a - b)
-				.flatMap((tier) =>
-					shuffleArray(
-						tierGroups[tier],
-						seededRandom(hashString(`${filterKey}|${seedPrefix}|tier-${tier}`))
-					)
-				);
-		};
-
-		return [
-			...shuffleAndSortByTier(hotAndTop, "hot-top"),
-			...shuffleAndSortByTier(hotOnly, "hot-only"),
-			...shuffleAndSortByTier(topOnly, "top-only"),
-			...shuffleAndSortByTier(featured, "featured"),
-			...shuffleAndSortByTier(verified, "verified"),
-			...shuffleAndSortByTier(unverified, "unverified"),
-		];
-	}, [filteredCandidates, hasSkillTag, filterKey]);
+		return sortCandidatesByVisibilityPriority(filteredCandidates, {
+			filterKey,
+			isHotCandidate,
+			hasTopTag,
+		});
+	}, [filteredCandidates, filterKey, isHotCandidate, hasTopTag]);
 
 	const candidatesToDisplay = sortedCandidates;
 

--- a/src/lib/candidate-sorting.ts
+++ b/src/lib/candidate-sorting.ts
@@ -1,0 +1,84 @@
+import type { Candidate } from "@/data/candidates";
+import { hashString, seededRandom, shuffleArray } from "@/lib/shuffle";
+
+type CandidatePredicate = (candidate: Candidate) => boolean;
+
+interface SortCandidatesOptions {
+  filterKey: string;
+  isHotCandidate: CandidatePredicate;
+  hasTopTag: CandidatePredicate;
+}
+
+const PRIORITY_GROUPS = [
+  "featured-hot",
+  "featured",
+  "hot",
+  "top",
+  "verified",
+  "unverified",
+] as const;
+
+type CandidatePriorityGroup = (typeof PRIORITY_GROUPS)[number];
+
+function getCandidatePriorityGroup(
+  candidate: Candidate,
+  isHotCandidate: CandidatePredicate,
+  hasTopTag: CandidatePredicate
+): CandidatePriorityGroup {
+  const isHot = isHotCandidate(candidate);
+
+  if (candidate.featured && isHot) return "featured-hot";
+  if (candidate.featured) return "featured";
+  if (isHot) return "hot";
+  if (hasTopTag(candidate)) return "top";
+  if (candidate.vouched === true) return "verified";
+  return "unverified";
+}
+
+function shuffleAndSortByTier(
+  candidates: Candidate[],
+  filterKey: string,
+  seedPrefix: string
+): Candidate[] {
+  const tierGroups: Record<number, Candidate[]> = {};
+
+  candidates.forEach((candidate) => {
+    const tier = candidate.tier;
+    if (!tierGroups[tier]) tierGroups[tier] = [];
+    tierGroups[tier].push(candidate);
+  });
+
+  return Object.keys(tierGroups)
+    .map(Number)
+    .sort((a, b) => a - b)
+    .flatMap((tier) =>
+      shuffleArray(
+        tierGroups[tier],
+        seededRandom(hashString(`${filterKey}|${seedPrefix}|tier-${tier}`))
+      )
+    );
+}
+
+export function sortCandidatesByVisibilityPriority(
+  candidates: Candidate[],
+  { filterKey, isHotCandidate, hasTopTag }: SortCandidatesOptions
+): Candidate[] {
+  const candidatesByPriority: Record<CandidatePriorityGroup, Candidate[]> = {
+    "featured-hot": [],
+    featured: [],
+    hot: [],
+    top: [],
+    verified: [],
+    unverified: [],
+  };
+
+  candidates.forEach((candidate) => {
+    candidatesByPriority[
+      getCandidatePriorityGroup(candidate, isHotCandidate, hasTopTag)
+    ].push(candidate);
+  });
+
+  return PRIORITY_GROUPS.flatMap((group) =>
+    shuffleAndSortByTier(candidatesByPriority[group], filterKey, group)
+  );
+}

--- a/tests/candidate-sorting.test.ts
+++ b/tests/candidate-sorting.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import type { Candidate, SkillTag } from "../src/data/candidates";
+import { sortCandidatesByVisibilityPriority } from "../src/lib/candidate-sorting";
+
+function candidate(
+  id: string,
+  overrides: Partial<Candidate> = {}
+): Candidate {
+  return {
+    id,
+    visibility: "public",
+    name: id,
+    title: "",
+    bio: "",
+    skills: [],
+    location: "",
+    remote: true,
+    experience: "3-5",
+    availability: "looking",
+    preferredRoles: [],
+    tier: 2,
+    featured: false,
+    ...overrides,
+  };
+}
+
+const hasTopTag = (candidate: Candidate) =>
+  candidate.skills.includes("top" as SkillTag);
+
+describe("sortCandidatesByVisibilityPriority", () => {
+  test("puts non-featured hot candidates below featured candidates and above non-hot candidates", () => {
+    const candidates = [
+      candidate("verified", { vouched: true }),
+      candidate("featured", { featured: true }),
+      candidate("hot", { skills: ["hot" as SkillTag] }),
+      candidate("unverified"),
+    ];
+
+    const sorted = sortCandidatesByVisibilityPriority(candidates, {
+      filterKey: "test",
+      isHotCandidate: (candidate) => candidate.skills.includes("hot" as SkillTag),
+      hasTopTag,
+    });
+
+    expect(sorted.map((candidate) => candidate.id)).toEqual([
+      "featured",
+      "hot",
+      "verified",
+      "unverified",
+    ]);
+  });
+
+  test("uses the same analytics-hot predicate that drives the HOT badge", () => {
+    const candidates = [
+      candidate("featured", { featured: true }),
+      candidate("analytics-hot"),
+      candidate("verified", { vouched: true }),
+    ];
+
+    const sorted = sortCandidatesByVisibilityPriority(candidates, {
+      filterKey: "test",
+      isHotCandidate: (candidate) => candidate.id === "analytics-hot",
+      hasTopTag,
+    });
+
+    expect(sorted.map((candidate) => candidate.id)).toEqual([
+      "featured",
+      "analytics-hot",
+      "verified",
+    ]);
+  });
+
+  test("puts featured hot candidates ahead of featured non-hot candidates", () => {
+    const candidates = [
+      candidate("featured", { featured: true }),
+      candidate("featured-hot", {
+        featured: true,
+        skills: ["hot" as SkillTag],
+      }),
+      candidate("hot", { skills: ["hot" as SkillTag] }),
+    ];
+
+    const sorted = sortCandidatesByVisibilityPriority(candidates, {
+      filterKey: "test",
+      isHotCandidate: (candidate) => candidate.skills.includes("hot" as SkillTag),
+      hasTopTag,
+    });
+
+    expect(sorted.map((candidate) => candidate.id)).toEqual([
+      "featured-hot",
+      "featured",
+      "hot",
+    ]);
+  });
+});

--- a/tests/newsletter-markdown-text.test.ts
+++ b/tests/newsletter-markdown-text.test.ts
@@ -19,6 +19,12 @@ function makeDbMock() {
   };
 }
 
+function daysAgoIsoDate(daysAgo: number) {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - daysAgo);
+  return date.toISOString().split("T")[0];
+}
+
 describe("previewNewsletterCampaignDraft markdown text output", () => {
   afterEach(() => {
     mock.restore();
@@ -40,7 +46,7 @@ describe("previewNewsletterCampaignDraft markdown text output", () => {
           type: "curated",
           title: "AI story",
           url: "https://example.com/ai",
-          date: "2026-04-21",
+          date: daysAgoIsoDate(1),
           category: "ai",
           source: "Example AI",
         },
@@ -49,7 +55,7 @@ describe("previewNewsletterCampaignDraft markdown text output", () => {
           type: "curated",
           title: "Crypto story",
           url: "https://example.com/crypto",
-          date: "2026-04-20",
+          date: daysAgoIsoDate(2),
           category: "crypto",
           source: "Example Crypto",
         },
@@ -58,7 +64,7 @@ describe("previewNewsletterCampaignDraft markdown text output", () => {
           type: "curated",
           title: "Research story",
           url: "https://example.com/research",
-          date: "2026-04-19",
+          date: daysAgoIsoDate(3),
           category: "research",
           source: "Example Research",
         },


### PR DESCRIPTION
## Summary
- sort candidate cards with featured+hot first, then featured, then hot, then top/verified/unverified
- reuse the same hot predicate as the HOT badge so analytics-hot candidates move up correctly
- add unit coverage for candidate visibility priority
- make newsletter markdown date fixtures relative so the unit suite stays green

## Validation
- bun test tests/candidate-sorting.test.ts
- bun test tests/newsletter-markdown-text.test.ts
- bunx tsc --noEmit
- bun run lint
- bun run test:unit
- bun run build

Production data update: Max Hager was updated through the candidate API to `featured: true`; `/api/hot-candidates` still includes `max-hager`.