### PR TITLE
Update landing layout and about durations

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -22,15 +22,53 @@ const isActive = (dateEnd: string | null): boolean => {
 	return dateEnd?.toLowerCase() === "present" || dateEnd === null;
 };
 
+const months: Record<string, number> = {
+	jan: 1, january: 1, feb: 2, february: 2, mar: 3, march: 3,
+	apr: 4, april: 4, may: 5, jun: 6, june: 6,
+	jul: 7, july: 7, aug: 8, august: 8, sep: 9, september: 9,
+	oct: 10, october: 10, nov: 11, november: 11, dec: 12, december: 12,
+};
+
+const parseMonthDate = (date: string | null): { year: number; month: number } | null => {
+	if (!date || date.toLowerCase() === "present") return null;
+	const parts = date.toLowerCase().split(" ");
+	const month = months[parts[0]];
+	const year = Number.parseInt(parts[1], 10);
+	if (!month || Number.isNaN(year)) return null;
+	return { year, month };
+};
+
+const formatAffiliationDuration = (
+	dateBegin: string | null,
+	dateEnd: string | null
+): string | null => {
+	const start = parseMonthDate(dateBegin);
+	if (!start) return null;
+
+	const now = new Date();
+	const end = parseMonthDate(dateEnd) ?? {
+		year: now.getFullYear(),
+		month: now.getMonth() + 1,
+	};
+
+	const totalMonths = Math.max(1, (end.year - start.year) * 12 + end.month - start.month);
+	const years = Math.floor(totalMonths / 12);
+	const monthsRemaining = totalMonths % 12;
+
+	if (years === 0) {
+		return `${monthsRemaining} ${monthsRemaining === 1 ? "month" : "months"}`;
+	}
+
+	if (monthsRemaining === 0) {
+		return `${years} ${years === 1 ? "year" : "years"}`;
+	}
+
+	return `${years} ${years === 1 ? "year" : "years"} ${monthsRemaining} ${monthsRemaining === 1 ? "month" : "months"}`;
+};
+
 // Parse date string like "Mar 2022", "July 2022", "Dec 2024" to comparable value
 const parseEndDate = (dateEnd: string | null): number => {
 	if (!dateEnd || dateEnd.toLowerCase() === "present") return Infinity;
-	const months: Record<string, number> = {
-		jan: 1, january: 1, feb: 2, february: 2, mar: 3, march: 3,
-		apr: 4, april: 4, may: 5, jun: 6, june: 6,
-		jul: 7, july: 7, aug: 8, august: 8, sep: 9, september: 9,
-		oct: 10, october: 10, nov: 11, november: 11, dec: 12, december: 12,
-	};
 	const parts = dateEnd.toLowerCase().split(" ");
 	const month = months[parts[0]] || 1;
 	const year = parseInt(parts[1]) || 2000;
@@ -114,46 +152,54 @@ export default async function About() {
 							Affiliations
 						</h2>
 						<div className="space-y-6 sm:space-y-8">
-							{affiliations.map((affiliation) => (
-								<a
-									key={affiliation.title}
-									href={affiliation.website || "#"}
-									target="_blank"
-									rel="noopener noreferrer"
-									className="group block p-4 sm:p-6 rounded-xl border border-neutral-200 dark:border-neutral-800 hover:border-neutral-400 dark:hover:border-neutral-600 transition-colors"
-								>
-									<div className="flex flex-col sm:flex-row gap-4 sm:gap-6 text-center sm:text-left">
-										<div className="shrink-0 flex items-center justify-center sm:w-32">
-											{affiliation.logo && (
-												<Image
-													src={affiliation.logo}
-													alt={affiliation.title}
-													width={160}
-													height={160}
-													className="w-32 h-32 sm:w-24 sm:h-24 object-contain bg-white rounded-lg p-2 group-hover:scale-[1.08] transition-transform duration-150"
-												/>
-											)}
-										</div>
-										<div className="flex-1">
-											<div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 mb-2">
-												<h3 className="text-lg sm:text-xl font-semibold">
-													{affiliation.title}
-												</h3>
-												<span className="text-neutral-500 dark:text-neutral-400">
-													{affiliation.role}
-												</span>
+							{affiliations.map((affiliation) => {
+								const duration = formatAffiliationDuration(
+									affiliation.dateBegin,
+									affiliation.dateEnd
+								);
+
+								return (
+									<a
+										key={affiliation.title}
+										href={affiliation.website || "#"}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="group block p-4 sm:p-6 rounded-xl border border-neutral-200 dark:border-neutral-800 hover:border-neutral-400 dark:hover:border-neutral-600 transition-colors"
+									>
+										<div className="flex flex-col sm:flex-row gap-4 sm:gap-6 text-center sm:text-left">
+											<div className="shrink-0 flex items-center justify-center sm:w-32">
+												{affiliation.logo && (
+													<Image
+														src={affiliation.logo}
+														alt={affiliation.title}
+														width={160}
+														height={160}
+														className="w-32 h-32 sm:w-24 sm:h-24 object-contain bg-white rounded-lg p-2 group-hover:scale-[1.08] transition-transform duration-150"
+													/>
+												)}
 											</div>
-											<p className="text-sm text-neutral-500 dark:text-neutral-400 mb-2 sm:mb-3">
-												{affiliation.dateBegin} –{" "}
-												{affiliation.dateEnd}
-											</p>
-											<p className="text-neutral-700 dark:text-neutral-300">
-												{affiliation.description}
-											</p>
+											<div className="flex-1">
+												<div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 mb-2">
+													<h3 className="text-lg sm:text-xl font-semibold">
+														{affiliation.title}
+													</h3>
+													<span className="text-neutral-500 dark:text-neutral-400">
+														{affiliation.role}
+													</span>
+												</div>
+												<p className="text-sm text-neutral-500 dark:text-neutral-400 mb-2 sm:mb-3">
+													{affiliation.dateBegin} –{" "}
+													{affiliation.dateEnd}
+													{duration && <> · {duration}</>}
+												</p>
+												<p className="text-neutral-700 dark:text-neutral-300">
+													{affiliation.description}
+												</p>
+											</div>
 										</div>
-									</div>
-								</a>
-							))}
+									</a>
+								);
+							})}
 						</div>
 					</section>
 				</div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,6 +28,32 @@ body {
   font-family: var(--font-inter), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 }
 
+.home-kaneki-shell {
+  width: 100%;
+}
+
+.home-kaneki-frame {
+  width: 100%;
+  max-width: clamp(5.5rem, min(64vw, calc(100dvh - var(--navbar-height) - 27.5rem)), 20rem);
+}
+
+@media (min-width: 640px) {
+  .home-kaneki-frame {
+    max-width: clamp(10rem, min(48vw, calc(100dvh - var(--navbar-height) - 23rem)), 30rem);
+  }
+}
+
+@media (min-width: 1024px) {
+  .home-kaneki-shell {
+    flex-shrink: 0;
+    width: min(50vw, calc(100dvh - var(--navbar-height) - 4rem));
+  }
+
+  .home-kaneki-frame {
+    max-width: 100%;
+  }
+}
+
 .skip-link {
   position: fixed;
   top: 0.5rem;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,11 +7,11 @@ export default function Home() {
   return (
     <>
       <Navbar />
-      <main id="main-content" className="min-h-screen pt-20 sm:pt-24 px-4 sm:px-[7.5vw]">
-        <div className="flex flex-col-reverse lg:flex-row items-center gap-6 sm:gap-8 py-8 sm:py-12">
+      <main id="main-content" className="h-dvh overflow-hidden pt-[var(--navbar-height)] px-4 sm:px-[7.5vw] lg:px-[2vw]">
+        <div className="mx-auto flex h-full max-w-[1700px] flex-col-reverse items-center justify-center gap-3 py-3 sm:gap-5 sm:py-5 lg:flex-row lg:gap-[clamp(3rem,4vw,5rem)] lg:py-3">
           {/* Image */}
-          <div className="w-full lg:w-[65%]">
-            <div className="bg-white dark:bg-[radial-gradient(circle,_#d9d9d9_0%,_#d9d9d9_50%,_#161616_100%)] rounded-2xl sm:rounded-[2.5rem] p-4 sm:p-8 w-full overflow-hidden hover:scale-[1.03] transition-transform duration-150">
+          <div className="home-kaneki-shell flex justify-center">
+            <div className="home-kaneki-frame bg-white dark:bg-[radial-gradient(circle,_#d9d9d9_0%,_#d9d9d9_50%,_#161616_100%)] rounded-2xl sm:rounded-[2.5rem] p-3 sm:p-5 lg:p-8 overflow-hidden hover:scale-[1.03] transition-transform duration-150">
               <Image
                 src={HERO.image}
                 alt={HERO.alt}
@@ -24,13 +24,13 @@ export default function Home() {
           </div>
 
           {/* Content */}
-          <div className="w-full lg:w-[35%] space-y-8 sm:space-y-10 text-center sm:text-left">
+          <div className="w-full space-y-4 text-center sm:space-y-6 sm:text-left lg:w-[clamp(26rem,36vw,33rem)] lg:max-w-none lg:space-y-8">
             {/* Research */}
             <section>
-              <h2 className="text-xl sm:text-2xl font-bold mb-3 sm:mb-4">
+              <h2 className="text-lg sm:text-xl lg:text-2xl font-bold mb-2 sm:mb-3 lg:mb-4">
                 {SECTIONS.research.title}
               </h2>
-              <ul className="space-y-1.5 sm:space-y-2 text-base sm:text-lg">
+              <ul className="space-y-1 sm:space-y-1.5 lg:space-y-2 text-sm sm:text-base lg:text-lg lg:whitespace-nowrap">
                 {SECTIONS.research.items.map((item, index) => (
                   <li key={index}>
                     {item.text}
@@ -42,10 +42,10 @@ export default function Home() {
 
             {/* Engineering */}
             <section>
-              <h2 className="text-xl sm:text-2xl font-bold mb-3 sm:mb-4">
+              <h2 className="text-lg sm:text-xl lg:text-2xl font-bold mb-2 sm:mb-3 lg:mb-4">
                 {SECTIONS.engineering.title}
               </h2>
-              <ul className="space-y-1.5 sm:space-y-2 text-base sm:text-lg">
+              <ul className="space-y-1 sm:space-y-1.5 lg:space-y-2 text-sm sm:text-base lg:text-lg lg:whitespace-nowrap">
                 {SECTIONS.engineering.items.map((item, index) => (
                   <li key={index}>{item.text}</li>
                 ))}
@@ -54,10 +54,10 @@ export default function Home() {
 
             {/* Angel Investing */}
             <section>
-              <h2 className="text-xl sm:text-2xl font-bold mb-3 sm:mb-4">
+              <h2 className="text-lg sm:text-xl lg:text-2xl font-bold mb-2 sm:mb-3 lg:mb-4">
                 {SECTIONS.angelInvesting.title}
               </h2>
-              <p className="text-base sm:text-lg">
+              <p className="text-sm sm:text-base lg:text-lg">
                 {SECTIONS.angelInvesting.text}{" "}
                 <Link
                   href="/portfolio"


### PR DESCRIPTION
## Summary
- Keep the landing page non-scrollable while tuning Kaneki size and text spacing.
- Add month/year durations to affiliation date ranges on the About page.

## Verification
- bunx tsc --noEmit
- bun run lint (passes; unrelated warning in untracked scripts/audit-jobs.ts)
- bun run test:unit
- Vercel preview checked for landing and /about layout