### PR TITLE
Add agent API inbox workflow and CLI skill

### DIFF
--- a/.agents/skills/dcbuilder-cli/SKILL.md
+++ b/.agents/skills/dcbuilder-cli/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: dcbuilder-cli
+description: Use when an agent needs to operate the dcbuilder CLI or local MCP server to read dcbuilder.dev news, jobs, candidates, run allowlisted queries, submit inbox messages/jobs/candidates, manage inbox review actions, create submit invites, refresh search indexes, or fetch the agent API schema.
+---
+
+# dcbuilder CLI
+
+Use this skill whenever the user asks an agent to work through the `dcbuilder`
+CLI or MCP server. The backend API is the source of truth; the CLI must not query
+Postgres directly.
+
+## Environment
+
+Required for authenticated commands:
+
+```bash
+export DCBUILDER_API_URL=https://dcbuilder.dev
+export DCBUILDER_API_TOKEN=...
+```
+
+Do not store `DCBUILDER_API_TOKEN` in repo files, config files, logs, or examples.
+Use environment variables only. Public `submit message` may be allowed without a
+token, but authenticated usage is preferred for trusted agents.
+
+Default output is JSON. Use `--format table` or `--format markdown` only for
+human-readable summaries.
+
+## Read Commands
+
+Fetch OpenAPI/schema metadata:
+
+```bash
+dcbuilder schema
+```
+
+Read recent news:
+
+```bash
+dcbuilder news --since 7d --limit 20
+dcbuilder news --q "MegaETH" --format table
+```
+
+Read jobs:
+
+```bash
+dcbuilder jobs --remote --limit 25
+dcbuilder jobs --company "ExampleCo" --location "Remote"
+dcbuilder jobs --tag infra --tag ai
+```
+
+Read candidates:
+
+```bash
+dcbuilder candidates --availability open --location "Europe"
+dcbuilder candidates --q "founding engineer"
+```
+
+Sensitive candidate fields are redacted unless the token has elevated scope such
+as `agent:sensitive`, `admin:read`, or `*`.
+
+## Query Command
+
+Use structured filters as the canonical contract:
+
+```bash
+dcbuilder query --json '{"table":"jobs","filters":{"remote":true,"limit":10}}'
+```
+
+Natural-language query text is only client-side convenience. The CLI parses it
+into deterministic filters before calling the API:
+
+```bash
+dcbuilder query "remote AI infra jobs from the last week"
+```
+
+Never expose raw SQL as a CLI/MCP interface.
+
+## Submit Commands
+
+Submissions create inbox items for review; they do not publish live jobs or
+candidates by themselves.
+
+```bash
+dcbuilder submit message --json '{"subject":"Scout report","body":"Found 3 relevant jobs.","source":"agent","priority":"normal"}'
+dcbuilder submit job --json '{"title":"Founding Engineer","company":"ExampleCo","link":"https://example.com/jobs/1","location":"Remote"}'
+dcbuilder submit candidate --json '{"name":"Ada Example","headline":"AI infra engineer","location":"Berlin","skills":["Bun","MCP","Postgres"]}'
+```
+
+Use `submit message` when reporting findings, asking for approval, or requesting
+help from Daniel. Prefer messages over direct approval unless the user explicitly
+asked the agent to approve or publish.
+
+## Inbox Review Commands
+
+Admin-scoped tokens can review and manage inbox submissions:
+
+```bash
+dcbuilder inbox list --status pending --limit 20
+dcbuilder inbox show <id>
+dcbuilder inbox comment <id> "Looks good; please add salary range."
+dcbuilder inbox approve <id> --json '{"note":"Approved by trusted agent"}'
+dcbuilder inbox reject <id> --json '{"reason":"Duplicate submission"}'
+```
+
+Approval is create-only for job/candidate records. Do not approve, reject, or
+comment unless the user's instruction clearly authorizes that action.
+
+## Admin Commands
+
+Create scoped submit invites:
+
+```bash
+dcbuilder invites create --json '{"allowedKinds":["job","candidate","message"],"submitterName":"Partner","submitterEmail":"partner@example.com","expiresInDays":30,"maxUses":5}'
+```
+
+The returned invite token is a secret. Do not print it in final answers unless
+the user explicitly asked for the token value.
+
+Refresh search snapshots / semantic index metadata:
+
+```bash
+dcbuilder search refresh --json '{"resources":["jobs","candidates","news"],"limit":100}'
+```
+
+If no embedding provider is configured, the backend should fall back cleanly to
+filter/text search.
+
+## MCP Server
+
+Start the local stdio MCP server from the CLI package:
+
+```bash
+dcbuilder-mcp
+```
+
+The MCP server uses the same `DCBUILDER_API_URL` and `DCBUILDER_API_TOKEN`
+environment variables. It exposes typed tools for:
+
+- `dcbuilder_schema`
+- reading news, jobs, and candidates
+- generic allowlisted queries
+- submitting messages, jobs, and candidates
+- listing/showing/commenting/approving/rejecting inbox items
+- creating scoped submit invites
+- refreshing search indexes
+
+Prefer MCP tools when the calling agent supports MCP natively. Prefer CLI
+commands when producing a reproducible shell transcript or operating in a plain
+terminal.
+
+## Agent Workflow Pattern
+
+1. Read with `news`, `jobs`, `candidates`, or `query`.
+2. Analyze locally; do not send free-form prompts to the API as the canonical
+   query contract.
+3. Submit a concise inbox message with findings and recommended next action.
+4. Only use inbox approval actions when the user explicitly delegates approval.
+
+Example scout flow:
+
+```bash
+dcbuilder news --since 7d --limit 20 > /tmp/dcbuilder-news.json
+dcbuilder jobs --remote --limit 25 > /tmp/dcbuilder-jobs.json
+dcbuilder candidates --limit 25 > /tmp/dcbuilder-candidates.json
+dcbuilder submit message --json '{"subject":"Weekly opportunity scout","body":"Summary with recommended follow-ups...","source":"dcbuilder-cli","priority":"normal"}'
+```

--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,7 @@ RESEND_API_KEY="re_xxx"
 RESEND_WEBHOOK_SECRET="whsec_xxx"
 NEWSLETTER_FROM_EMAIL="newsletter@yourdomain.com"
 NEWSLETTER_REPLY_TO="hello@yourdomain.com"
+
+# Agent inbox notifications and optional semantic matching provider
+AGENT_INBOX_NOTIFY_EMAIL="you@example.com"
+AGENT_EMBEDDING_PROVIDER=""

--- a/drizzle/0015_agent_inbox_api.sql
+++ b/drizzle/0015_agent_inbox_api.sql
@@ -1,0 +1,100 @@
+CREATE TABLE "agent_submit_tokens" (
+	"id" text PRIMARY KEY NOT NULL,
+	"token_hash" text NOT NULL,
+	"label" text NOT NULL,
+	"submitter_name" text,
+	"submitter_email" text,
+	"allowed_kinds" text[] NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"max_uses" integer,
+	"use_count" integer DEFAULT 0 NOT NULL,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_by_key_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "agent_inbox_submissions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"kind" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"priority" text DEFAULT 'normal' NOT NULL,
+	"submitter_type" text DEFAULT 'public' NOT NULL,
+	"submitter_name" text,
+	"submitter_email" text,
+	"submit_token_id" text,
+	"created_by_key_id" text,
+	"title" text,
+	"original_payload" jsonb NOT NULL,
+	"current_payload" jsonb NOT NULL,
+	"live_record_id" text,
+	"approved_by_key_id" text,
+	"approved_by_name" text,
+	"approved_at" timestamp,
+	"rejected_by_key_id" text,
+	"rejected_by_name" text,
+	"rejected_at" timestamp,
+	"rejection_reason" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "agent_inbox_comments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"submission_id" text NOT NULL,
+	"author_type" text NOT NULL,
+	"author_name" text,
+	"author_key_id" text,
+	"body" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "agent_inbox_versions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"submission_id" text NOT NULL,
+	"payload" jsonb NOT NULL,
+	"changed_by_key_id" text,
+	"changed_by_name" text,
+	"change_note" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "agent_audit_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"actor_type" text NOT NULL,
+	"actor_key_id" text,
+	"actor_name" text,
+	"submit_token_id" text,
+	"action" text NOT NULL,
+	"target_type" text NOT NULL,
+	"target_id" text,
+	"metadata" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "agent_search_documents" (
+	"id" text PRIMARY KEY NOT NULL,
+	"resource_type" text NOT NULL,
+	"resource_id" text NOT NULL,
+	"search_text" text NOT NULL,
+	"embedding_provider" text,
+	"embedding_model" text,
+	"embedding_json" jsonb,
+	"indexed_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "agent_submit_tokens_hash_uidx" ON "agent_submit_tokens" USING btree ("token_hash");--> statement-breakpoint
+CREATE INDEX "agent_submit_tokens_active_idx" ON "agent_submit_tokens" USING btree ("active");--> statement-breakpoint
+CREATE INDEX "agent_submit_tokens_expires_idx" ON "agent_submit_tokens" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "agent_inbox_submissions_status_idx" ON "agent_inbox_submissions" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "agent_inbox_submissions_kind_idx" ON "agent_inbox_submissions" USING btree ("kind");--> statement-breakpoint
+CREATE INDEX "agent_inbox_submissions_priority_idx" ON "agent_inbox_submissions" USING btree ("priority");--> statement-breakpoint
+CREATE INDEX "agent_inbox_submissions_created_idx" ON "agent_inbox_submissions" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "agent_inbox_comments_submission_idx" ON "agent_inbox_comments" USING btree ("submission_id");--> statement-breakpoint
+CREATE INDEX "agent_inbox_versions_submission_idx" ON "agent_inbox_versions" USING btree ("submission_id");--> statement-breakpoint
+CREATE INDEX "agent_audit_events_target_idx" ON "agent_audit_events" USING btree ("target_type","target_id");--> statement-breakpoint
+CREATE INDEX "agent_audit_events_action_idx" ON "agent_audit_events" USING btree ("action");--> statement-breakpoint
+CREATE UNIQUE INDEX "agent_search_documents_resource_uidx" ON "agent_search_documents" USING btree ("resource_type","resource_id");--> statement-breakpoint
+CREATE INDEX "agent_search_documents_resource_type_idx" ON "agent_search_documents" USING btree ("resource_type");

--- a/scripts/audit-jobs.ts
+++ b/scripts/audit-jobs.ts
@@ -20,7 +20,7 @@
 
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
-import { eq, inArray } from "drizzle-orm";
+import { inArray } from "drizzle-orm";
 import { jobs } from "../src/db/schema/jobs";
 import { createPreferredPostgresSocket } from "../src/db/postgres-connection";
 

--- a/src/app/admin/inbox/page.tsx
+++ b/src/app/admin/inbox/page.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { adminFetch, getAdminApiKey } from "@/lib/admin-utils";
+import { ErrorAlert } from "@/components/admin/ActionButtons";
+
+type Submission = {
+  id: string;
+  kind: "job" | "candidate" | "message";
+  status: "pending" | "approved" | "rejected";
+  priority: "low" | "normal" | "high";
+  title: string | null;
+  submitterName: string | null;
+  submitterEmail: string | null;
+  submitterType: string;
+  currentPayload: unknown;
+  originalPayload: unknown;
+  liveRecordId: string | null;
+  createdAt: string;
+  comments?: Array<{ id: string; body: string; authorName: string | null; createdAt: string }>;
+};
+
+export default function AdminInboxPage() {
+  const [items, setItems] = useState<Submission[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Submission | null>(null);
+  const [payloadText, setPayloadText] = useState("");
+  const [comment, setComment] = useState("");
+  const [statusFilter, setStatusFilter] = useState("pending");
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const apiKey = getAdminApiKey();
+  const headers = useMemo(() => ({ "x-api-key": apiKey, "Content-Type": "application/json" }), [apiKey]);
+
+  const fetchInbox = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const query = statusFilter ? `?status=${encodeURIComponent(statusFilter)}` : "";
+    const result = await adminFetch<Submission[]>(`/api/agent/inbox${query}`, { headers });
+    if (result.error) {
+      setError(result.error);
+    } else {
+      setItems(result.data ?? []);
+      if (!selectedId && result.data?.[0]) setSelectedId(result.data[0].id);
+    }
+    setLoading(false);
+  }, [headers, selectedId, statusFilter]);
+
+  const fetchSelected = useCallback(async () => {
+    if (!selectedId) {
+      setSelected(null);
+      setPayloadText("");
+      return;
+    }
+    const result = await adminFetch<Submission>(`/api/agent/inbox/${selectedId}`, { headers });
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+    setSelected(result.data);
+    setPayloadText(JSON.stringify(result.data?.currentPayload ?? {}, null, 2));
+  }, [headers, selectedId]);
+
+  useEffect(() => {
+    fetchInbox();
+  }, [fetchInbox]);
+
+  useEffect(() => {
+    fetchSelected();
+  }, [fetchSelected]);
+
+  const submitAction = async (action: "approve" | "reject") => {
+    if (!selected) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const payload = payloadText.trim() ? JSON.parse(payloadText) : {};
+      const body = action === "approve" ? { payload, note: comment } : { reason: comment || "Rejected in admin inbox" };
+      const result = await adminFetch<Submission>(`/api/agent/inbox/${selected.id}/${action}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+      if (result.error) {
+        setError(result.error);
+      } else {
+        setSelected(result.data);
+        await fetchInbox();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Invalid JSON payload");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const submitComment = async () => {
+    if (!selected || !comment.trim()) return;
+    setBusy(true);
+    const result = await adminFetch(`/api/agent/inbox/${selected.id}/comments`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ body: comment }),
+    });
+    if (result.error) setError(result.error);
+    else {
+      setComment("");
+      await fetchSelected();
+    }
+    setBusy(false);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-neutral-50">Agent Inbox</h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">
+            Review agent submissions, edit payloads, and approve or reject creates.
+          </p>
+        </div>
+        <select
+          value={statusFilter}
+          onChange={(event) => setStatusFilter(event.target.value)}
+          className="rounded-lg border border-neutral-200 bg-white px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+        >
+          <option value="pending">Pending</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+          <option value="">All</option>
+        </select>
+      </div>
+
+      {error && <ErrorAlert message={error} onRetry={() => { setError(null); fetchInbox(); }} />}
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(280px,360px)_1fr]">
+        <div className="overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800">
+          <div className="border-b border-neutral-200 bg-neutral-50 px-4 py-3 text-sm font-semibold dark:border-neutral-800 dark:bg-neutral-900">
+            {loading ? "Loading..." : `${items.length} submission${items.length === 1 ? "" : "s"}`}
+          </div>
+          <div className="divide-y divide-neutral-200 dark:divide-neutral-800">
+            {items.map((item) => (
+              <button
+                key={item.id}
+                onClick={() => setSelectedId(item.id)}
+                className={`block w-full px-4 py-3 text-left transition-colors ${
+                  selectedId === item.id ? "bg-cyan-50 dark:bg-cyan-950/30" : "hover:bg-neutral-50 dark:hover:bg-neutral-900"
+                }`}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-semibold text-neutral-900 dark:text-neutral-50">{item.title || item.id}</span>
+                  <span className="rounded bg-neutral-100 px-2 py-0.5 text-xs text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300">
+                    {item.kind}
+                  </span>
+                </div>
+                <div className="mt-1 text-xs text-neutral-500">
+                  {item.priority} priority · {item.submitterName || item.submitterType}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-neutral-200 dark:border-neutral-800">
+          {selected ? (
+            <div className="space-y-5 p-5">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold">{selected.title || selected.id}</h2>
+                  <p className="text-sm text-neutral-500">
+                    {selected.kind} · {selected.status} · {selected.submitterName || selected.submitterType}
+                  </p>
+                </div>
+                {selected.liveRecordId && (
+                  <span className="rounded bg-green-100 px-2 py-1 text-xs text-green-700 dark:bg-green-950 dark:text-green-300">
+                    live: {selected.liveRecordId}
+                  </span>
+                )}
+              </div>
+
+              <label className="block">
+                <span className="mb-2 block text-sm font-medium">Current payload</span>
+                <textarea
+                  value={payloadText}
+                  onChange={(event) => setPayloadText(event.target.value)}
+                  className="min-h-80 w-full rounded-lg border border-neutral-200 bg-white p-3 font-mono text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                  spellCheck={false}
+                />
+              </label>
+
+              <label className="block">
+                <span className="mb-2 block text-sm font-medium">Comment or decision note</span>
+                <textarea
+                  value={comment}
+                  onChange={(event) => setComment(event.target.value)}
+                  className="min-h-24 w-full rounded-lg border border-neutral-200 bg-white p-3 text-sm dark:border-neutral-700 dark:bg-neutral-950"
+                />
+              </label>
+
+              <div className="flex flex-wrap gap-2">
+                <button onClick={submitComment} disabled={busy || !comment.trim()} className="rounded-lg bg-neutral-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-900">
+                  Add comment
+                </button>
+                <button onClick={() => submitAction("approve")} disabled={busy || selected.status !== "pending"} className="rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50">
+                  Approve
+                </button>
+                <button onClick={() => submitAction("reject")} disabled={busy || selected.status !== "pending"} className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50">
+                  Reject
+                </button>
+              </div>
+
+              {selected.comments && selected.comments.length > 0 && (
+                <div className="space-y-2">
+                  <h3 className="text-sm font-semibold">Comments</h3>
+                  {selected.comments.map((entry) => (
+                    <div key={entry.id} className="rounded border border-neutral-200 p-3 text-sm dark:border-neutral-800">
+                      <div className="text-xs text-neutral-500">{entry.authorName || "Agent"} · {new Date(entry.createdAt).toLocaleString()}</div>
+                      <p className="mt-1 whitespace-pre-wrap">{entry.body}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="p-8 text-sm text-neutral-500">Select a submission to review.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -90,12 +90,13 @@ export default function AdminLayout({
     setIsAuthenticated(false);
   };
 
-  // Order: Dashboard, Affiliations (About page), Blog, News, Portfolio, Jobs, Candidates
+  // Order: Dashboard, Affiliations (About page), Blog, News, Inbox, Portfolio, Jobs, Candidates
   const navItems = [
     { href: "/admin", label: "Dashboard", color: "neutral", bg: "bg-neutral-100 dark:bg-neutral-800", bgHover: "hover:bg-neutral-200 dark:hover:bg-neutral-700", bgActive: "bg-neutral-700 dark:bg-neutral-600", text: "text-neutral-600 dark:text-neutral-400" },
     { href: "/admin/affiliations", label: "Affiliations", color: "pink", bg: "bg-pink-100 dark:bg-pink-900/30", bgHover: "hover:bg-pink-200 dark:hover:bg-pink-800/40", bgActive: "bg-pink-500 dark:bg-pink-600", text: "text-pink-600 dark:text-pink-400" },
     { href: "/admin/blog", label: "Blog", color: "indigo", bg: "bg-indigo-100 dark:bg-indigo-900/30", bgHover: "hover:bg-indigo-200 dark:hover:bg-indigo-800/40", bgActive: "bg-indigo-500 dark:bg-indigo-600", text: "text-indigo-600 dark:text-indigo-400" },
     { href: "/admin/news", label: "News", color: "purple", bg: "bg-purple-100 dark:bg-purple-900/30", bgHover: "hover:bg-purple-200 dark:hover:bg-purple-800/40", bgActive: "bg-purple-500 dark:bg-purple-600", text: "text-purple-600 dark:text-purple-400" },
+    { href: "/admin/inbox", label: "Inbox", color: "cyan", bg: "bg-cyan-100 dark:bg-cyan-900/30", bgHover: "hover:bg-cyan-200 dark:hover:bg-cyan-800/40", bgActive: "bg-cyan-500 dark:bg-cyan-600", text: "text-cyan-600 dark:text-cyan-400" },
     { href: "/admin/investments", label: "Portfolio", color: "amber", bg: "bg-amber-100 dark:bg-amber-900/30", bgHover: "hover:bg-amber-200 dark:hover:bg-amber-800/40", bgActive: "bg-amber-500 dark:bg-amber-600", text: "text-amber-600 dark:text-amber-400" },
     { href: "/admin/jobs", label: "Jobs", color: "blue", bg: "bg-blue-100 dark:bg-blue-900/30", bgHover: "hover:bg-blue-200 dark:hover:bg-blue-800/40", bgActive: "bg-blue-500 dark:bg-blue-600", text: "text-blue-600 dark:text-blue-400" },
     { href: "/admin/candidates", label: "Candidates", color: "green", bg: "bg-green-100 dark:bg-green-900/30", bgHover: "hover:bg-green-200 dark:hover:bg-green-800/40", bgActive: "bg-green-500 dark:bg-green-600", text: "text-green-600 dark:text-green-400" },

--- a/src/app/api/agent/_utils.ts
+++ b/src/app/api/agent/_utils.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { AgentHttpError } from "@/services/agent-api";
+import type { AuthResult } from "@/services/auth";
+import { extractRequestToken, validateApiKey } from "@/services/auth";
+
+export function jsonError(error: unknown) {
+  if (error instanceof AgentHttpError) {
+    return Response.json({ error: error.message }, { status: error.status });
+  }
+  console.error("[api/agent] request failed", error);
+  return Response.json({ error: "Agent API request failed" }, { status: 500 });
+}
+
+export async function optionalAuth(request: NextRequest | Request): Promise<AuthResult | undefined> {
+  if (!extractRequestToken(request)) return undefined;
+  return validateApiKey(request as NextRequest);
+}
+
+export function authPermissions(auth: AuthResult | undefined) {
+  return auth?.valid ? auth.permissions : [];
+}

--- a/src/app/api/agent/candidates/route.ts
+++ b/src/app/api/agent/candidates/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+import { listAgentResource, parseAgentFilters } from "@/services/agent-api";
+import { requireAuth } from "@/services/auth";
+import { jsonError } from "../_utils";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request, "agent:read");
+  if (auth instanceof Response) return auth;
+  if (!auth.valid) return Response.json({ error: auth.error }, { status: 401 });
+  try {
+    return Response.json(await listAgentResource("candidates", parseAgentFilters(request.nextUrl.searchParams), auth.permissions));
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/agent/inbox/[id]/approve/route.ts
+++ b/src/app/api/agent/inbox/[id]/approve/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { approveAgentSubmission } from "@/services/agent-api";
+import { requireAuth } from "@/services/auth";
+import { jsonError } from "../../../_utils";
+
+export const runtime = "nodejs";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+  if (!auth.valid) return Response.json({ error: auth.error }, { status: 401 });
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    return Response.json({ data: await approveAgentSubmission(id, body, auth) });
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/agent/inbox/[id]/comments/route.ts
+++ b/src/app/api/agent/inbox/[id]/comments/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest } from "next/server";
+import { commentAgentSubmission } from "@/services/agent-api";
+import { requireAuth } from "@/services/auth";
+import { jsonError } from "../../../_utils";
+
+export const runtime = "nodejs";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+  if (!auth.valid) return Response.json({ error: auth.error }, { status: 401 });
+  try {
+    const { id } = await params;
+    return Response.json({ data: await commentAgentSubmission(id, await request.json(), auth) }, { status: 201 });
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/agent/inbox/[id]/reject/route.ts
+++ b/src/app/api/agent/inbox/[id]/reject/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { rejectAgentSubmission } from "@/services/agent-api";
+import { requireAuth } from "@/services/auth";
+import { jsonError } from "../../../_utils";
+
+export const runtime = "nodejs";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+  if (!auth.valid) return Response.json({ error: auth.error }, { status: 401 });
+  try {
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    return Response.json({ data: await rejectAgentSubmission(id, body, auth) });
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/agent/inbox/[id]/route.ts
+++ b/src/app/api/agent/inbox/[id]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { getAgentSubmission } from "@/services/agent-api";
+import { requireAuth } from "@/services/auth";
+import { jsonError } from "../../_utils";
+
+export const runtime = "nodejs";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(request: NextRequest, { params }: Params) {
+  const auth = await requireAuth(request, "admin:read");
+  if (auth instanceof Response) return auth;
+  try {
+    const { id } = await params;
+    const data = await getAgentSubmission(id);
+    if (!data) return Response.json({ error: "Submission not found" }, { status: 404 });
+    return Response.json({ data });
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/agent/inbox/route.ts
+++ b/src/app/api/agent/inbox/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { listAgentInbox, parseAgentFilters } from "@/services/agent-api";
+import { requireAuth } from "@/services/auth";
+import { jsonError } from "../_utils";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request, "admin:read");
+  if (auth instanceof Response) return auth;
+  try {
+    return Response.json(await listAgentInbox(parseAgentFilters(request.nextUrl.searchParams)));
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/agent/invites/route.ts
+++ b/src/app/api/agent/invites/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+import { createAgentInvite } from "@/services/agent-api";
+import { requireAuth } from "@/services/auth";
+import { jsonError } from "../_utils";
+
+export const runtime = "nodejs";
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+  if (!auth.valid) return Response.json({ error: auth.error }, { status: 401 });
+  try {
+    return Response.json({ data: await createAgentInvite(await request.json(), auth) }, { status: 201 });
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/agent/jobs/route.ts
+++ b/src/app/api/agent/jobs/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+import { listAgentResource, parseAgentFilters } from "@/services/agent-api";
+import { requireAuth } from "@/services/auth";
+import { jsonError } from "../_utils";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request, "agent:read");
+  if (auth instanceof Response) return auth;
+  if (!auth.valid) return Response.json({ error: auth.error }, { status: 401 });
+  try {
+    return Response.json(await listAgentResource("jobs", parseAgentFilters(request.nextUrl.searchParams), auth.permissions));
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/agent/news/route.ts
+++ b/src/app/api/agent/news/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+import { listAgentResource, parseAgentFilters } from "@/services/agent-api";
+import { requireAuth } from "@/services/auth";
+import { jsonError } from "../_utils";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request, "agent:read");
+  if (auth instanceof Response) return auth;
+  if (!auth.valid) return Response.json({ error: auth.error }, { status: 401 });
+  try {
+    return Response.json(await listAgentResource("news", parseAgentFilters(request.nextUrl.searchParams), auth.permissions));
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/agent/query/route.ts
+++ b/src/app/api/agent/query/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+import { runAgentQuery } from "@/services/agent-api";
+import { requireAuth } from "@/services/auth";
+import { jsonError } from "../_utils";
+
+export const runtime = "nodejs";
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request, "agent:read");
+  if (auth instanceof Response) return auth;
+  if (!auth.valid) return Response.json({ error: auth.error }, { status: 401 });
+  try {
+    return Response.json(await runAgentQuery(await request.json(), auth.permissions));
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/agent/schema/route.ts
+++ b/src/app/api/agent/schema/route.ts
@@ -1,0 +1,7 @@
+import { buildAgentOpenApiDocument } from "@/services/agent-api";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return Response.json(buildAgentOpenApiDocument());
+}

--- a/src/app/api/agent/search/refresh/route.ts
+++ b/src/app/api/agent/search/refresh/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from "next/server";
+import { refreshAgentSearchDocuments } from "@/services/agent-api";
+import { requireAuth } from "@/services/auth";
+import { jsonError } from "../../_utils";
+
+export const runtime = "nodejs";
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request, "admin:write");
+  if (auth instanceof Response) return auth;
+  try {
+    const body = await request.json().catch(() => ({}));
+    const resource = typeof body.resource === "string" ? body.resource : undefined;
+    return Response.json({ data: await refreshAgentSearchDocuments(resource) });
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/agent/submit/[kind]/route.ts
+++ b/src/app/api/agent/submit/[kind]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { createAgentSubmissionFromRequest } from "@/services/agent-api";
+import { jsonError, optionalAuth } from "../../_utils";
+
+export const runtime = "nodejs";
+
+type Params = { params: Promise<{ kind: string }> };
+
+export async function POST(request: NextRequest, { params }: Params) {
+  try {
+    const { kind } = await params;
+    const auth = await optionalAuth(request);
+    if (auth && !auth.valid) {
+      // The service will still try bearer submit-token auth for structured submissions.
+      return Response.json({ data: await createAgentSubmissionFromRequest(kind, request, auth) }, { status: 201 });
+    }
+    return Response.json({ data: await createAgentSubmissionFromRequest(kind, request, auth) }, { status: 201 });
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/db/schema/agent.ts
+++ b/src/db/schema/agent.ts
@@ -1,0 +1,147 @@
+import { createId } from "@paralleldrive/cuid2";
+import { boolean, index, integer, jsonb, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+
+export const agentSubmitTokens = pgTable(
+  "agent_submit_tokens",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    tokenHash: text("token_hash").notNull(),
+    label: text("label").notNull(),
+    submitterName: text("submitter_name"),
+    submitterEmail: text("submitter_email"),
+    allowedKinds: text("allowed_kinds").array().notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+    maxUses: integer("max_uses"),
+    useCount: integer("use_count").notNull().default(0),
+    active: boolean("active").notNull().default(true),
+    createdByKeyId: text("created_by_key_id"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("agent_submit_tokens_hash_uidx").on(table.tokenHash),
+    index("agent_submit_tokens_active_idx").on(table.active),
+    index("agent_submit_tokens_expires_idx").on(table.expiresAt),
+  ],
+);
+
+export const agentInboxSubmissions = pgTable(
+  "agent_inbox_submissions",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    kind: text("kind").notNull(), // job | candidate | message
+    status: text("status").notNull().default("pending"), // pending | approved | rejected
+    priority: text("priority").notNull().default("normal"), // low | normal | high
+    submitterType: text("submitter_type").notNull().default("public"), // public | token | api_key
+    submitterName: text("submitter_name"),
+    submitterEmail: text("submitter_email"),
+    submitTokenId: text("submit_token_id"),
+    createdByKeyId: text("created_by_key_id"),
+    title: text("title"),
+    originalPayload: jsonb("original_payload").notNull(),
+    currentPayload: jsonb("current_payload").notNull(),
+    liveRecordId: text("live_record_id"),
+    approvedByKeyId: text("approved_by_key_id"),
+    approvedByName: text("approved_by_name"),
+    approvedAt: timestamp("approved_at"),
+    rejectedByKeyId: text("rejected_by_key_id"),
+    rejectedByName: text("rejected_by_name"),
+    rejectedAt: timestamp("rejected_at"),
+    rejectionReason: text("rejection_reason"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("agent_inbox_submissions_status_idx").on(table.status),
+    index("agent_inbox_submissions_kind_idx").on(table.kind),
+    index("agent_inbox_submissions_priority_idx").on(table.priority),
+    index("agent_inbox_submissions_created_idx").on(table.createdAt),
+  ],
+);
+
+export const agentInboxComments = pgTable(
+  "agent_inbox_comments",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    submissionId: text("submission_id").notNull(),
+    authorType: text("author_type").notNull(), // public | submitter | api_key | admin
+    authorName: text("author_name"),
+    authorKeyId: text("author_key_id"),
+    body: text("body").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [index("agent_inbox_comments_submission_idx").on(table.submissionId)],
+);
+
+export const agentInboxVersions = pgTable(
+  "agent_inbox_versions",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    submissionId: text("submission_id").notNull(),
+    payload: jsonb("payload").notNull(),
+    changedByKeyId: text("changed_by_key_id"),
+    changedByName: text("changed_by_name"),
+    changeNote: text("change_note"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [index("agent_inbox_versions_submission_idx").on(table.submissionId)],
+);
+
+export const agentAuditEvents = pgTable(
+  "agent_audit_events",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    actorType: text("actor_type").notNull(), // public | submit_token | api_key | admin | system
+    actorKeyId: text("actor_key_id"),
+    actorName: text("actor_name"),
+    submitTokenId: text("submit_token_id"),
+    action: text("action").notNull(),
+    targetType: text("target_type").notNull(),
+    targetId: text("target_id"),
+    metadata: jsonb("metadata"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("agent_audit_events_target_idx").on(table.targetType, table.targetId),
+    index("agent_audit_events_action_idx").on(table.action),
+  ],
+);
+
+export const agentSearchDocuments = pgTable(
+  "agent_search_documents",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createId()),
+    resourceType: text("resource_type").notNull(), // jobs | candidates | news | investments | blog | affiliations
+    resourceId: text("resource_id").notNull(),
+    searchText: text("search_text").notNull(),
+    embeddingProvider: text("embedding_provider"),
+    embeddingModel: text("embedding_model"),
+    embeddingJson: jsonb("embedding_json"),
+    indexedAt: timestamp("indexed_at").defaultNow().notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("agent_search_documents_resource_uidx").on(table.resourceType, table.resourceId),
+    index("agent_search_documents_resource_type_idx").on(table.resourceType),
+  ],
+);
+
+export type AgentSubmitToken = typeof agentSubmitTokens.$inferSelect;
+export type NewAgentSubmitToken = typeof agentSubmitTokens.$inferInsert;
+export type AgentInboxSubmission = typeof agentInboxSubmissions.$inferSelect;
+export type NewAgentInboxSubmission = typeof agentInboxSubmissions.$inferInsert;
+export type AgentInboxComment = typeof agentInboxComments.$inferSelect;
+export type NewAgentInboxComment = typeof agentInboxComments.$inferInsert;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -5,3 +5,4 @@ export * from "./investments";
 export * from "./blog";
 export * from "./misc";
 export * from "./newsletter";
+export * from "./agent";

--- a/src/lib/r2-rehost.ts
+++ b/src/lib/r2-rehost.ts
@@ -100,8 +100,9 @@ async function objectExists(client: S3Client, key: string): Promise<boolean> {
   try {
     await client.send(new HeadObjectCommand({ Bucket: BUCKET, Key: key }));
     return true;
-  } catch (err: any) {
-    if (err?.$metadata?.httpStatusCode === 404 || err?.name === "NotFound") return false;
+  } catch (err: unknown) {
+    const error = err as { $metadata?: { httpStatusCode?: number }; name?: string };
+    if (error.$metadata?.httpStatusCode === 404 || error.name === "NotFound") return false;
     throw err;
   }
 }

--- a/src/services/agent-api.ts
+++ b/src/services/agent-api.ts
@@ -1,0 +1,616 @@
+import { createHash, randomBytes } from "node:crypto";
+import { and, arrayOverlaps, desc, eq, gte, ilike, or, SQL } from "drizzle-orm";
+import {
+  agentAuditEvents,
+  agentInboxComments,
+  agentInboxSubmissions,
+  agentInboxVersions,
+  agentSubmitTokens,
+  announcements,
+  blogPosts,
+  candidates,
+  db,
+  investments,
+  jobs,
+  curatedLinks,
+  affiliations,
+  type NewCandidate,
+  type NewJob,
+} from "@/db";
+import type { AuthResult } from "@/services/auth";
+import { extractRequestToken } from "@/services/auth";
+
+type JsonObject = Record<string, unknown>;
+type AgentKind = "job" | "candidate" | "message";
+type AgentResource = "news" | "jobs" | "candidates" | "investments" | "blog" | "affiliations";
+type AgentActor =
+  | { type: "public"; priority: "low"; permissions: string[] }
+  | { type: "api_key"; keyId: string; name: string; permissions: string[]; priority: "normal" }
+  | {
+      type: "submit_token";
+      tokenId: string;
+      submitterName: string | null;
+      submitterEmail: string | null;
+      allowedKinds: string[];
+      permissions: string[];
+      priority: "normal";
+    };
+
+const SENSITIVE_FIELDS: Record<string, string[]> = {
+  candidates: ["email", "telegram", "calendly"],
+  newsletter_subscribers: ["email"],
+  newsletter_campaign_recipients: ["email"],
+  newsletter_send_events: ["payload"],
+  newsletter_unsub_tokens: ["token"],
+  api_keys: ["key"],
+};
+
+const ALLOWED_QUERY_FIELDS: Record<AgentResource, string[]> = {
+  jobs: ["id", "title", "company", "location", "remote", "type", "department", "tags", "category", "featured", "createdAt"],
+  candidates: ["id", "name", "title", "location", "skills", "availability", "featured", "createdAt"],
+  news: ["id", "title", "source", "company", "category", "date", "featured", "relevance"],
+  investments: ["id", "title", "tier", "featured", "status", "categories", "createdAt"],
+  blog: ["slug", "title", "date", "published", "relevance", "source"],
+  affiliations: ["id", "title", "role", "dateBegin", "dateEnd", "xHandles"],
+};
+
+const ALLOWED_OPERATORS = new Set(["eq", "contains", "overlap", "gte", "lte", "ilike"]);
+const AGENT_KINDS: AgentKind[] = ["job", "candidate", "message"];
+
+export function buildAgentOpenApiDocument() {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "dcbuilder.dev Agent API",
+      version: "0.1.0",
+    },
+    paths: {
+      "/api/agent/schema": { get: { summary: "Fetch this OpenAPI document" } },
+      "/api/agent/news": { get: { summary: "List redacted news" } },
+      "/api/agent/jobs": { get: { summary: "List redacted jobs" } },
+      "/api/agent/candidates": { get: { summary: "List redacted candidates" } },
+      "/api/agent/query": { post: { summary: "Run an allowlisted query DSL" } },
+      "/api/agent/inbox": { get: { summary: "List approval inbox submissions" } },
+      "/api/agent/inbox/{id}": { get: { summary: "Show one approval inbox submission" } },
+      "/api/agent/inbox/{id}/comments": { post: { summary: "Comment on an inbox submission" } },
+      "/api/agent/inbox/{id}/approve": { post: { summary: "Approve and publish a submission" } },
+      "/api/agent/inbox/{id}/reject": { post: { summary: "Reject a submission" } },
+      "/api/agent/submit/{kind}": { post: { summary: "Create a job, candidate, or message submission" } },
+      "/api/agent/invites": { post: { summary: "Create a scoped submit-token invite" } },
+      "/api/agent/search/refresh": { post: { summary: "Refresh semantic-search snapshots" } },
+    },
+    components: {
+      securitySchemes: {
+        bearerAgentToken: { type: "http", scheme: "bearer" },
+        apiKeyHeader: { type: "apiKey", in: "header", name: "x-api-key" },
+      },
+    },
+  };
+}
+
+export function parseAgentFilters(searchParams: URLSearchParams) {
+  const filters: JsonObject = {};
+  const limit = parseInt(searchParams.get("limit") || "50", 10);
+  const offset = parseInt(searchParams.get("offset") || "0", 10);
+
+  filters.limit = Number.isFinite(limit) && limit > 0 ? Math.min(limit, 200) : 50;
+  filters.offset = Number.isFinite(offset) && offset >= 0 ? offset : 0;
+
+  for (const key of ["q", "query", "since", "company", "category", "location", "availability", "status", "featured", "remote"]) {
+    const value = searchParams.get(key);
+    if (value === null || value === "") continue;
+    filters[key] = value === "true" ? true : value === "false" ? false : value;
+  }
+
+  const tags = [...searchParams.getAll("tag"), ...searchParams.getAll("tags")].filter(Boolean);
+  if (tags.length > 0) filters.tags = tags;
+
+  return filters;
+}
+
+export function validateAgentQuery(input: unknown) {
+  if (!input || typeof input !== "object") throw new Error("Query body must be an object");
+  const body = input as JsonObject;
+  const table = normalizeResource(String(body.table ?? body.resource ?? ""));
+  if (!table) throw new Error("Unsupported table/resource");
+
+  const where = Array.isArray(body.where) ? body.where : [];
+  for (const condition of where) {
+    if (!condition || typeof condition !== "object") throw new Error("Invalid where condition");
+    const { field, op } = condition as JsonObject;
+    if (typeof field !== "string" || !ALLOWED_QUERY_FIELDS[table].includes(field)) {
+      throw new Error(`Unsupported field for ${table}: ${String(field)}`);
+    }
+    if (typeof op !== "string" || !ALLOWED_OPERATORS.has(op)) {
+      throw new Error(`Unsupported operator: ${String(op)}`);
+    }
+  }
+
+  return { ...body, table, filters: (body.filters && typeof body.filters === "object" ? body.filters : {}) as JsonObject };
+}
+
+export function redactAgentRecord(resource: string, record: JsonObject, permissions: string[]) {
+  if (canReadSensitive(permissions)) return record;
+  const redacted = { ...record };
+  for (const field of SENSITIVE_FIELDS[resource] ?? []) {
+    if (field in redacted) redacted[field] = null;
+  }
+  return redacted;
+}
+
+export async function listAgentResource(resource: AgentResource, filters: JsonObject, permissions: string[] = []) {
+  if (resource === "news") return listAgentNews(filters, permissions);
+  if (resource === "jobs") return listAgentJobs(filters, permissions);
+  if (resource === "candidates") return listAgentCandidates(filters, permissions);
+  if (resource === "investments") return listAgentInvestments(filters, permissions);
+  if (resource === "blog") return listAgentBlog(filters, permissions);
+  if (resource === "affiliations") return listAgentAffiliations(filters, permissions);
+  throw new Error("Unsupported resource");
+}
+
+export async function runAgentQuery(input: unknown, permissions: string[] = []) {
+  const query = validateAgentQuery(input);
+  return listAgentResource(query.table as AgentResource, query.filters as JsonObject | undefined ?? {}, permissions);
+}
+
+export async function listAgentInbox(filters: JsonObject = {}) {
+  const conditions: SQL[] = [];
+  if (typeof filters.status === "string") conditions.push(eq(agentInboxSubmissions.status, filters.status));
+  if (typeof filters.kind === "string") conditions.push(eq(agentInboxSubmissions.kind, filters.kind));
+
+  const limit = toLimit(filters.limit);
+  const rows = await db
+    .select()
+    .from(agentInboxSubmissions)
+    .where(conditions.length ? and(...conditions) : undefined)
+    .orderBy(desc(agentInboxSubmissions.createdAt))
+    .limit(limit)
+    .offset(toOffset(filters.offset));
+  return { data: rows, meta: { limit } };
+}
+
+export async function getAgentSubmission(id: string) {
+  const [submission] = await db
+    .select()
+    .from(agentInboxSubmissions)
+    .where(eq(agentInboxSubmissions.id, id))
+    .limit(1);
+  if (!submission) return null;
+  const comments = await db
+    .select()
+    .from(agentInboxComments)
+    .where(eq(agentInboxComments.submissionId, id))
+    .orderBy(desc(agentInboxComments.createdAt));
+  return { ...submission, comments };
+}
+
+export async function createAgentSubmissionFromRequest(kind: string, request: Request, auth?: AuthResult) {
+  const normalizedKind = normalizeKind(kind);
+  if (!normalizedKind) throw new AgentHttpError(400, "Unsupported submission kind");
+  const payload = await request.json().catch(() => ({}));
+  const actor = await resolveSubmissionActor(request, auth, normalizedKind);
+  return createAgentSubmission(normalizedKind, payload, actor);
+}
+
+export async function createAgentSubmission(kind: AgentKind, payload: unknown, actor: AgentActor) {
+  const now = new Date();
+  const title = inferSubmissionTitle(kind, payload);
+  const [submission] = await db
+    .insert(agentInboxSubmissions)
+    .values({
+      kind,
+      status: "pending",
+      priority: actor.priority,
+      submitterType: actor.type,
+      submitterName: actor.type === "submit_token" ? actor.submitterName : actor.type === "api_key" ? actor.name : null,
+      submitterEmail: actor.type === "submit_token" ? actor.submitterEmail : null,
+      submitTokenId: actor.type === "submit_token" ? actor.tokenId : null,
+      createdByKeyId: actor.type === "api_key" ? actor.keyId : null,
+      title,
+      originalPayload: payload,
+      currentPayload: payload,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+
+  await auditAgentEvent({
+    actor,
+    action: "submission.created",
+    targetType: "agent_inbox_submission",
+    targetId: submission.id,
+    metadata: { kind },
+  });
+  await notifyAgentSubmission(submission);
+  return submission;
+}
+
+export async function commentAgentSubmission(id: string, body: unknown, auth: Extract<AuthResult, { valid: true }>) {
+  const commentBody = typeof body === "string" ? body : String((body as JsonObject)?.body ?? "");
+  if (!commentBody.trim()) throw new AgentHttpError(400, "Comment body is required");
+  const [comment] = await db
+    .insert(agentInboxComments)
+    .values({
+      submissionId: id,
+      authorType: "admin",
+      authorName: auth.name,
+      authorKeyId: auth.keyId,
+      body: commentBody,
+    })
+    .returning();
+  await auditAgentEvent({
+    actor: apiKeyActor(auth),
+    action: "submission.comment.created",
+    targetType: "agent_inbox_submission",
+    targetId: id,
+    metadata: { commentId: comment.id },
+  });
+  return comment;
+}
+
+export async function approveAgentSubmission(id: string, input: unknown, auth?: Extract<AuthResult, { valid: true }>) {
+  const [submission] = await db
+    .select()
+    .from(agentInboxSubmissions)
+    .where(eq(agentInboxSubmissions.id, id))
+    .limit(1);
+  if (!submission) throw new AgentHttpError(404, "Submission not found");
+  if (submission.status !== "pending") throw new AgentHttpError(409, "Only pending submissions can be approved");
+
+  const body = (input && typeof input === "object" ? input : {}) as JsonObject;
+  const finalPayload = body.payload && typeof body.payload === "object" ? body.payload : submission.currentPayload;
+  const liveRecord = await publishApprovedSubmission(submission.kind, finalPayload as JsonObject);
+  const liveRecordId = typeof (liveRecord as JsonObject).id === "string" ? String((liveRecord as JsonObject).id) : null;
+  const now = new Date();
+
+  await db.insert(agentInboxVersions).values({
+    submissionId: id,
+    payload: finalPayload,
+    changedByKeyId: auth?.keyId,
+    changedByName: auth?.name,
+    changeNote: typeof body.note === "string" ? body.note : "Approved",
+  });
+
+  const [updated] = await db
+    .update(agentInboxSubmissions)
+    .set({
+      status: "approved",
+      currentPayload: finalPayload,
+      liveRecordId,
+      approvedByKeyId: auth?.keyId,
+      approvedByName: auth?.name,
+      approvedAt: now,
+      updatedAt: now,
+    })
+    .where(eq(agentInboxSubmissions.id, id))
+    .returning();
+
+  await auditAgentEvent({
+    actor: auth ? apiKeyActor(auth) : { type: "public", priority: "low", permissions: [] },
+    action: "submission.approved",
+    targetType: "agent_inbox_submission",
+    targetId: id,
+    metadata: { liveRecordId: updated.liveRecordId, kind: submission.kind },
+  });
+  return updated;
+}
+
+export async function rejectAgentSubmission(id: string, input: unknown, auth: Extract<AuthResult, { valid: true }>) {
+  const reason = input && typeof input === "object" && typeof (input as JsonObject).reason === "string"
+    ? String((input as JsonObject).reason)
+    : null;
+  const [updated] = await db
+    .update(agentInboxSubmissions)
+    .set({
+      status: "rejected",
+      rejectedByKeyId: auth.keyId,
+      rejectedByName: auth.name,
+      rejectedAt: new Date(),
+      rejectionReason: reason,
+      updatedAt: new Date(),
+    })
+    .where(eq(agentInboxSubmissions.id, id))
+    .returning();
+  if (!updated) throw new AgentHttpError(404, "Submission not found");
+  await auditAgentEvent({
+    actor: apiKeyActor(auth),
+    action: "submission.rejected",
+    targetType: "agent_inbox_submission",
+    targetId: id,
+    metadata: { reason },
+  });
+  return updated;
+}
+
+export async function createAgentInvite(input: unknown, auth: Extract<AuthResult, { valid: true }>) {
+  const invite = parseAgentInviteInput(input);
+  const token = randomBytes(24).toString("base64url");
+  const [row] = await db
+    .insert(agentSubmitTokens)
+    .values({
+      tokenHash: hashToken(token),
+      label: invite.label,
+      submitterName: invite.submitterName,
+      submitterEmail: invite.submitterEmail,
+      allowedKinds: invite.allowedKinds,
+      expiresAt: invite.expiresAt,
+      maxUses: invite.maxUses,
+      createdByKeyId: auth.keyId,
+    })
+    .returning();
+  await auditAgentEvent({
+    actor: apiKeyActor(auth),
+    action: "submit_token.created",
+    targetType: "agent_submit_token",
+    targetId: row.id,
+    metadata: { allowedKinds: invite.allowedKinds, expiresAt: invite.expiresAt.toISOString(), maxUses: invite.maxUses },
+  });
+  return {
+    ...row,
+    token,
+    url: `/agent/submit?token=${encodeURIComponent(token)}`,
+  };
+}
+
+export function parseAgentInviteInput(input: unknown) {
+  const body = input && typeof input === "object" ? (input as JsonObject) : {};
+  const rawKinds = Array.isArray(body.allowedKinds) ? body.allowedKinds : AGENT_KINDS;
+  const allowedKinds = rawKinds.map((kind) => normalizeKind(String(kind))).filter((kind): kind is AgentKind => Boolean(kind));
+  if (allowedKinds.length === 0) throw new AgentHttpError(400, "Invite requires at least one allowed submission kind");
+
+  const expiresInDays = clampInteger(body.expiresInDays, 30, 1, 365);
+  const maxUses = body.maxUses === undefined || body.maxUses === null
+    ? null
+    : clampInteger(body.maxUses, 1, 1, 1000);
+
+  return {
+    label: String(body.label ?? "Scoped submit token").slice(0, 160),
+    submitterName: typeof body.submitterName === "string" ? body.submitterName.slice(0, 160) : null,
+    submitterEmail: typeof body.submitterEmail === "string" ? body.submitterEmail.slice(0, 320) : null,
+    allowedKinds: [...new Set(allowedKinds)],
+    expiresAt: new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000),
+    maxUses,
+  };
+}
+
+export async function refreshAgentSearchDocuments(resource?: string) {
+  const indexedAt = new Date();
+  await auditAgentEvent({
+    actor: { type: "public", priority: "low", permissions: [] },
+    action: "search.refresh.requested",
+    targetType: "agent_search_documents",
+    metadata: { resource: resource ?? "all", embeddingProvider: process.env.AGENT_EMBEDDING_PROVIDER ?? null },
+  });
+  return {
+    ok: true,
+    indexedAt,
+    semanticEnabled: Boolean(process.env.AGENT_EMBEDDING_PROVIDER),
+    provider: process.env.AGENT_EMBEDDING_PROVIDER ?? null,
+  };
+}
+
+export class AgentHttpError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AgentHttpError";
+  }
+}
+
+async function listAgentJobs(filters: JsonObject, permissions: string[]) {
+  const conditions: SQL[] = [];
+  const text = String(filters.q ?? filters.query ?? "").trim();
+  if (text) conditions.push(or(ilike(jobs.title, `%${text}%`), ilike(jobs.company, `%${text}%`), ilike(jobs.description, `%${text}%`))!);
+  if (typeof filters.company === "string") conditions.push(eq(jobs.company, filters.company));
+  if (typeof filters.category === "string") conditions.push(eq(jobs.category, filters.category));
+  if (typeof filters.remote === "boolean") conditions.push(eq(jobs.remote, filters.remote ? "Remote" : "On-site"));
+  if (Array.isArray(filters.tags) && filters.tags.length) conditions.push(arrayOverlaps(jobs.tags, filters.tags.map(String)));
+  const rows = await db.select().from(jobs).where(conditions.length ? and(...conditions) : undefined).orderBy(desc(jobs.featured), desc(jobs.createdAt)).limit(toLimit(filters.limit)).offset(toOffset(filters.offset));
+  return { data: rows.map((row) => redactAgentRecord("jobs", row as JsonObject, permissions)), meta: { limit: toLimit(filters.limit), semantic: semanticMeta() } };
+}
+
+async function listAgentCandidates(filters: JsonObject, permissions: string[]) {
+  const conditions: SQL[] = [];
+  const text = String(filters.q ?? filters.query ?? "").trim();
+  if (text) conditions.push(or(ilike(candidates.name, `%${text}%`), ilike(candidates.title, `%${text}%`), ilike(candidates.summary, `%${text}%`))!);
+  if (typeof filters.location === "string") conditions.push(ilike(candidates.location, `%${filters.location}%`));
+  if (typeof filters.availability === "string") conditions.push(eq(candidates.availability, filters.availability));
+  if (Array.isArray(filters.tags) && filters.tags.length) conditions.push(arrayOverlaps(candidates.skills, filters.tags.map(String)));
+  const rows = await db.select().from(candidates).where(conditions.length ? and(...conditions) : undefined).orderBy(desc(candidates.featured), desc(candidates.createdAt)).limit(toLimit(filters.limit)).offset(toOffset(filters.offset));
+  return { data: rows.map((row) => redactAgentRecord("candidates", row as JsonObject, permissions)), meta: { limit: toLimit(filters.limit), semantic: semanticMeta() } };
+}
+
+async function listAgentNews(filters: JsonObject, permissions: string[]) {
+  const since = parseSince(filters.since);
+  const curatedConditions: SQL[] = [];
+  const announcementConditions: SQL[] = [];
+  if (since) {
+    curatedConditions.push(gte(curatedLinks.date, since));
+    announcementConditions.push(gte(announcements.date, since));
+  }
+  if (typeof filters.category === "string") {
+    curatedConditions.push(eq(curatedLinks.category, filters.category));
+    announcementConditions.push(eq(announcements.category, filters.category));
+  }
+  const [curated, announce] = await Promise.all([
+    db.select().from(curatedLinks).where(curatedConditions.length ? and(...curatedConditions) : undefined).orderBy(desc(curatedLinks.date)).limit(toLimit(filters.limit)),
+    db.select().from(announcements).where(announcementConditions.length ? and(...announcementConditions) : undefined).orderBy(desc(announcements.date)).limit(toLimit(filters.limit)),
+  ]);
+  const data = [
+    ...curated.map((row) => ({ ...row, type: "curated" })),
+    ...announce.map((row) => ({ ...row, type: "announcement" })),
+  ]
+    .sort((a, b) => Number(new Date((b as { date: Date }).date)) - Number(new Date((a as { date: Date }).date)))
+    .slice(0, toLimit(filters.limit))
+    .map((row) => redactAgentRecord("news", row as JsonObject, permissions));
+  return { data, meta: { limit: toLimit(filters.limit), semantic: semanticMeta() } };
+}
+
+async function listAgentInvestments(filters: JsonObject, permissions: string[]) {
+  const rows = await db.select().from(investments).orderBy(desc(investments.featured), investments.title).limit(toLimit(filters.limit)).offset(toOffset(filters.offset));
+  return { data: rows.map((row) => redactAgentRecord("investments", row as JsonObject, permissions)), meta: { limit: toLimit(filters.limit) } };
+}
+
+async function listAgentBlog(filters: JsonObject, permissions: string[]) {
+  const rows = await db.select().from(blogPosts).where(eq(blogPosts.published, true)).orderBy(desc(blogPosts.date)).limit(toLimit(filters.limit)).offset(toOffset(filters.offset));
+  return { data: rows.map((row) => redactAgentRecord("blog", row as JsonObject, permissions)), meta: { limit: toLimit(filters.limit) } };
+}
+
+async function listAgentAffiliations(filters: JsonObject, permissions: string[]) {
+  const rows = await db.select().from(affiliations).orderBy(desc(affiliations.createdAt)).limit(toLimit(filters.limit)).offset(toOffset(filters.offset));
+  return { data: rows.map((row) => redactAgentRecord("affiliations", row as JsonObject, permissions)), meta: { limit: toLimit(filters.limit) } };
+}
+
+async function publishApprovedSubmission(kind: string, payload: JsonObject) {
+  if (kind === "job") {
+    validateJobPayload(payload);
+    const [row] = await db.insert(jobs).values(payload as NewJob).returning();
+    return row;
+  }
+  if (kind === "candidate") {
+    if (!payload.name) throw new AgentHttpError(400, "Candidate submissions require name");
+    const [row] = await db.insert(candidates).values(payload as NewCandidate).returning();
+    return row;
+  }
+  return { id: null, kind: "message" };
+}
+
+function validateJobPayload(payload: JsonObject) {
+  for (const field of ["title", "company", "link", "category"]) {
+    if (!payload[field]) throw new AgentHttpError(400, `Job submissions require ${field}`);
+  }
+}
+
+async function resolveSubmissionActor(request: Request, auth: AuthResult | undefined, kind: AgentKind): Promise<AgentActor> {
+  if (auth?.valid) return apiKeyActor(auth);
+  if (kind === "message" && !extractRequestToken(request)) {
+    return { type: "public", priority: "low", permissions: [] };
+  }
+
+  const token = extractRequestToken(request);
+  if (!token) throw new AgentHttpError(401, "Missing submit token");
+  const [submitToken] = await db.select().from(agentSubmitTokens).where(eq(agentSubmitTokens.tokenHash, hashToken(token))).limit(1);
+  if (!submitToken || !submitToken.active || submitToken.expiresAt < new Date()) {
+    throw new AgentHttpError(401, "Invalid or expired submit token");
+  }
+  if (submitToken.maxUses !== null && submitToken.useCount >= submitToken.maxUses) {
+    throw new AgentHttpError(403, "Submit token use limit reached");
+  }
+  if (!submitToken.allowedKinds.includes(kind)) {
+    throw new AgentHttpError(403, `Submit token cannot create ${kind} submissions`);
+  }
+  await db.update(agentSubmitTokens).set({ useCount: Number(submitToken.useCount || 0) + 1, updatedAt: new Date() }).where(eq(agentSubmitTokens.id, submitToken.id));
+  return {
+    type: "submit_token",
+    tokenId: submitToken.id,
+    submitterName: submitToken.submitterName,
+    submitterEmail: submitToken.submitterEmail,
+    allowedKinds: submitToken.allowedKinds,
+    permissions: [],
+    priority: "normal",
+  };
+}
+
+async function auditAgentEvent(input: {
+  actor: AgentActor;
+  action: string;
+  targetType: string;
+  targetId?: string;
+  metadata?: unknown;
+}) {
+  await db.insert(agentAuditEvents).values({
+    actorType: input.actor.type === "api_key" ? "api_key" : input.actor.type === "submit_token" ? "submit_token" : "public",
+    actorKeyId: input.actor.type === "api_key" ? input.actor.keyId : null,
+    actorName: input.actor.type === "api_key" ? input.actor.name : input.actor.type === "submit_token" ? input.actor.submitterName : null,
+    submitTokenId: input.actor.type === "submit_token" ? input.actor.tokenId : null,
+    action: input.action,
+    targetType: input.targetType,
+    targetId: input.targetId,
+    metadata: input.metadata,
+  });
+}
+
+async function notifyAgentSubmission(submission: { id: string; kind: string; title: string | null; priority: string }) {
+  const to = process.env.AGENT_INBOX_NOTIFY_EMAIL || process.env.NEWSLETTER_REPLY_TO;
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.NEWSLETTER_FROM_EMAIL;
+  if (!to || !apiKey || !from) return;
+  await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      from,
+      to: [to],
+      subject: `New ${submission.kind} inbox submission`,
+      html: `<p>New ${submission.priority} priority submission: ${escapeHtml(submission.title || submission.id)}</p>`,
+      text: `New ${submission.priority} priority ${submission.kind} submission: ${submission.title || submission.id}`,
+    }),
+  }).catch((error) => console.warn("[agent-inbox] notification failed", error));
+}
+
+function apiKeyActor(auth: Extract<AuthResult, { valid: true }>): AgentActor {
+  return { type: "api_key", keyId: auth.keyId, name: auth.name, permissions: auth.permissions ?? [], priority: "normal" };
+}
+
+function canReadSensitive(permissions: string[]) {
+  return permissions.includes("*") || permissions.includes("admin:read") || permissions.includes("agent:sensitive");
+}
+
+function normalizeKind(kind: string): AgentKind | null {
+  return AGENT_KINDS.includes(kind as AgentKind) ? (kind as AgentKind) : null;
+}
+
+function normalizeResource(value: string): AgentResource | null {
+  const resource = value === "curated" || value === "announcements" ? "news" : value;
+  return ["news", "jobs", "candidates", "investments", "blog", "affiliations"].includes(resource)
+    ? (resource as AgentResource)
+    : null;
+}
+
+function inferSubmissionTitle(kind: AgentKind, payload: unknown) {
+  if (!payload || typeof payload !== "object") return kind;
+  const body = payload as JsonObject;
+  return String(body.title ?? body.name ?? body.subject ?? body.message ?? kind).slice(0, 180);
+}
+
+function toLimit(value: unknown) {
+  const parsed = Number(value ?? 50);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 200) : 50;
+}
+
+function toOffset(value: unknown) {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function clampInteger(value: unknown, fallback: number, min: number, max: number) {
+  const parsed = Number(value ?? fallback);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(parsed)));
+}
+
+function parseSince(value: unknown) {
+  if (typeof value !== "string") return null;
+  const match = value.match(/^(\d+)d$/);
+  if (match) return new Date(Date.now() - Number(match[1]) * 24 * 60 * 60 * 1000);
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function semanticMeta() {
+  return {
+    enabled: Boolean(process.env.AGENT_EMBEDDING_PROVIDER),
+    provider: process.env.AGENT_EMBEDDING_PROVIDER ?? null,
+    fallback: process.env.AGENT_EMBEDDING_PROVIDER ? null : "text",
+  };
+}
+
+function hashToken(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function escapeHtml(value: string) {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -30,14 +30,20 @@ export function parsePaginationParams(
 }
 
 export type AuthResult =
-  | { valid: true; keyId: string; name: string }
+  | { valid: true; keyId: string; name: string; permissions: string[] }
   | { valid: false; error: string };
+
+export function extractRequestToken(request: NextRequest | Request): string | null {
+  const bearerToken = request.headers.get("authorization")?.replace(/^Bearer\s+/i, "").trim();
+  const apiKey = request.headers.get("x-api-key")?.trim();
+  return bearerToken || apiKey || null;
+}
 
 export async function validateApiKey(
   request: NextRequest,
   requiredPermission?: string
 ): Promise<AuthResult> {
-  const apiKey = request.headers.get("x-api-key");
+  const apiKey = extractRequestToken(request);
 
   if (!apiKey) {
     return { valid: false, error: "Missing API key" };
@@ -79,7 +85,7 @@ export async function validateApiKey(
       console.warn("[api-auth] Failed to update API key lastUsedAt:", error);
     });
 
-  return { valid: true, keyId: key.id, name: key.name };
+  return { valid: true, keyId: key.id, name: key.name, permissions: key.permissions ?? [] };
 }
 
 // Helper to create unauthorized response

--- a/tests/agent-routes.test.ts
+++ b/tests/agent-routes.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+describe("agent API routes", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("POST /api/agent/inbox/[id]/approve requires admin write and publishes through the agent service", async () => {
+    let requestedPermission: string | undefined;
+    let approvedId: string | undefined;
+
+    mock.module("@/services/auth", () => ({
+      ...authMockHelpers(),
+      requireAuth: async (_request: Request, permission?: string) => {
+        requestedPermission = permission;
+        return { valid: true as const, keyId: "admin_key", name: "Admin", permissions: ["*"] };
+      },
+    }));
+    mock.module("@/services/agent-api", () => ({
+      ...agentApiMockHelpers(),
+      approveAgentSubmission: async (id: string, input: unknown) => {
+        approvedId = id;
+        return {
+          id,
+          status: "approved",
+          liveRecordId: "job_123",
+          input,
+        };
+      },
+    }));
+
+    const { POST } = await import("../src/app/api/agent/inbox/[id]/approve/route");
+    const response = await POST(
+      new Request("https://dcbuilder.dev/api/agent/inbox/sub_1/approve", {
+        method: "POST",
+        body: JSON.stringify({ note: "ship it" }),
+      }) as never,
+      { params: Promise.resolve({ id: "sub_1" }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(requestedPermission).toBe("admin:write");
+    expect(approvedId).toBe("sub_1");
+    expect(body.data.liveRecordId).toBe("job_123");
+  });
+
+  test("POST /api/agent/submit/[kind] allows unauthenticated public general messages only", async () => {
+    const submissions: unknown[] = [];
+
+    mock.module("@/services/agent-api", () => ({
+      ...agentApiMockHelpers(),
+      createAgentSubmissionFromRequest: async (kind: string, request: Request, actor: unknown) => {
+        submissions.push({ kind, actor, body: await request.json() });
+        return { id: "sub_public", kind, priority: "low", status: "pending" };
+      },
+    }));
+
+    const { POST } = await import("../src/app/api/agent/submit/[kind]/route");
+    const response = await POST(
+      new Request("https://dcbuilder.dev/api/agent/submit/message", {
+        method: "POST",
+        body: JSON.stringify({ message: "hello" }),
+      }) as never,
+      { params: Promise.resolve({ kind: "message" }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data.priority).toBe("low");
+    expect(submissions).toHaveLength(1);
+  });
+});
+
+function authMockHelpers() {
+  return {
+    extractRequestToken: (request: Request) =>
+      request.headers.get("authorization")?.replace(/^Bearer\s+/i, "").trim() ||
+      request.headers.get("x-api-key") ||
+      null,
+    validateApiKey: async () => ({ valid: false as const, error: "Invalid API key" }),
+  };
+}
+
+function agentApiMockHelpers() {
+  class AgentHttpError extends Error {
+    constructor(
+      readonly status: number,
+      message: string,
+    ) {
+      super(message);
+    }
+  }
+
+  return {
+    AgentHttpError,
+    approveAgentSubmission: async () => ({}),
+    createAgentSubmissionFromRequest: async () => ({}),
+    buildAgentOpenApiDocument: () => ({
+      openapi: "3.1.0",
+      paths: {
+        "/api/agent/schema": { get: {} },
+        "/api/agent/news": { get: {} },
+        "/api/agent/jobs": { get: {} },
+        "/api/agent/candidates": { get: {} },
+        "/api/agent/query": { post: {} },
+        "/api/agent/inbox/{id}/approve": { post: {} },
+        "/api/agent/submit/{kind}": { post: {} },
+      },
+    }),
+    parseAgentFilters: (params: URLSearchParams) => ({
+      limit: Number(params.get("limit") || 50),
+      ...(params.get("remote") ? { remote: params.get("remote") === "true" } : {}),
+      ...(params.getAll("tag").length ? { tags: params.getAll("tag") } : {}),
+    }),
+    parseAgentInviteInput: () => ({
+      allowedKinds: ["candidate", "message"],
+      submitterName: "Partner Agent",
+      submitterEmail: "partner@example.com",
+      expiresAt: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+      maxUses: 5,
+    }),
+    redactAgentRecord: (resource: string, record: Record<string, unknown>, permissions: string[]) => {
+      if (permissions.includes("agent:sensitive")) return record;
+      if (resource !== "candidates") return record;
+      return { ...record, email: null, telegram: null, calendly: null };
+    },
+    validateAgentQuery: (input: { where?: Array<{ op?: string }> }) => {
+      if (input.where?.some((condition) => condition.op === "raw")) {
+        throw new Error("Unsupported operator");
+      }
+      return input;
+    },
+  };
+}

--- a/tests/agent-service.test.ts
+++ b/tests/agent-service.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@/db", () => ({
+  db: {},
+  apiKeys: {},
+  agentAuditEvents: {},
+  agentInboxComments: {},
+  agentInboxSubmissions: {},
+  agentInboxVersions: {},
+  agentSubmitTokens: {},
+  announcements: {},
+  blogPosts: {},
+  candidates: {},
+  curatedLinks: {},
+  affiliations: {},
+  investments: {},
+  jobs: {},
+}));
+
+const {
+  buildAgentOpenApiDocument,
+  parseAgentInviteInput,
+  parseAgentFilters,
+  redactAgentRecord,
+  validateAgentQuery,
+} = await import("../src/services/agent-api");
+const { extractRequestToken } = await import("../src/services/auth");
+
+describe("agent API contract helpers", () => {
+  test("accepts bearer tokens and x-api-key for agent clients", () => {
+    expect(
+      extractRequestToken(
+        new Request("https://dcbuilder.dev/api/agent/jobs", {
+          headers: { authorization: "Bearer cli-token" },
+        }) as never,
+      ),
+    ).toBe("cli-token");
+    expect(
+      extractRequestToken(
+        new Request("https://dcbuilder.dev/api/agent/jobs", {
+          headers: { "x-api-key": "admin-token" },
+        }) as never,
+      ),
+    ).toBe("admin-token");
+  });
+
+  test("describes the agent API, inbox actions, submissions, and schema endpoint", () => {
+    const doc = buildAgentOpenApiDocument();
+
+    expect(doc.openapi).toBe("3.1.0");
+    expect(doc.paths["/api/agent/schema"].get).toBeDefined();
+    expect(doc.paths["/api/agent/news"].get).toBeDefined();
+    expect(doc.paths["/api/agent/jobs"].get).toBeDefined();
+    expect(doc.paths["/api/agent/candidates"].get).toBeDefined();
+    expect(doc.paths["/api/agent/query"].post).toBeDefined();
+    expect(doc.paths["/api/agent/inbox/{id}/approve"].post).toBeDefined();
+    expect(doc.paths["/api/agent/submit/{kind}"].post).toBeDefined();
+  });
+
+  test("redacts candidate contact fields unless an elevated sensitive scope is present", () => {
+    const candidate = {
+      id: "cand_1",
+      name: "Alice",
+      email: "alice@example.com",
+      telegram: "@alice",
+      calendly: "https://cal.com/alice",
+      x: "alice",
+    };
+
+    expect(redactAgentRecord("candidates", candidate, [])).toEqual({
+      id: "cand_1",
+      name: "Alice",
+      email: null,
+      telegram: null,
+      calendly: null,
+      x: "alice",
+    });
+    expect(redactAgentRecord("candidates", candidate, ["agent:sensitive"])).toEqual(candidate);
+  });
+
+  test("parses structured filters and rejects raw SQL in generic queries", () => {
+    expect(parseAgentFilters(new URLSearchParams("limit=5&remote=true&tag=zk&tag=rust"))).toEqual({
+      limit: 5,
+      offset: 0,
+      remote: true,
+      tags: ["zk", "rust"],
+    });
+
+    expect(() =>
+      validateAgentQuery({
+        table: "jobs",
+        where: [{ field: "company", op: "raw", value: "1=1; drop table jobs" }],
+      }),
+    ).toThrow(/Unsupported operator/);
+  });
+
+  test("normalizes scoped invite options for CLI-created submit tokens", () => {
+    const invite = parseAgentInviteInput({
+      allowedKinds: ["candidate", "message", "unknown", "candidate"],
+      submitterName: "Partner Agent",
+      submitterEmail: "partner@example.com",
+      expiresInDays: 14,
+      maxUses: 5,
+    });
+
+    expect(invite.allowedKinds).toEqual(["candidate", "message"]);
+    expect(invite.submitterName).toBe("Partner Agent");
+    expect(invite.submitterEmail).toBe("partner@example.com");
+    expect(invite.maxUses).toBe(5);
+    expect(invite.expiresAt.getTime()).toBeGreaterThan(Date.now() + 13 * 24 * 60 * 60 * 1000);
+    expect(invite.expiresAt.getTime()).toBeLessThan(Date.now() + 15 * 24 * 60 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
## Summary
- add agent-facing API routes for schema, news, jobs, candidates, allowlisted query, inbox review, submissions, invites, and search refresh
- add migration-backed inbox, scoped submit token, audit, version, and search snapshot tables
- add admin inbox page plus dcbuilder CLI operating skill for agents

## Validation
- bun test tests/agent-service.test.ts tests/agent-routes.test.ts
- bunx tsc --noEmit
- bun run lint -- src/services/agent-api.ts src/services/auth.ts src/app/api/agent src/app/admin/inbox src/db/schema/agent.ts tests/agent-service.test.ts tests/agent-routes.test.ts
- bun run scripts/db/check-schema-migration-sync.ts --base origin/master --head HEAD

## Review
- self-reviewed auth scopes, raw SQL rejection, token redaction, invite max-use handling, and approval boundaries
