### PR TITLE
Guard fixture seeds from prod database

### DIFF
--- a/scripts/db/cleanup-test-data.ts
+++ b/scripts/db/cleanup-test-data.ts
@@ -16,8 +16,9 @@ import {
   newsletterSendEvents,
   newsletterSubscribers,
   newsletterUnsubTokens,
-} from "../../src/db";
+} from "../../src/db/schema";
 import { createPreferredPostgresSocket, resolvePreferredPostgresTarget } from "../../src/db/postgres-connection";
+import { assertNotProd, formatDatabaseTarget } from "../../src/lib/prod-db-guard";
 import { TEST_ID_PREFIX } from "../../src/lib/test-data-cleanup";
 import { isMissingNewsletterSchemaError } from "../../src/services/newsletter-schema";
 
@@ -34,6 +35,22 @@ const TEST_SUBSTRINGS = [
   "@example.com",
   ".example.com",
   "://example.com",
+];
+const CLEANUP_TARGETS = [
+  "newsletter_send_events",
+  "newsletter_campaign_recipients",
+  "newsletter_preferences",
+  "newsletter_unsub_tokens",
+  "newsletter_campaigns",
+  "newsletter_subscribers",
+  "announcements",
+  "curated_links",
+  "jobs",
+  "candidates",
+  "investments",
+  "investment_categories",
+  "job_tags",
+  "job_roles",
 ];
 
 function parseEnvArg(argv: string[]): TargetEnv {
@@ -93,6 +110,15 @@ async function run() {
   const targetEnv = parseEnvArg(process.argv.slice(2));
   const databaseUrl = resolveUrl(targetEnv);
   console.log(`[db:cleanup-test-data] Cleaning ${targetEnv}`);
+  try {
+    console.log(`[db:cleanup-test-data] Database: ${formatDatabaseTarget(databaseUrl)}`);
+  } catch {
+    console.log(`[db:cleanup-test-data] Database: malformed URL (${databaseUrl || "empty"})`);
+  }
+  console.log(
+    `[db:cleanup-test-data] Rows this script may touch: matching test/demo/qa/e2e rows in ${CLEANUP_TARGETS.length} tables`
+  );
+  assertNotProd(databaseUrl);
 
   const target = await resolvePreferredPostgresTarget(databaseUrl);
   if (target.tlsServername && target.connectHost !== target.tlsServername) {

--- a/scripts/seed-test-data.ts
+++ b/scripts/seed-test-data.ts
@@ -6,7 +6,6 @@
  * Use TEST_MODE=true environment variable to only seed when appropriate.
  */
 
-import { db } from "../src/db";
 import {
   jobs,
   jobTags,
@@ -17,10 +16,40 @@ import {
   investmentCategories,
 } from "../src/db/schema";
 import { sql } from "drizzle-orm";
+import { assertNotProd, formatDatabaseTarget } from "../src/lib/prod-db-guard";
 import { TEST_ID_PREFIX } from "../src/lib/test-data-cleanup";
 
 // Deterministic test IDs for reliable test assertions
 const TEST_PREFIX = TEST_ID_PREFIX;
+
+const databaseUrl = process.env.DATABASE_URL || "";
+const args = process.argv.slice(2);
+const cleanOnly = args.includes("--clean");
+const seedOnly = args.includes("--seed");
+
+function logWritePlan() {
+  console.log("\n🚧 Test data seed target");
+  try {
+    console.log(`Database: ${formatDatabaseTarget(databaseUrl)}`);
+  } catch {
+    console.log(`Database: malformed URL (${databaseUrl || "empty"})`);
+  }
+
+  console.log("Rows this script may touch:");
+  if (!seedOnly) {
+    console.log("  delete: matching test-* rows in jobs, candidates, curated_links, investments, investment_categories, job_tags, job_roles");
+  }
+  if (!cleanOnly) {
+    console.log(`  insert job_tags: ${testJobTags.length}`);
+    console.log(`  insert job_roles: ${testJobRoles.length}`);
+    console.log(`  insert jobs: ${testJobs.length}`);
+    console.log(`  insert candidates: ${testCandidates.length}`);
+    console.log(`  insert curated_links: ${testCuratedLinks.length}`);
+    console.log(`  insert investment_categories: ${testInvestmentCategories.length}`);
+    console.log(`  insert investments: ${testInvestments.length}`);
+  }
+  console.log("");
+}
 
 const testJobTags = [
   { id: `${TEST_PREFIX}tag-ai`, slug: "ai", label: "AI" },
@@ -176,6 +205,16 @@ const testInvestments = [
   },
 ];
 
+logWritePlan();
+try {
+  assertNotProd(databaseUrl);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}
+
+const { db } = await import("../src/db");
+
 async function cleanTestData() {
   console.log("Cleaning existing test data...\n");
 
@@ -245,10 +284,6 @@ async function seedTestData() {
 }
 
 async function main() {
-  const args = process.argv.slice(2);
-  const cleanOnly = args.includes("--clean");
-  const seedOnly = args.includes("--seed");
-
   try {
     if (cleanOnly) {
       await cleanTestData();

--- a/src/lib/prod-db-guard.ts
+++ b/src/lib/prod-db-guard.ts
@@ -1,0 +1,66 @@
+const PROD_PROJECT_REF = "rzjbyplttszgdyfiaghb";
+const STAGING_PROJECT_REF = "tjlxqxtpbwvtlqulahlx";
+const PROD_SEED_OVERRIDE = "i-know-what-im-doing";
+const RED = "\x1b[31m";
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+
+export interface DatabaseTargetInfo {
+  host: string;
+  projectRef: string | null;
+  isProd: boolean;
+  isStaging: boolean;
+}
+
+export function describeDatabaseTarget(databaseUrl: string): DatabaseTargetInfo {
+  let parsed: URL;
+  try {
+    parsed = new URL(databaseUrl);
+  } catch {
+    throw new Error(`Malformed database URL: ${databaseUrl || "(empty)"}`);
+  }
+
+  const lowerUrl = databaseUrl.toLowerCase();
+  const usernameProjectRef = decodeURIComponent(parsed.username).match(/^postgres\.([a-z0-9]+)$/i)?.[1] ?? null;
+  const hostProjectRef = parsed.hostname.match(/(?:^|\.)?(rzjbyplttszgdyfiaghb|tjlxqxtpbwvtlqulahlx)(?:\.|$)/i)?.[1] ?? null;
+  const projectRef = lowerUrl.includes(PROD_PROJECT_REF)
+    ? PROD_PROJECT_REF
+    : lowerUrl.includes(STAGING_PROJECT_REF)
+      ? STAGING_PROJECT_REF
+      : usernameProjectRef || hostProjectRef;
+
+  return {
+    host: parsed.host,
+    projectRef,
+    isProd: lowerUrl.includes(PROD_PROJECT_REF),
+    isStaging: lowerUrl.includes(STAGING_PROJECT_REF),
+  };
+}
+
+export function formatDatabaseTarget(databaseUrl: string): string {
+  const target = describeDatabaseTarget(databaseUrl);
+  return `${target.host} (${target.projectRef ? `project ${target.projectRef}` : "project unknown"})`;
+}
+
+export function assertNotProd(
+  databaseUrl: string,
+  opts: {
+    allowEnvVar?: string;
+  } = {}
+): DatabaseTargetInfo {
+  const target = describeDatabaseTarget(databaseUrl);
+  const allowEnvVar = opts.allowEnvVar || "ALLOW_PROD_SEED";
+  const overrideValue = process.env[allowEnvVar];
+
+  if (target.isProd && overrideValue !== PROD_SEED_OVERRIDE) {
+    throw new Error(
+      `${RED}${BOLD}Refusing to write test/fixture data to the production Supabase database.${RESET}\n` +
+        `Detected URL: ${databaseUrl}\n` +
+        `Detected host: ${target.host}\n` +
+        `Detected project ref: ${target.projectRef || "unknown"}\n` +
+        `Set ${allowEnvVar}=${PROD_SEED_OVERRIDE} only if you intentionally want to modify prod.`
+    );
+  }
+
+  return target;
+}

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -20,6 +20,7 @@ import postgres from "postgres";
 import { resolve } from "node:path";
 import { loadEnvConfig } from "@next/env";
 import * as dbSchema from "../src/db/schema";
+import { assertNotProd, formatDatabaseTarget } from "../src/lib/prod-db-guard";
 import { TEST_ID_PREFIX } from "../src/lib/test-data-cleanup";
 
 const TEST_PREFIX = TEST_ID_PREFIX;
@@ -303,6 +304,9 @@ export default async function globalSetup() {
   console.log("\n🌱 Setting up E2E test data...");
 
   const connectionString = getConnectionString();
+  console.log(`E2E database: ${formatDatabaseTarget(connectionString)}`);
+  assertNotProd(connectionString, { allowEnvVar: "__ALLOW_E2E_PROD_SEED_NEVER__" });
+
   const queryClient = postgres(connectionString, { onnotice: () => {} });
   const testDb = drizzle(queryClient, { schema: dbSchema });
 

--- a/tests/prod-db-guard.test.ts
+++ b/tests/prod-db-guard.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { assertNotProd } from "../src/lib/prod-db-guard";
+
+const PROD_URL =
+  "postgresql://postgres.rzjbyplttszgdyfiaghb:password@aws-1-eu-west-2.pooler.supabase.com:5432/postgres";
+const STAGING_URL =
+  "postgresql://postgres.tjlxqxtpbwvtlqulahlx:password@aws-1-eu-west-2.pooler.supabase.com:5432/postgres";
+
+describe("assertNotProd", () => {
+  afterEach(() => {
+    delete process.env.ALLOW_PROD_SEED;
+  });
+
+  test("throws for the production Supabase project", () => {
+    expect(() => assertNotProd(PROD_URL)).toThrow("production Supabase database");
+  });
+
+  test("passes for the staging Supabase project", () => {
+    expect(assertNotProd(STAGING_URL).isStaging).toBe(true);
+  });
+
+  test("passes for localhost", () => {
+    expect(assertNotProd("postgres://postgres:postgres@127.0.0.1:5432/dcbuilder_test").host).toBe(
+      "127.0.0.1:5432"
+    );
+  });
+
+  test("bypasses prod only with the explicit override value", () => {
+    process.env.ALLOW_PROD_SEED = "i-know-what-im-doing";
+    expect(assertNotProd(PROD_URL).isProd).toBe(true);
+  });
+
+  test("throws for malformed URLs", () => {
+    expect(() => assertNotProd("not a postgres url")).toThrow("Malformed database URL");
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable production Supabase guard for fixture/test-data scripts
- guard test seed and cleanup scripts before opening database connections
- hard-fail Playwright global setup if DATABASE_URL points at the production project

## Why
A test seed script was run against production and inserted `test-*` rows into live tables. The guard now detects the production project ref in the URL itself, regardless of env var name, and requires the explicit `ALLOW_PROD_SEED=i-know-what-im-doing` override for script runs.

## Validation
- `bun test tests/prod-db-guard.test.ts`
- `bunx tsc --noEmit`
- `bun run lint`
- smoke-tested seed and cleanup scripts with a dummy production Supabase URL and confirmed both refuse before connecting
