### PR TITLE
Move news company logos into author metadata

### DIFF
--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -200,6 +200,26 @@ export function NewsGrid({ news }: NewsGridProps) {
 		});
 	};
 
+	const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+	const getSourceWithoutPortfolioCompany = (item: AggregatedNewsItem) => {
+		const source = item.source?.trim();
+		const company = item.portfolioCompany;
+		const companyTitle = company?.title?.trim();
+		if (!source || !company || !companyTitle) return source;
+
+		if (company.sourceIsCompanyAccount && source.toLowerCase() === companyTitle.toLowerCase()) {
+			return undefined;
+		}
+
+		const companySuffix = new RegExp(`\\s*\\(${escapeRegExp(companyTitle)}\\)`, "i");
+		return source
+			.split(",")
+			.map((token) => token.replace(companySuffix, "").trim())
+			.filter(Boolean)
+			.join(", ");
+	};
+
 	// Extract X/Twitter handle from URL
 	const getXHandle = (url: string): string | null => {
 		const match = url.match(/x\.com\/([^/]+)/);
@@ -272,6 +292,36 @@ export function NewsGrid({ news }: NewsGridProps) {
 				title={company.title}
 			>
 				{logo}
+			</a>
+		);
+	};
+
+	const getPortfolioCompanyMetaName = (item: AggregatedNewsItem) => {
+		const company = item.portfolioCompany;
+		if (!company?.title?.trim()) return null;
+
+		const className =
+			"pointer-events-auto inline-flex rounded-sm font-medium text-white underline-offset-4 transition-colors hover:text-neutral-200 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70";
+
+		if (!company.website) {
+			return (
+				<span className={className} title={company.title}>
+					{company.title}
+				</span>
+			);
+		}
+
+		return (
+			<a
+				href={company.website}
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={(event) => event.stopPropagation()}
+				className={className}
+				aria-label={`Open ${company.title}`}
+				title={company.title}
+			>
+				{company.title}
 			</a>
 		);
 	};
@@ -738,8 +788,9 @@ export function NewsGrid({ news }: NewsGridProps) {
 
 										<div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-neutral-500">
 											<span>Published {formatDate(item.date)}</span>
-											{renderCommaSeparatedTokens(item.source, `${item.id}:source`)}
+											{renderCommaSeparatedTokens(getSourceWithoutPortfolioCompany(item), `${item.id}:source`)}
 											{item.company && <span>{item.company}</span>}
+											{getPortfolioCompanyMetaName(item)}
 											{getPortfolioCompanyMetaLogo(item)}
 											<span
 												className={`px-2 py-0.5 rounded-full ${

--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -231,79 +231,27 @@ export function NewsGrid({ news }: NewsGridProps) {
 		return `${url}${separator}v=${BLOG_IMAGE_CACHE_VERSION}`;
 	}, []);
 
-	const getPortfolioCompanyBadge = (item: AggregatedNewsItem) => {
+	const getPortfolioCompanyMetaLogo = (item: AggregatedNewsItem) => {
 		const company = item.portfolioCompany;
-		if (!company?.logo?.trim() || company.sourceIsCompanyAccount) return null;
+		if (!company?.logo?.trim()) return null;
 
-		const imageKey = `${item.id}:portfolio-company`;
+		const imageKey = `${item.id}:portfolio-company-meta`;
 		if (failedImageKeys[imageKey]) return null;
 
 		const logo = (
 			<Image
 				src={company.logo.trim()}
 				alt={company.title}
-				width={40}
-				height={40}
-				sizes="40px"
+				width={24}
+				height={24}
+				sizes="24px"
 				className="h-full w-full rounded-md bg-white object-contain p-0.5"
 				unoptimized
 				onError={() => markImageFailed(imageKey)}
 			/>
 		);
 		const className =
-			"pointer-events-auto absolute -bottom-12 left-1/2 z-10 flex h-10 w-10 -translate-x-1/2 items-center justify-center rounded-lg border-2 border-white bg-white shadow-sm transition-transform duration-150 hover:scale-110 dark:border-neutral-900";
-
-		if (!company.website) {
-			return (
-				<span className={className} aria-label={company.title}>
-					{logo}
-				</span>
-			);
-		}
-
-		return (
-			<a
-				href={company.website}
-				target="_blank"
-				rel="noopener noreferrer"
-				onClick={(event) => event.stopPropagation()}
-				className={className}
-				aria-label={`Open ${company.title}`}
-				title={company.title}
-			>
-				{logo}
-			</a>
-		);
-	};
-
-	const hasPortfolioCompanyAvatarBadge = (item: AggregatedNewsItem) => {
-		const company = item.portfolioCompany;
-		if (!company?.logo?.trim() || company.sourceIsCompanyAccount) return false;
-
-		return !failedImageKeys[`${item.id}:portfolio-company`];
-	};
-
-	const getPortfolioCompanyTitleLink = (item: AggregatedNewsItem) => {
-		const company = item.portfolioCompany;
-		if (!company?.sourceIsCompanyAccount || !company.logo?.trim()) return null;
-
-		const imageKey = `${item.id}:portfolio-company-title`;
-		if (failedImageKeys[imageKey]) return null;
-
-		const logo = (
-			<Image
-				src={company.logo.trim()}
-				alt={company.title}
-				width={28}
-				height={28}
-				sizes="28px"
-				className="h-full w-full rounded-md bg-white object-contain p-0.5"
-				unoptimized
-				onError={() => markImageFailed(imageKey)}
-			/>
-		);
-		const className =
-			"pointer-events-auto inline-flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg border border-neutral-200 bg-white shadow-sm transition-transform duration-150 hover:scale-110 dark:border-neutral-700";
+			"pointer-events-auto inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md border border-neutral-200 bg-white shadow-sm transition-transform duration-150 hover:scale-110 dark:border-neutral-700";
 
 		if (!company.website) {
 			return (
@@ -388,7 +336,6 @@ export function NewsGrid({ news }: NewsGridProps) {
 							onError={() => markImageFailed(imageKey)}
 						/>
 						<XLogo />
-						{getPortfolioCompanyBadge(item)}
 					</div>
 				);
 			}
@@ -408,14 +355,12 @@ export function NewsGrid({ news }: NewsGridProps) {
 							onError={() => markImageFailed(imageKey)}
 						/>
 						<XLogo />
-						{getPortfolioCompanyBadge(item)}
 					</div>
 				);
 			}
 			return (
 				<span className="relative inline-block text-5xl transition-transform duration-150 group-hover:scale-[1.08]">
 					𝕏
-					{getPortfolioCompanyBadge(item)}
 				</span>
 			);
 		}
@@ -459,14 +404,12 @@ export function NewsGrid({ news }: NewsGridProps) {
 								className="rounded-full w-14 h-14 object-cover"
 								onError={() => markImageFailed(imageKey)}
 							/>
-							{getPortfolioCompanyBadge(item)}
 						</div>
 					);
 				}
 				return (
 					<span className="relative inline-block text-5xl transition-transform duration-150 group-hover:scale-[1.08]">
 						🔗
-						{getPortfolioCompanyBadge(item)}
 					</span>
 				);
 			case "announcement":
@@ -658,7 +601,6 @@ export function NewsGrid({ news }: NewsGridProps) {
 				) : (
 					renderedNews.map((item) => {
 						const isDescriptionExpanded = expandedDescriptionIds.has(item.id);
-						const hasAvatarBadge = hasPortfolioCompanyAvatarBadge(item);
 
 						return (
 							<div
@@ -676,11 +618,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 									<span className="sr-only">Open {item.title}</span>
 								</a>
 								<div className="relative z-10 flex items-start gap-4 pointer-events-none">
-									<div
-										className={`flex w-14 flex-shrink-0 justify-center ${
-											hasAvatarBadge ? "h-28 items-start" : "h-14 items-center"
-										}`}
-									>
+									<div className="flex h-14 w-14 flex-shrink-0 items-center justify-center">
 										{getTypeIcon(item)}
 									</div>
 
@@ -693,7 +631,6 @@ export function NewsGrid({ news }: NewsGridProps) {
 												</span>
 											)}
 											{getPortfolioHiringLink(item)}
-											{getPortfolioCompanyTitleLink(item)}
 											{clicksLoaded && isPopular(item.id) && (
 												<span className="flex-shrink-0 px-2 py-0.5 text-xs font-semibold rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400">
 													🔥 POPULAR
@@ -739,12 +676,9 @@ export function NewsGrid({ news }: NewsGridProps) {
 
 										<div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-neutral-500">
 											<span>Published {formatDate(item.date)}</span>
-											{clicksLoaded && getClickCount(item.id) > 0 && (
-												<span>{getClickCount(item.id)} clicks</span>
-											)}
 											{renderCommaSeparatedTokens(item.source, `${item.id}:source`)}
 											{item.company && <span>{item.company}</span>}
-											{item.readingTime && <span>{item.readingTime}</span>}
+											{getPortfolioCompanyMetaLogo(item)}
 											<span
 												className={`px-2 py-0.5 rounded-full ${
 													item.category === "crypto"
@@ -766,6 +700,10 @@ export function NewsGrid({ news }: NewsGridProps) {
 											>
 												{categoryLabels[item.category]}
 											</span>
+											{clicksLoaded && getClickCount(item.id) > 0 && (
+												<span>{getClickCount(item.id)} clicks</span>
+											)}
+											{item.readingTime && <span>{item.readingTime}</span>}
 										</div>
 									</div>
 								</div>

--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -233,7 +233,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 
 	const getPortfolioCompanyMetaLogo = (item: AggregatedNewsItem) => {
 		const company = item.portfolioCompany;
-		if (!company?.logo?.trim()) return null;
+		if (!company?.logo?.trim() || !company.sourceIsCompanyAccount) return null;
 
 		const imageKey = `${item.id}:portfolio-company-meta`;
 		if (failedImageKeys[imageKey]) return null;
@@ -274,6 +274,58 @@ export function NewsGrid({ news }: NewsGridProps) {
 				{logo}
 			</a>
 		);
+	};
+
+	const getPortfolioCompanyAvatarBadge = (item: AggregatedNewsItem) => {
+		const company = item.portfolioCompany;
+		if (!company?.logo?.trim() || company.sourceIsCompanyAccount) return null;
+
+		const imageKey = `${item.id}:portfolio-company-avatar`;
+		if (failedImageKeys[imageKey]) return null;
+
+		const logo = (
+			<Image
+				src={company.logo.trim()}
+				alt={company.title}
+				width={40}
+				height={40}
+				sizes="40px"
+				className="h-full w-full rounded-md bg-white object-contain p-0.5"
+				unoptimized
+				onError={() => markImageFailed(imageKey)}
+			/>
+		);
+		const className =
+			"pointer-events-auto absolute -bottom-12 left-1/2 z-10 flex h-10 w-10 -translate-x-1/2 items-center justify-center rounded-lg border-2 border-white bg-white shadow-sm transition-transform duration-150 hover:scale-110 dark:border-neutral-900";
+
+		if (!company.website) {
+			return (
+				<span className={className} aria-label={company.title} title={company.title}>
+					{logo}
+				</span>
+			);
+		}
+
+		return (
+			<a
+				href={company.website}
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={(event) => event.stopPropagation()}
+				className={className}
+				aria-label={`Open ${company.title}`}
+				title={company.title}
+			>
+				{logo}
+			</a>
+		);
+	};
+
+	const hasPortfolioCompanyAvatarBadge = (item: AggregatedNewsItem) => {
+		const company = item.portfolioCompany;
+		if (!company?.logo?.trim() || company.sourceIsCompanyAccount) return false;
+
+		return !failedImageKeys[`${item.id}:portfolio-company-avatar`];
 	};
 
 	const getPortfolioHiringLink = (item: AggregatedNewsItem) => {
@@ -336,6 +388,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 							onError={() => markImageFailed(imageKey)}
 						/>
 						<XLogo />
+						{getPortfolioCompanyAvatarBadge(item)}
 					</div>
 				);
 			}
@@ -355,12 +408,14 @@ export function NewsGrid({ news }: NewsGridProps) {
 							onError={() => markImageFailed(imageKey)}
 						/>
 						<XLogo />
+						{getPortfolioCompanyAvatarBadge(item)}
 					</div>
 				);
 			}
 			return (
 				<span className="relative inline-block text-5xl transition-transform duration-150 group-hover:scale-[1.08]">
 					𝕏
+					{getPortfolioCompanyAvatarBadge(item)}
 				</span>
 			);
 		}
@@ -404,12 +459,14 @@ export function NewsGrid({ news }: NewsGridProps) {
 								className="rounded-full w-14 h-14 object-cover"
 								onError={() => markImageFailed(imageKey)}
 							/>
+							{getPortfolioCompanyAvatarBadge(item)}
 						</div>
 					);
 				}
 				return (
 					<span className="relative inline-block text-5xl transition-transform duration-150 group-hover:scale-[1.08]">
 						🔗
+						{getPortfolioCompanyAvatarBadge(item)}
 					</span>
 				);
 			case "announcement":
@@ -601,6 +658,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 				) : (
 					renderedNews.map((item) => {
 						const isDescriptionExpanded = expandedDescriptionIds.has(item.id);
+						const hasAvatarBadge = hasPortfolioCompanyAvatarBadge(item);
 
 						return (
 							<div
@@ -618,7 +676,11 @@ export function NewsGrid({ news }: NewsGridProps) {
 									<span className="sr-only">Open {item.title}</span>
 								</a>
 								<div className="relative z-10 flex items-start gap-4 pointer-events-none">
-									<div className="flex h-14 w-14 flex-shrink-0 items-center justify-center">
+									<div
+										className={`flex w-14 flex-shrink-0 justify-center ${
+											hasAvatarBadge ? "h-28 items-start" : "h-14 items-center"
+										}`}
+									>
 										{getTypeIcon(item)}
 									</div>
 

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -2890,24 +2890,50 @@ export async function sendDueNewsletterCampaigns() {
 // ---------------------------------------------------------------------------
 
 export async function listSentNewsletterCampaigns(limit: number = 50) {
-  const campaigns = await db
-    .select({
-      id: newsletterCampaigns.id,
-      publicSlug: newsletterCampaigns.publicSlug,
-      subject: newsletterCampaigns.subject,
-      previewText: newsletterCampaigns.previewText,
-      newsletterType: newsletterCampaigns.newsletterType,
-      sentAt: newsletterCampaigns.sentAt,
-      archiveSubject: newsletterCampaigns.archiveSubject,
-      archivePreviewText: newsletterCampaigns.archivePreviewText,
-      archiveCorrectedAt: newsletterCampaigns.archiveCorrectedAt,
-    })
-    .from(newsletterCampaigns)
-    .where(eq(newsletterCampaigns.status, "sent"))
-    .orderBy(desc(newsletterCampaigns.sentAt))
-    .limit(limit);
+  try {
+    const campaigns = await db
+      .select({
+        id: newsletterCampaigns.id,
+        publicSlug: newsletterCampaigns.publicSlug,
+        subject: newsletterCampaigns.subject,
+        previewText: newsletterCampaigns.previewText,
+        newsletterType: newsletterCampaigns.newsletterType,
+        sentAt: newsletterCampaigns.sentAt,
+        archiveSubject: newsletterCampaigns.archiveSubject,
+        archivePreviewText: newsletterCampaigns.archivePreviewText,
+        archiveCorrectedAt: newsletterCampaigns.archiveCorrectedAt,
+      })
+      .from(newsletterCampaigns)
+      .where(eq(newsletterCampaigns.status, "sent"))
+      .orderBy(desc(newsletterCampaigns.sentAt))
+      .limit(limit);
 
-  return campaigns.map(resolveArchiveCampaignSummary);
+    return campaigns.map(resolveArchiveCampaignSummary);
+  } catch (error) {
+    if (!isMissingNewsletterSchemaError(error)) {
+      throw error;
+    }
+
+    const campaigns = await db
+      .select({
+        id: newsletterCampaigns.id,
+        subject: newsletterCampaigns.subject,
+        previewText: newsletterCampaigns.previewText,
+        newsletterType: newsletterCampaigns.newsletterType,
+        sentAt: newsletterCampaigns.sentAt,
+      })
+      .from(newsletterCampaigns)
+      .where(eq(newsletterCampaigns.status, "sent"))
+      .orderBy(desc(newsletterCampaigns.sentAt))
+      .limit(limit);
+
+    return campaigns.map((campaign) =>
+      resolveArchiveCampaignSummary({
+        ...campaign,
+        publicSlug: campaign.id,
+      })
+    );
+  }
 }
 
 export async function getSentNewsletterCampaignForArchive(id: string) {
@@ -2915,28 +2941,36 @@ export async function getSentNewsletterCampaignForArchive(id: string) {
 }
 
 async function getSentNewsletterCampaignForArchiveByPublicSlug(publicSlug: string) {
-  const [campaign] = await db
-    .select({
-      id: newsletterCampaigns.id,
-      publicSlug: newsletterCampaigns.publicSlug,
-      subject: newsletterCampaigns.subject,
-      previewText: newsletterCampaigns.previewText,
-      newsletterType: newsletterCampaigns.newsletterType,
-      sentAt: newsletterCampaigns.sentAt,
-      renderedHtml: newsletterCampaigns.renderedHtml,
-      archiveSubject: newsletterCampaigns.archiveSubject,
-      archivePreviewText: newsletterCampaigns.archivePreviewText,
-      archiveRenderedHtml: newsletterCampaigns.archiveRenderedHtml,
-      archiveCorrectedAt: newsletterCampaigns.archiveCorrectedAt,
-    })
-    .from(newsletterCampaigns)
-    .where(
-      and(
-        eq(newsletterCampaigns.publicSlug, publicSlug),
-        eq(newsletterCampaigns.status, "sent")
+  let campaign;
+  try {
+    [campaign] = await db
+      .select({
+        id: newsletterCampaigns.id,
+        publicSlug: newsletterCampaigns.publicSlug,
+        subject: newsletterCampaigns.subject,
+        previewText: newsletterCampaigns.previewText,
+        newsletterType: newsletterCampaigns.newsletterType,
+        sentAt: newsletterCampaigns.sentAt,
+        renderedHtml: newsletterCampaigns.renderedHtml,
+        archiveSubject: newsletterCampaigns.archiveSubject,
+        archivePreviewText: newsletterCampaigns.archivePreviewText,
+        archiveRenderedHtml: newsletterCampaigns.archiveRenderedHtml,
+        archiveCorrectedAt: newsletterCampaigns.archiveCorrectedAt,
+      })
+      .from(newsletterCampaigns)
+      .where(
+        and(
+          eq(newsletterCampaigns.publicSlug, publicSlug),
+          eq(newsletterCampaigns.status, "sent")
+        )
       )
-    )
-    .limit(1);
+      .limit(1);
+  } catch (error) {
+    if (isMissingNewsletterSchemaError(error)) {
+      return null;
+    }
+    throw error;
+  }
 
   if (!campaign) {
     return null;
@@ -2959,28 +2993,60 @@ export async function findSentNewsletterCampaignForArchive(identifier: string) {
     };
   }
 
-  const [campaign] = await db
-    .select({
-      id: newsletterCampaigns.id,
-      publicSlug: newsletterCampaigns.publicSlug,
-      subject: newsletterCampaigns.subject,
-      previewText: newsletterCampaigns.previewText,
-      newsletterType: newsletterCampaigns.newsletterType,
-      sentAt: newsletterCampaigns.sentAt,
-      renderedHtml: newsletterCampaigns.renderedHtml,
-      archiveSubject: newsletterCampaigns.archiveSubject,
-      archivePreviewText: newsletterCampaigns.archivePreviewText,
-      archiveRenderedHtml: newsletterCampaigns.archiveRenderedHtml,
-      archiveCorrectedAt: newsletterCampaigns.archiveCorrectedAt,
-    })
-    .from(newsletterCampaigns)
-    .where(
-      and(
-        eq(newsletterCampaigns.id, identifier),
-        eq(newsletterCampaigns.status, "sent")
+  let campaign;
+  try {
+    [campaign] = await db
+      .select({
+        id: newsletterCampaigns.id,
+        publicSlug: newsletterCampaigns.publicSlug,
+        subject: newsletterCampaigns.subject,
+        previewText: newsletterCampaigns.previewText,
+        newsletterType: newsletterCampaigns.newsletterType,
+        sentAt: newsletterCampaigns.sentAt,
+        renderedHtml: newsletterCampaigns.renderedHtml,
+        archiveSubject: newsletterCampaigns.archiveSubject,
+        archivePreviewText: newsletterCampaigns.archivePreviewText,
+        archiveRenderedHtml: newsletterCampaigns.archiveRenderedHtml,
+        archiveCorrectedAt: newsletterCampaigns.archiveCorrectedAt,
+      })
+      .from(newsletterCampaigns)
+      .where(
+        and(
+          eq(newsletterCampaigns.id, identifier),
+          eq(newsletterCampaigns.status, "sent")
+        )
       )
-    )
-    .limit(1);
+      .limit(1);
+  } catch (error) {
+    if (!isMissingNewsletterSchemaError(error)) {
+      throw error;
+    }
+
+    [campaign] = await db
+      .select({
+        id: newsletterCampaigns.id,
+        subject: newsletterCampaigns.subject,
+        previewText: newsletterCampaigns.previewText,
+        newsletterType: newsletterCampaigns.newsletterType,
+        sentAt: newsletterCampaigns.sentAt,
+        renderedHtml: newsletterCampaigns.renderedHtml,
+      })
+      .from(newsletterCampaigns)
+      .where(
+        and(
+          eq(newsletterCampaigns.id, identifier),
+          eq(newsletterCampaigns.status, "sent")
+        )
+      )
+      .limit(1);
+
+    if (campaign) {
+      campaign = {
+        ...campaign,
+        publicSlug: campaign.id,
+      };
+    }
+  }
 
   const resolved = campaign ? resolveArchiveCampaignDetail(campaign) : null;
   if (!resolved?.renderedHtml) {

--- a/tests/newsletter-public-slug-service.test.ts
+++ b/tests/newsletter-public-slug-service.test.ts
@@ -7,6 +7,21 @@ type DbMockOptions = {
 };
 
 function makeQueryResult<T>(value: T) {
+  if (value instanceof Error) {
+    return {
+      limit: async () => {
+        throw value;
+      },
+      orderBy: () => ({
+        limit: async () => {
+          throw value;
+        },
+      }),
+      then: (_resolve: (result: T) => unknown, reject?: (reason: unknown) => unknown) =>
+        Promise.reject(value).then(undefined, reject),
+    };
+  }
+
   return {
     limit: async () => value,
     orderBy: () => ({
@@ -52,6 +67,17 @@ async function installNewsletterDbMock({
       }),
     },
   }));
+}
+
+function createMissingPublicSlugError() {
+  const cause = new Error('column "public_slug" does not exist') as Error & {
+    code?: string;
+  };
+  cause.code = "42703";
+
+  const error = new Error("Failed query") as Error & { cause?: Error };
+  error.cause = cause;
+  return error;
 }
 
 describe("newsletter public slug services", () => {
@@ -167,6 +193,35 @@ describe("newsletter public slug services", () => {
     }]);
   });
 
+  test("falls back to legacy ids for archive summaries when public_slug is missing", async () => {
+    await installNewsletterDbMock({
+      selectQueue: [
+        createMissingPublicSlugError(),
+        [{
+          id: "camp_sent_legacy",
+          subject: "Legacy sent campaign",
+          previewText: "Legacy preview",
+          newsletterType: "news",
+          sentAt: new Date("2026-03-10T08:00:00.000Z"),
+        }],
+      ],
+    });
+
+    const { listSentNewsletterCampaigns } = await import(
+      `../src/services/newsletter?newsletter-public-slug-list-fallback=${Date.now()}`
+    );
+
+    await expect(listSentNewsletterCampaigns(10)).resolves.toEqual([{
+      id: "camp_sent_legacy",
+      publicSlug: "camp_sent_legacy",
+      subject: "Legacy sent campaign",
+      previewText: "Legacy preview",
+      newsletterType: "news",
+      sentAt: new Date("2026-03-10T08:00:00.000Z"),
+      archiveCorrectedAt: null,
+    }]);
+  });
+
   test("finds sent archive campaigns by slug first and falls back to legacy ids", async () => {
     await installNewsletterDbMock({
       selectQueue: [
@@ -229,6 +284,41 @@ describe("newsletter public slug services", () => {
         newsletterType: "news",
         sentAt: new Date("2026-03-11T08:00:00.000Z"),
         renderedHtml: "<p>Body</p>",
+        archiveCorrectedAt: null,
+      },
+      matchedByLegacyId: true,
+    });
+  });
+
+  test("loads legacy sent campaign ids when public_slug is missing", async () => {
+    await installNewsletterDbMock({
+      selectQueue: [
+        createMissingPublicSlugError(),
+        createMissingPublicSlugError(),
+        [{
+          id: "camp_sent_legacy",
+          subject: "Legacy sent campaign",
+          previewText: "Legacy preview",
+          newsletterType: "news",
+          sentAt: new Date("2026-03-10T08:00:00.000Z"),
+          renderedHtml: "<p>Legacy body</p>",
+        }],
+      ],
+    });
+
+    const { findSentNewsletterCampaignForArchive } = await import(
+      `../src/services/newsletter?newsletter-public-slug-find-fallback=${Date.now()}`
+    );
+
+    await expect(findSentNewsletterCampaignForArchive("camp_sent_legacy")).resolves.toEqual({
+      campaign: {
+        id: "camp_sent_legacy",
+        publicSlug: "camp_sent_legacy",
+        subject: "Legacy sent campaign",
+        previewText: "Legacy preview",
+        newsletterType: "news",
+        sentAt: new Date("2026-03-10T08:00:00.000Z"),
+        renderedHtml: "<p>Legacy body</p>",
         archiveCorrectedAt: null,
       },
       matchedByLegacyId: true,


### PR DESCRIPTION
## Summary
- move portfolio company logo links out of news avatars/title badges and into the news metadata row
- keep the metadata order as published date, author/source/company, company logo, category tag
- preserve logo click-through to the company landing page

## Verification
- bunx tsc --noEmit
- bun run lint
- bun run test:unit