### PR TITLE
CON-18: Surface affiliation company logos on news cards

### DIFF
--- a/drizzle/0014_motionless_power_man.sql
+++ b/drizzle/0014_motionless_power_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "affiliations" ADD COLUMN "x_handles" text[];

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2313 @@
+{
+  "id": "7700584d-a41b-48a2-8485-73146506dc38",
+  "prevId": "cf8489b8-4399-4886-8e1a-e2994a39a762",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blog_posts": {
+      "name": "blog_posts",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blog_posts_date_idx": {
+          "name": "blog_posts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_posts_published_idx": {
+          "name": "blog_posts_published_idx",
+          "columns": [
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidates": {
+      "name": "candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experience": {
+          "name": "experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education": {
+          "name": "education",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cv": {
+          "name": "cv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'looking'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendly": {
+          "name": "calendly",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidates_featured_idx": {
+          "name": "candidates_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "candidates_available_idx": {
+          "name": "candidates_available_idx",
+          "columns": [
+            {
+              "expression": "available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_roles": {
+      "name": "job_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_roles_slug_idx": {
+          "name": "job_roles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_roles_slug_unique": {
+          "name": "job_roles_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_tags": {
+      "name": "job_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "job_tags_slug_idx": {
+          "name": "job_tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_tags_slug_unique": {
+          "name": "job_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote": {
+          "name": "remote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary": {
+          "name": "salary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_x": {
+          "name": "company_x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_github": {
+          "name": "company_github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_company_idx": {
+          "name": "jobs_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_category_idx": {
+          "name": "jobs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_featured_idx": {
+          "name": "jobs_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_company_idx": {
+          "name": "announcements_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_date_idx": {
+          "name": "announcements_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.curated_links": {
+      "name": "curated_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_image": {
+          "name": "source_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "curated_links_category_idx": {
+          "name": "curated_links_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "curated_links_date_idx": {
+          "name": "curated_links_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_source_investments": {
+      "name": "news_source_investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_value": {
+          "name": "source_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'person'"
+        },
+        "investment_id": {
+          "name": "investment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_title": {
+          "name": "company_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_logo": {
+          "name": "company_logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_website": {
+          "name": "company_website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_companies": {
+          "name": "job_companies",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "news_source_investments_source_unique": {
+          "name": "news_source_investments_source_unique",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_source_investments_investment_idx": {
+          "name": "news_source_investments_investment_idx",
+          "columns": [
+            {
+              "expression": "investment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "news_source_investments_investment_id_investments_id_fk": {
+          "name": "news_source_investments_investment_id_investments_id_fk",
+          "tableFrom": "news_source_investments",
+          "tableTo": "investments",
+          "columnsFrom": [
+            "investment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investment_categories": {
+      "name": "investment_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investment_categories_slug_idx": {
+          "name": "investment_categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "investment_categories_slug_unique": {
+          "name": "investment_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investments": {
+      "name": "investments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "investments_tier_idx": {
+          "name": "investments_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "investments_featured_idx": {
+          "name": "investments_featured_idx",
+          "columns": [
+            {
+              "expression": "featured",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.affiliations": {
+      "name": "affiliations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_begin": {
+          "name": "date_begin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x_handles": {
+          "name": "x_handles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliations_title_idx": {
+          "name": "affiliations_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate_redirects": {
+      "name": "candidate_redirects",
+      "schema": "",
+      "columns": {
+        "old_id": {
+          "name": "old_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_id": {
+          "name": "new_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_redirects_new_id_idx": {
+          "name": "candidate_redirects_new_id_idx",
+          "columns": [
+            {
+              "expression": "new_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_campaign_recipients": {
+      "name": "newsletter_campaign_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_campaign_recipients_campaign_idx": {
+          "name": "newsletter_campaign_recipients_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaign_recipients_subscriber_idx": {
+          "name": "newsletter_campaign_recipients_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaign_recipients_campaign_subscriber_uidx": {
+          "name": "newsletter_campaign_recipients_campaign_subscriber_uidx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_campaigns": {
+      "name": "newsletter_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_slug": {
+          "name": "public_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'template'"
+        },
+        "markdown_content": {
+          "name": "markdown_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_html": {
+          "name": "manual_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manual_text": {
+          "name": "manual_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rendered_html": {
+          "name": "rendered_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rendered_text": {
+          "name": "rendered_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_subject": {
+          "name": "archive_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_preview_text": {
+          "name": "archive_preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_content_mode": {
+          "name": "archive_content_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_markdown_content": {
+          "name": "archive_markdown_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_manual_html": {
+          "name": "archive_manual_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_manual_text": {
+          "name": "archive_manual_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_rendered_html": {
+          "name": "archive_rendered_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_rendered_text": {
+          "name": "archive_rendered_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_corrected_at": {
+          "name": "archive_corrected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_corrected_by": {
+          "name": "archive_corrected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "period_days": {
+          "name": "period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "timeframe_preset": {
+          "name": "timeframe_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'weekly'"
+        },
+        "minimum_relevance": {
+          "name": "minimum_relevance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_campaigns_public_slug_uidx": {
+          "name": "newsletter_campaigns_public_slug_uidx",
+          "columns": [
+            {
+              "expression": "public_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_status_idx": {
+          "name": "newsletter_campaigns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_type_idx": {
+          "name": "newsletter_campaigns_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_campaigns_scheduled_idx": {
+          "name": "newsletter_campaigns_scheduled_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_preferences": {
+      "name": "newsletter_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_preferences_subscriber_idx": {
+          "name": "newsletter_preferences_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_preferences_type_idx": {
+          "name": "newsletter_preferences_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_preferences_subscriber_type_uidx": {
+          "name": "newsletter_preferences_subscriber_type_uidx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_send_events": {
+      "name": "newsletter_send_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_send_events_campaign_idx": {
+          "name": "newsletter_send_events_campaign_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_send_events_type_idx": {
+          "name": "newsletter_send_events_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'news-page'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_status_idx": {
+          "name": "newsletter_subscribers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscribers_email_unique": {
+          "name": "newsletter_subscribers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_templates": {
+      "name": "newsletter_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_template": {
+          "name": "subject_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_template": {
+          "name": "html_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_template": {
+          "name": "text_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown_template": {
+          "name": "markdown_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{{default_markdown_body}}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_templates_type_idx": {
+          "name": "newsletter_templates_type_idx",
+          "columns": [
+            {
+              "expression": "newsletter_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_templates_newsletter_type_unique": {
+          "name": "newsletter_templates_newsletter_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "newsletter_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_unsub_tokens": {
+      "name": "newsletter_unsub_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newsletter_type": {
+          "name": "newsletter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unsubscribe'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_unsub_tokens_subscriber_idx": {
+          "name": "newsletter_unsub_tokens_subscriber_idx",
+          "columns": [
+            {
+              "expression": "subscriber_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "newsletter_unsub_tokens_token_idx": {
+          "name": "newsletter_unsub_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_unsub_tokens_token_unique": {
+          "name": "newsletter_unsub_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1779141000000,
       "tag": "0013_news_source_company_contexts",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1780049115356,
+      "tag": "0014_motionless_power_man",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/NewsGrid.tsx
+++ b/src/components/NewsGrid.tsx
@@ -11,6 +11,7 @@ import { NewsCategory, categoryLabels } from "@/data/news";
 import { CustomSelect } from "./CustomSelect";
 import { trackNewsClick } from "@/lib/posthog";
 import { useNewsClicks } from "@/hooks/useNewsClicks";
+import { renderInlineNewsMarkdown } from "./news-inline-markdown";
 
 type NewsType = "all" | "portfolio" | "blog" | "curated" | "announcement";
 type NewsSortMode = "posted" | "content";
@@ -807,7 +808,7 @@ export function NewsGrid({ news }: NewsGridProps) {
 													isDescriptionExpanded ? "" : "line-clamp-3 sm:line-clamp-2"
 												}`}
 											>
-												{item.description}
+												{renderInlineNewsMarkdown(item.description)}
 											</p>
 										)}
 

--- a/src/components/news-inline-markdown.tsx
+++ b/src/components/news-inline-markdown.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+
+function findClosingMarker(value: string, marker: string, start: number): number {
+  const closingIndex = value.indexOf(marker, start);
+  return closingIndex > start ? closingIndex : -1;
+}
+
+export function renderInlineNewsMarkdown(value: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+
+  while (cursor < value.length) {
+    const boldIndex = value.indexOf("**", cursor);
+    const rawItalicIndex = value.indexOf("*", cursor);
+    const italicIndex =
+      rawItalicIndex !== -1 &&
+      value[rawItalicIndex + 1] !== "*" &&
+      value[rawItalicIndex - 1] !== "*"
+        ? rawItalicIndex
+        : -1;
+    const nextIndex =
+      boldIndex !== -1 && (italicIndex === -1 || boldIndex <= italicIndex) ? boldIndex : italicIndex;
+
+    if (nextIndex === -1) {
+      nodes.push(value.slice(cursor));
+      break;
+    }
+
+    if (nextIndex > cursor) {
+      nodes.push(value.slice(cursor, nextIndex));
+    }
+
+    if (nextIndex === boldIndex) {
+      const contentStart = nextIndex + 2;
+      const contentEnd = findClosingMarker(value, "**", contentStart);
+      if (contentEnd === -1) {
+        nodes.push(value.slice(nextIndex));
+        break;
+      }
+
+      nodes.push(<strong key={`strong-${nodes.length}`}>{value.slice(contentStart, contentEnd)}</strong>);
+      cursor = contentEnd + 2;
+      continue;
+    }
+
+    const contentStart = nextIndex + 1;
+    const contentEnd = findClosingMarker(value, "*", contentStart);
+    if (contentEnd === -1) {
+      nodes.push(value.slice(nextIndex));
+      break;
+    }
+
+    nodes.push(<em key={`em-${nodes.length}`}>{value.slice(contentStart, contentEnd)}</em>);
+    cursor = contentEnd + 1;
+  }
+
+  return nodes;
+}

--- a/src/db/schema/misc.ts
+++ b/src/db/schema/misc.ts
@@ -16,6 +16,7 @@ export const affiliations = pgTable(
     imageUrl: text("image_url"),
     logo: text("logo"),
     website: text("website"),
+    xHandles: text("x_handles").array(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -1,12 +1,6 @@
 import { getAllPosts } from "./blog";
 import { db } from "@/db";
-import {
-  curatedLinks as curatedLinksTable,
-  announcements as announcementsTable,
-  newsSourceInvestments as newsSourceInvestmentsTable,
-  investments as investmentsTable,
-  jobs as jobsTable,
-} from "@/db/schema";
+import * as dbSchema from "@/db/schema";
 import { desc, inArray, sql } from "drizzle-orm";
 import { NewsCategory } from "@/data/news";
 import { isMissingColumnError, isMissingRelationError } from "@/lib/db-schema-compat";
@@ -17,6 +11,15 @@ import {
   getPortfolioJobsUrl,
 } from "@/lib/portfolio-jobs";
 
+const {
+  curatedLinks: curatedLinksTable,
+  announcements: announcementsTable,
+  newsSourceInvestments: newsSourceInvestmentsTable,
+  investments: investmentsTable,
+  affiliations: affiliationsTable,
+  jobs: jobsTable,
+} = dbSchema;
+
 interface PortfolioCompanyNewsContext {
   title: string;
   logo: string | null;
@@ -24,6 +27,11 @@ interface PortfolioCompanyNewsContext {
   jobsUrl: string;
   jobCount: number;
   sourceIsCompanyAccount: boolean;
+}
+
+interface PortfolioCompanyNewsContexts {
+  bySource: Map<string, PortfolioCompanyNewsContext>;
+  byTitle: Map<string, PortfolioCompanyNewsContext>;
 }
 
 const WORLD_COMPANY = {
@@ -335,6 +343,10 @@ function normalizeHost(value: string): string {
   return value.trim().replace(/^www\./, "").toLowerCase();
 }
 
+function normalizeCompanyTitle(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
 function getUrlHost(value: string): string | null {
   try {
     const url = new URL(value);
@@ -376,8 +388,11 @@ function getSourceLookupKeys(item: AggregatedNewsItem): string[] {
   return Array.from(keys);
 }
 
-async function getPortfolioCompanyContextsBySource() {
-  const contexts = new Map<string, PortfolioCompanyNewsContext>();
+async function getPortfolioCompanyContexts(): Promise<PortfolioCompanyNewsContexts> {
+  const contexts: PortfolioCompanyNewsContexts = {
+    bySource: new Map(),
+    byTitle: new Map(),
+  };
 
   try {
     if (!investmentsTable) {
@@ -506,6 +521,32 @@ async function getPortfolioCompanyContextsBySource() {
 
     const investmentsById = new Map(investments.map((investment) => [investment.id, investment]));
     const investmentsByTitle = new Map(investments.map((investment) => [investment.title, investment]));
+    let affiliationRows: Array<{
+      title: string;
+      logo: string | null;
+      website: string | null;
+      xHandles: string[] | null;
+    }> = [];
+
+    if (affiliationsTable) {
+      try {
+        affiliationRows = await db
+          .select({
+            title: affiliationsTable.title,
+            logo: affiliationsTable.logo,
+            website: affiliationsTable.website,
+            xHandles: affiliationsTable.xHandles,
+          })
+          .from(affiliationsTable);
+      } catch (error) {
+        if (isMissingRelationError(error, "affiliations") || isMissingColumnError(error, "x_handles")) {
+          affiliationRows = [];
+        } else {
+          console.error("[news] Failed to load affiliation portfolio contexts:", error);
+        }
+      }
+    }
+
     const getDirectJobCompanies = (mapping: { companyTitle: string | null; jobCompanies: string[] | null }) => {
       const jobCompanies = (mapping.jobCompanies || []).map((company) => company.trim()).filter(Boolean);
       if (jobCompanies.length > 0) return jobCompanies;
@@ -518,6 +559,7 @@ async function getPortfolioCompanyContextsBySource() {
       new Set([
         ...investments.flatMap((investment) => getPortfolioJobCompanies(investment.title)),
         ...directCompanyMappings.flatMap((mapping) => getDirectJobCompanies(mapping)),
+        ...affiliationRows.flatMap((affiliation) => getPortfolioJobCompanies(affiliation.title)),
       ])
     );
 
@@ -566,14 +608,17 @@ async function getPortfolioCompanyContextsBySource() {
         sourceType === "x_handle" ? normalizeXHandle(rawSourceValue) : normalizeHost(rawSourceValue);
       const sourceKind = rawSourceKind?.trim().toLowerCase();
 
-      contexts.set(`${sourceType}:${sourceValue}`, {
+      const context = {
         title: investment.title,
         logo: investment.logo,
         website: investment.website,
         jobsUrl: getPortfolioJobsUrl(investment.title),
         jobCount: getPortfolioJobCount(investment.title, jobCountsByCompany),
         sourceIsCompanyAccount: sourceKind === "company",
-      });
+      };
+
+      contexts.bySource.set(`${sourceType}:${sourceValue}`, context);
+      contexts.byTitle.set(normalizeCompanyTitle(investment.title), context);
     };
 
     const setDirectCompanyContext = (
@@ -599,14 +644,17 @@ async function getPortfolioCompanyContextsBySource() {
         .map((entity) => `company=${encodeURIComponent(entity)}`)
         .join("&");
 
-      contexts.set(`${sourceType}:${sourceValue}`, {
+      const context = {
         title,
         logo: company.companyLogo?.trim() || null,
         website: company.companyWebsite?.trim() || null,
         jobsUrl: `/jobs?${jobsUrl}`,
         jobCount: companiesForJobs.reduce((sum, entity) => sum + (jobCountsByCompany[entity] || 0), 0),
         sourceIsCompanyAccount: sourceKind === "company",
-      });
+      };
+
+      contexts.bySource.set(`${sourceType}:${sourceValue}`, context);
+      contexts.byTitle.set(normalizeCompanyTitle(title), context);
     };
 
     mappings.forEach((mapping) => {
@@ -629,7 +677,7 @@ async function getPortfolioCompanyContextsBySource() {
           ? normalizeXHandle(mapping.sourceValue)
           : normalizeHost(mapping.sourceValue);
       const key = `${mapping.sourceType}:${sourceValue}`;
-      if (contexts.has(key)) return;
+      if (contexts.bySource.has(key)) return;
 
       setContext(
         mapping.sourceType,
@@ -645,9 +693,38 @@ async function getPortfolioCompanyContextsBySource() {
           ? normalizeXHandle(mapping.sourceValue)
           : normalizeHost(mapping.sourceValue);
       const key = `${mapping.sourceType}:${sourceValue}`;
-      if (contexts.has(key)) return;
+      if (contexts.bySource.has(key)) return;
 
       setDirectCompanyContext(mapping.sourceType, mapping.sourceValue, mapping, mapping.sourceKind);
+    });
+
+    affiliationRows.forEach((affiliation) => {
+      const title = affiliation.title.trim();
+      if (!title) return;
+
+      const context = {
+        title,
+        logo: affiliation.logo?.trim() || null,
+        website: affiliation.website?.trim() || null,
+        jobsUrl: getPortfolioJobsUrl(title),
+        jobCount: getPortfolioJobCount(title, jobCountsByCompany),
+        sourceIsCompanyAccount: false,
+      };
+      const titleKey = normalizeCompanyTitle(title);
+
+      if (!contexts.byTitle.has(titleKey)) {
+        contexts.byTitle.set(titleKey, context);
+      }
+
+      (affiliation.xHandles ?? []).forEach((handle) => {
+        const normalizedHandle = normalizeXHandle(handle);
+        if (!normalizedHandle) return;
+
+        const sourceKey = `x_handle:${normalizedHandle}`;
+        if (!contexts.bySource.has(sourceKey)) {
+          contexts.bySource.set(sourceKey, context);
+        }
+      });
     });
   } catch (error) {
     console.error("[news] Failed to load portfolio source mappings:", error);
@@ -662,7 +739,7 @@ export async function getAllNews(): Promise<AggregatedNewsItem[]> {
     getAllPosts(),
     getCuratedLinksWithFallback(),
     getAnnouncementsWithFallback(),
-    getPortfolioCompanyContextsBySource(),
+    getPortfolioCompanyContexts(),
   ]);
 
   // Map blog posts
@@ -716,9 +793,11 @@ export async function getAllNews(): Promise<AggregatedNewsItem[]> {
   // Combine and sort by date, then relevance for same-day items.
   const allNews = [...blogItems, ...curatedItems, ...announcementItems];
   allNews.forEach((item) => {
-    const portfolioCompany = getSourceLookupKeys(item)
-      .map((key) => portfolioCompanyContexts.get(key))
-      .find(Boolean);
+    const portfolioCompany =
+      getSourceLookupKeys(item)
+        .map((key) => portfolioCompanyContexts.bySource.get(key))
+        .find(Boolean) ||
+      (item.company ? portfolioCompanyContexts.byTitle.get(normalizeCompanyTitle(item.company)) : undefined);
 
     if (portfolioCompany) {
       item.portfolioCompany = portfolioCompany;

--- a/tests/news-aggregation-relevance.test.ts
+++ b/tests/news-aggregation-relevance.test.ts
@@ -45,6 +45,7 @@ describe("getAllNews relevance mapping", () => {
       announcements,
       newsSourceInvestments: null,
       investments: null,
+      affiliations: null,
       jobs: null,
     }));
 
@@ -134,6 +135,7 @@ describe("getAllNews relevance mapping", () => {
       announcements,
       newsSourceInvestments: null,
       investments: null,
+      affiliations: null,
       jobs: null,
     }));
 
@@ -222,6 +224,7 @@ describe("getAllNews relevance mapping", () => {
       announcements,
       newsSourceInvestments: null,
       investments: null,
+      affiliations: null,
       jobs: null,
     }));
 
@@ -296,6 +299,7 @@ describe("getAllNews relevance mapping", () => {
       announcements,
       newsSourceInvestments,
       investments,
+      affiliations: null,
       jobs,
     }));
 
@@ -399,6 +403,7 @@ describe("getAllNews relevance mapping", () => {
       announcements,
       newsSourceInvestments: null,
       investments,
+      affiliations: null,
       jobs,
     }));
 
@@ -497,6 +502,7 @@ describe("getAllNews relevance mapping", () => {
       announcements,
       newsSourceInvestments,
       investments,
+      affiliations: null,
       jobs,
     }));
 
@@ -592,6 +598,7 @@ describe("getAllNews relevance mapping", () => {
       announcements,
       newsSourceInvestments: null,
       investments,
+      affiliations: null,
       jobs,
     }));
 
@@ -681,6 +688,7 @@ describe("getAllNews relevance mapping", () => {
       announcements,
       newsSourceInvestments: null,
       investments,
+      affiliations: null,
       jobs,
     }));
 
@@ -781,6 +789,7 @@ describe("getAllNews relevance mapping", () => {
       announcements,
       newsSourceInvestments: null,
       investments,
+      affiliations: null,
       jobs,
     }));
 
@@ -842,6 +851,113 @@ describe("getAllNews relevance mapping", () => {
       jobsUrl: "/jobs?company=World",
       jobCount: 78,
       sourceIsCompanyAccount: true,
+    });
+  });
+
+  test("attaches affiliation company context from X handles", async () => {
+    const curatedLinks = { __table: "curated_links" };
+    const announcements = { __table: "announcements" };
+    const affiliations = {
+      __table: "affiliations",
+      title: {},
+      logo: {},
+      website: {},
+      xHandles: {},
+    };
+    const investments = {
+      __table: "investments",
+      id: {},
+      title: {},
+      logo: {},
+      website: {},
+    };
+    const jobs = {
+      __table: "jobs",
+      company: {},
+    };
+
+    mock.module("../src/lib/blog", () => ({
+      getAllPosts: async () => [],
+    }));
+
+    mock.module("@/db/schema", () => ({
+      curatedLinks,
+      announcements,
+      newsSourceInvestments: null,
+      investments,
+      affiliations,
+      jobs,
+    }));
+
+    mock.module("@/db", () => ({
+      ...dbTableExportPlaceholders,
+      db: {
+        select: (selection?: { count?: unknown }) => ({
+          from: (table: { __table: string }) => {
+            if (table.__table === "curated_links") {
+              return {
+                orderBy: async () => [
+                  {
+                    id: "paris-2",
+                    title: "Paris 2.0",
+                    url: "https://x.com/bidhan/status/2060043273545429503",
+                    source: "bidhan",
+                    sourceImage: null,
+                    date: new Date("2026-05-29T00:00:00.000Z"),
+                    description: "**Bagel** releases Paris 2.0.",
+                    category: "ai",
+                    featured: false,
+                    relevance: 8,
+                  },
+                ],
+              };
+            }
+
+            if (table.__table === "announcements") {
+              return { orderBy: async () => [] };
+            }
+
+            if (table.__table === "investments") {
+              return { where: async () => [] };
+            }
+
+            if (table.__table === "affiliations") {
+              return Promise.resolve([
+                {
+                  title: "Bagel",
+                  logo: "https://r2.example/bagel.png",
+                  website: "https://www.bagel.net/",
+                  xHandles: ["@bidhan"],
+                },
+              ]);
+            }
+
+            if (selection?.count) {
+              return {
+                where: () => ({
+                  groupBy: async () => [{ company: "Bagel", count: 2 }],
+                }),
+              };
+            }
+
+            return {
+              where: async () => [{ company: "Bagel" }, { company: "Bagel" }],
+            };
+          },
+        }),
+      },
+    }));
+
+    const { getAllNews } = await import(`../src/lib/news?news-affiliation-context=${Date.now()}`);
+    const news = await getAllNews();
+
+    expect(news[0].portfolioCompany).toMatchObject({
+      title: "Bagel",
+      logo: "https://r2.example/bagel.png",
+      website: "https://www.bagel.net/",
+      jobsUrl: "/jobs?company=Bagel",
+      jobCount: 2,
+      sourceIsCompanyAccount: false,
     });
   });
 });

--- a/tests/news-inline-markdown.test.tsx
+++ b/tests/news-inline-markdown.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { renderInlineNewsMarkdown } from "../src/components/news-inline-markdown";
+
+describe("renderInlineNewsMarkdown", () => {
+  test("renders bold and italic emphasis inline", () => {
+    const markup = renderToStaticMarkup(
+      <p>{renderInlineNewsMarkdown("**Bagel** releases *Paris 2.0*.")}</p>
+    );
+
+    expect(markup).toContain("<strong>Bagel</strong>");
+    expect(markup).toContain("<em>Paris 2.0</em>");
+  });
+
+  test("leaves unmatched emphasis markers as text", () => {
+    const markup = renderToStaticMarkup(
+      <p>{renderInlineNewsMarkdown("This **stays literal.")}</p>
+    );
+
+    expect(markup).toContain("This **stays literal.");
+  });
+});


### PR DESCRIPTION
## Summary
- Add nullable affiliation x_handles schema and migration support.
- Merge affiliation rows into news portfolio context maps without overriding investment title matches.
- Render news descriptions with lightweight inline bold and italic support.

## Files changed
- drizzle/0014_motionless_power_man.sql
- src/db/schema/misc.ts
- src/lib/news.ts
- src/components/NewsGrid.tsx
- src/components/news-inline-markdown.tsx
- tests/news-aggregation-relevance.test.ts
- tests/news-inline-markdown.test.tsx

## Verification
- bun test tests/news-inline-markdown.test.tsx tests/news-aggregation-relevance.test.ts
- bun run db:check:migrations
- bunx tsc --noEmit
- bun run lint
- bun run test:unit
- Production sanity: /api/v1/news/curated?limit=5 returned 200, /api/v1/news/announcements?limit=5 returned 200.
- Vercel preview /news returned 200.
- Preview check: Paris 2.0 card shows the Bagel stacked badge under bidhan's avatar, Bagel metadata, Hiring badge, and bold Bagel description text.

## Data writes
- Applied affiliations.x_handles migration in prod and staging Supabase.
- Set Bagel x_handles to ['bidhan'] in prod and staging.
- Updated the Paris 2.0 curated_link description in prod and staging.

## Screenshots
- Before: production Paris 2.0 card showed bidhan's avatar only and plain Bagel text.
- After: Vercel preview shows Bagel badge and bold Bagel text on the Paris 2.0 card.

## Review note
The NewsGrid description-render change is intentionally a tiny import plus paragraph render swap so it can be rebased onto the existing NewsGrid WIP last.