### PR TITLE
[codex] Fix candidate OG avatar mask

### DIFF
--- a/src/app/candidates/[id]/opengraph-image.tsx
+++ b/src/app/candidates/[id]/opengraph-image.tsx
@@ -17,6 +17,15 @@ const MAX_SKILLS = 5;
 const SKILL_HORIZONTAL_PADDING = 72;
 const ESTIMATED_SKILL_CHAR_WIDTH = 18;
 
+function roundImageStyle(size: number) {
+	return {
+		width: size,
+		height: size,
+		borderRadius: size / 2,
+		objectFit: "cover" as const,
+	};
+}
+
 function estimateSkillWidth(skill: string) {
 	return SKILL_HORIZONTAL_PADDING + skill.length * ESTIMATED_SKILL_CHAR_WIDTH;
 }
@@ -99,7 +108,7 @@ export default async function Image({ params }: Props) {
 								alt="dcbuilder"
 								width={88}
 								height={88}
-								style={{ objectFit: "cover" }}
+								style={roundImageStyle(88)}
 							/>
 						</div>
 						<div style={{ display: "flex", flexDirection: "column" }}>
@@ -187,7 +196,7 @@ export default async function Image({ params }: Props) {
 								alt={name}
 								width={240}
 								height={240}
-								style={{ objectFit: "cover" }}
+								style={roundImageStyle(240)}
 							/>
 						</div>
 					) : (

--- a/tests/candidate-opengraph-image.test.ts
+++ b/tests/candidate-opengraph-image.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+type ElementLike = {
+	type?: unknown;
+	props?: {
+		alt?: unknown;
+		children?: unknown;
+		style?: Record<string, unknown>;
+	};
+};
+
+function isElementLike(value: unknown): value is ElementLike {
+	return typeof value === "object" && value !== null && "props" in value;
+}
+
+function findImageByAlt(node: unknown, alt: string): ElementLike | null {
+	if (!isElementLike(node)) return null;
+
+	if (node.type === "img" && node.props?.alt === alt) {
+		return node;
+	}
+
+	const children = node.props?.children;
+	if (Array.isArray(children)) {
+		for (const child of children) {
+			const match = findImageByAlt(child, alt);
+			if (match) return match;
+		}
+		return null;
+	}
+
+	return findImageByAlt(children, alt);
+}
+
+describe("candidate opengraph image", () => {
+	afterEach(() => {
+		mock.restore();
+	});
+
+	test("masks square candidate profile images directly as circles", async () => {
+		mock.module("next/og", () => ({
+			ImageResponse: function ImageResponse(element: unknown, options: unknown) {
+				return { element, options };
+			},
+		}));
+
+		mock.module("@/lib/data", () => ({
+			getCandidateById: async () => ({
+				id: "square-image-candidate",
+				name: "Square Image Candidate",
+				title: "Protocol Engineer",
+				skills: ["Rust", "TypeScript"],
+				image: "https://example.com/square-profile.png",
+				createdAt: new Date("2026-01-01T00:00:00.000Z"),
+			}),
+		}));
+
+		const { default: CandidateOpenGraphImage } = await import(
+			`../src/app/candidates/[id]/opengraph-image?candidate-og-image=${Date.now()}`
+		);
+		const response = await CandidateOpenGraphImage({
+			params: Promise.resolve({ id: "square-image-candidate" }),
+		});
+
+		const candidateImage = findImageByAlt(
+			(response as { element: unknown }).element,
+			"Square Image Candidate"
+		);
+
+		expect(candidateImage).not.toBeNull();
+		expect(candidateImage?.props?.style).toMatchObject({
+			width: 240,
+			height: 240,
+			borderRadius: 120,
+			objectFit: "cover",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Apply explicit square dimensions and a concrete circular radius to images rendered inside candidate OG avatars.
- Add a focused Bun regression test that verifies square candidate profile images are masked directly as circles in the generated OG JSX.

## Why

Square candidate photos could render without the expected circular crop in the Open Graph image because the image element itself only used `objectFit`, relying on the wrapper mask in the OG renderer. The direct image style makes the generated preview deterministic.

## Validation

- `bun test tests/candidate-opengraph-image.test.ts` passed
- `bunx tsc --noEmit` passed
- `bun run lint 'src/app/candidates/[id]/opengraph-image.tsx' tests/candidate-opengraph-image.test.ts` passed

## Notes

- `bun run test:unit` was attempted in an isolated clean worktree and failed on existing environment-dependent tests because the temporary worktree has no local database connection string (`DATABASE_URL` or `DATABASE_URL_DEV`). The new candidate OG regression test passed within that run before the unrelated failures.