### PR TITLE
Trim duplicate news metadata

### DIFF
--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -71,19 +71,6 @@ export function NewsGrid({ news }: NewsGridProps) {
 			}),
 		[],
 	);
-	const postedAtFormatter = useMemo(
-		() =>
-			new Intl.DateTimeFormat("en-US", {
-				year: "numeric",
-				month: "short",
-				day: "numeric",
-				hour: "numeric",
-				minute: "2-digit",
-				timeZoneName: "short",
-			}),
-		[],
-	);
-
 	// Get all unique categories from news items
 	const allCategories = useMemo(() => {
 		const categories = new Set<NewsCategory>();
@@ -143,11 +130,6 @@ export function NewsGrid({ news }: NewsGridProps) {
 	const formatDate = (dateString: string) => {
 		const date = new Date(dateString);
 		return dateFormatter.format(date);
-	};
-
-	const formatPostedAt = (dateString: string) => {
-		const date = new Date(dateString);
-		return postedAtFormatter.format(date);
 	};
 
 	const renderCommaSeparatedTokens = (value: string | undefined, keyPrefix: string) => {
@@ -559,7 +541,6 @@ export function NewsGrid({ news }: NewsGridProps) {
 									{/* Meta info */}
 									<div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-neutral-500">
 										<span>Published {formatDate(item.date)}</span>
-										<span>Added {formatPostedAt(item.postedAt)}</span>
 										{clicksLoaded && getClickCount(item.id) > 0 && (
 											<span>{getClickCount(item.id)} clicks</span>
 										)}

--- a/src/lib/recommendations.ts
+++ b/src/lib/recommendations.ts
@@ -57,11 +57,6 @@ export const OTHER_CONTENT_I_LIKE: RecommendationItem[] = [
     description: "Podcast on ZK proofs and the decentralized web",
   },
   {
-    name: "TBPN Podcast",
-    url: "https://tbpn.substack.com",
-    description: "Daily live video & audio show on business and tech by @johncoogan & @jordihays",
-  },
-  {
     name: "Hardcore History",
     url: "https://www.dancarlin.com/hardcore-history-series",
     description: "Dan Carlin's epic deep-dives into history",


### PR DESCRIPTION
## Summary
- Remove TBPN Podcast from the secondary "Other content I like" recommendations list.
- Remove the "Added" timestamp from news card metadata while keeping the published date.

## Validation
- `bunx tsc --noEmit`
- `bun run lint`
