### PR TITLE
[codex] Feature jobs from featured portfolio companies

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -3,6 +3,7 @@ import {
   jobs as jobsTable,
   jobTags,
   jobRoles,
+  investments as investmentsTable,
   candidates as candidatesTable,
   curatedLinks as curatedLinksTable,
   candidateRedirects,
@@ -10,6 +11,7 @@ import {
 import { asc, desc, eq, sql } from "drizzle-orm";
 import type { Job, Company, RelationshipCategory, JobTag, JobTier } from "@/data/jobs";
 import { normalizeJobTags } from "@/lib/job-tags";
+import { getFeaturedPortfolioJobCompanies } from "@/lib/portfolio-jobs";
 import { isMissingColumnError, isMissingRelationError } from "@/lib/db-schema-compat";
 import type {
   Candidate,
@@ -25,8 +27,9 @@ import type { CuratedLink } from "@/data/news";
 // Fetch all jobs from database and transform to component format
 export async function getJobsFromDB(): Promise<Job[]> {
   const dbJobs = await getJobRowsFromDB({ orderBy: "created" });
+  const featuredPortfolioJobCompanies = await getFeaturedPortfolioJobCompanyNames();
 
-  return dbJobs.map(mapJobRowToJob);
+  return dbJobs.map((job) => mapJobRowToJob(job, featuredPortfolioJobCompanies));
 }
 
 type JobRow = {
@@ -94,32 +97,62 @@ const optionalJobColumnFallbacks = {
 
 const requiredJobColumns = ["id", "title", "company", "link", "category"] as const;
 
-function mapJobRowToJob(job: JobRow): Job {
-    const company: Company = {
-      name: job.company,
-      logo: job.companyLogo || undefined,
-      website: job.companyWebsite || "",
-      category: job.category as RelationshipCategory,
-      x: job.companyX || undefined,
-      github: job.companyGithub || undefined,
-    };
+function mapJobRowToJob(
+  job: JobRow,
+  featuredPortfolioJobCompanies: Set<string> = new Set(),
+): Job {
+  const company: Company = {
+    name: job.company,
+    logo: job.companyLogo || undefined,
+    website: job.companyWebsite || "",
+    category: job.category as RelationshipCategory,
+    x: job.companyX || undefined,
+    github: job.companyGithub || undefined,
+  };
 
-    return {
-      id: job.id,
-      title: job.title,
-      company,
-      location: job.location || "",
-      remote: job.remote === "Remote",
-      type: job.type as Job["type"],
-      department: job.department || undefined,
-      salary: job.salary || undefined,
-      link: job.link,
-      featured: job.featured || false,
-      tags: normalizeJobTags(job.tags) as JobTag[],
-      tier: 3 as JobTier, // Default tier
-      description: job.description || undefined,
-      createdAt: job.createdAt,
-    };
+  return {
+    id: job.id,
+    title: job.title,
+    company,
+    location: job.location || "",
+    remote: job.remote === "Remote",
+    type: job.type as Job["type"],
+    department: job.department || undefined,
+    salary: job.salary || undefined,
+    link: job.link,
+    featured: Boolean(job.featured) || featuredPortfolioJobCompanies.has(job.company),
+    tags: normalizeJobTags(job.tags) as JobTag[],
+    tier: 3 as JobTier, // Default tier
+    description: job.description || undefined,
+    createdAt: job.createdAt,
+  };
+}
+
+async function getFeaturedPortfolioJobCompanyNames() {
+  try {
+    const featuredInvestments = await db
+      .select({
+        title: investmentsTable.title,
+        featured: investmentsTable.featured,
+      })
+      .from(investmentsTable)
+      .where(eq(investmentsTable.featured, true));
+
+    return getFeaturedPortfolioJobCompanies(featuredInvestments);
+  } catch (error) {
+    if (
+      isMissingRelationError(error, "investments") ||
+      isMissingColumnError(error, "featured")
+    ) {
+      console.error(
+        "[jobs-read-compat] investments featured state unavailable, using job flags only",
+        error,
+      );
+      return new Set<string>();
+    }
+
+    throw error;
+  }
 }
 
 export async function getJobRowsFromDB(options: JobReadOptions = {}): Promise<JobRow[]> {

--- a/src/lib/portfolio-jobs.ts
+++ b/src/lib/portfolio-jobs.ts
@@ -2,8 +2,29 @@ const HIRING_ENTITIES: Record<string, string[]> = {
   Monad: ["Monad Foundation", "Category Labs"],
 };
 
+type PortfolioJobInvestment = {
+  title: string;
+  featured?: boolean | null;
+};
+
 export function getPortfolioJobCompanies(companyTitle: string): string[] {
   return HIRING_ENTITIES[companyTitle] || [companyTitle];
+}
+
+export function getFeaturedPortfolioJobCompanies(
+  investments: PortfolioJobInvestment[]
+): Set<string> {
+  const companies = new Set<string>();
+
+  investments.forEach((investment) => {
+    if (!investment.featured) return;
+
+    getPortfolioJobCompanies(investment.title).forEach((company) => {
+      companies.add(company);
+    });
+  });
+
+  return companies;
 }
 
 export function getPortfolioJobCount(

--- a/tests/jobs-read-compat.test.ts
+++ b/tests/jobs-read-compat.test.ts
@@ -37,13 +37,21 @@ describe("jobs read compatibility", () => {
       ...actualDb,
       db: {
         select: () => ({
-          from: () => ({
-            $dynamic: () => ({
-              orderBy: () => {
-                throw createMissingColumnError("company_website");
-              },
-            }),
-          }),
+          from: (table: unknown) => {
+            if (table === actualDb.investments) {
+              return {
+                where: async () => [{ title: "Monad", featured: true }],
+              };
+            }
+
+            return {
+              $dynamic: () => ({
+                orderBy: () => {
+                  throw createMissingColumnError("company_website");
+                },
+              }),
+            };
+          },
         }),
         execute: async () => {
           executeCall += 1;
@@ -64,11 +72,11 @@ describe("jobs read compatibility", () => {
 
           return [
             {
-              id: "morpho-protocol-engineer",
+              id: "monad-foundation-protocol-engineer",
               title: "Protocol Engineer",
-              company: "Morpho",
+              company: "Monad Foundation",
               companyLogo: null,
-              link: "https://example.com/morpho",
+              link: "https://example.com/monad",
               location: "Remote",
               remote: "Remote",
               type: "full-time",
@@ -93,8 +101,9 @@ describe("jobs read compatibility", () => {
     const jobs = await getJobsFromDB();
 
     expect(jobs).toHaveLength(1);
-    expect(jobs[0].company.name).toBe("Morpho");
-    expect(jobs[0].link).toBe("https://example.com/morpho");
+    expect(jobs[0].company.name).toBe("Monad Foundation");
+    expect(jobs[0].link).toBe("https://example.com/monad");
+    expect(jobs[0].featured).toBe(true);
     expect(jobs[0].tags).toEqual([]);
   });
 

--- a/tests/portfolio-jobs.test.ts
+++ b/tests/portfolio-jobs.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getFeaturedPortfolioJobCompanies,
+  getPortfolioJobCompanies,
+} from "../src/lib/portfolio-jobs";
+
+describe("portfolio job helpers", () => {
+  test("maps portfolio companies to configured hiring entities", () => {
+    expect(getPortfolioJobCompanies("Monad")).toEqual([
+      "Monad Foundation",
+      "Category Labs",
+    ]);
+    expect(getPortfolioJobCompanies("Morpho")).toEqual(["Morpho"]);
+  });
+
+  test("returns job companies for featured portfolio investments only", () => {
+    const companies = getFeaturedPortfolioJobCompanies([
+      { title: "Monad", featured: true },
+      { title: "Morpho", featured: false },
+      { title: "Prime Intellect", featured: null },
+      { title: "MegaETH", featured: true },
+    ]);
+
+    expect(companies).toEqual(
+      new Set(["Monad Foundation", "Category Labs", "MegaETH"])
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Mark jobs as featured on the jobs page when their company belongs to a featured portfolio investment.
- Reuse the existing portfolio hiring-entity mapping so aliases like Monad Foundation and Category Labs inherit Monad's featured state.
- Add unit coverage for featured portfolio job-company mapping and the jobs read compatibility path.

## Validation
- `bunx tsc --noEmit`
- `bunx eslint src/lib/data.ts src/lib/portfolio-jobs.ts tests/jobs-read-compat.test.ts tests/portfolio-jobs.test.ts`
- `bun test tests/portfolio-jobs.test.ts tests/jobs-read-compat.test.ts`

## Baseline Notes
- `bun run lint` still fails on untouched files: `scripts/audit-jobs.ts` unused `eq`, `src/lib/r2-rehost.ts` explicit `any`.
- `bun run test:unit` still fails in unrelated newsletter tests around `isCompanyTimelineNewsItem` export and one archive slug expectation.